### PR TITLE
docs(runtime): fix runtime headers and links

### DIFF
--- a/runtimes/getting-started.mdx
+++ b/runtimes/getting-started.mdx
@@ -81,21 +81,19 @@ In most cases, the newest runtimes will also support previous versions of your R
 There are a number of ways to export your Rive files in cases where re-exporting is necessary to take advantage of the latest features. Check out our documentation on [Exporting](../editor/exporting) for more information.
 
 
-## Official runtimes
+## Official Runtimes
 
 Check out the runtime subpages for steps on how to get started!
-
-
-## Community Runtimes
 
 <Accordion title="Web">
   All web runtimes are distributed via npm:
 
-  - **[canvas (Recommended)](https://www.npmjs.com/package/@rive-app/canvas)**
+  - [GitHub](https://github.com/rive-app/rive-wasm)
+  - [canvas](https://www.npmjs.com/package/@rive-app/canvas)
   - [canvas-lite](https://www.npmjs.com/package/@rive-app/canvas-lite)
-  - **[canvas (advanced)](https://www.npmjs.com/package/@rive-app/canvas-advanced)**
-  - **[webgl](https://www.npmjs.com/package/@rive-app/webgl)**
-  - **[webgl (advanced)](https://www.npmjs.com/package/@rive-app/webgl-advanced)**
+  - [canvas (advanced)](https://www.npmjs.com/package/@rive-app/canvas-advanced)
+  - [webgl](https://www.npmjs.com/package/@rive-app/webgl)
+  - [webgl (advanced)](https://www.npmjs.com/package/@rive-app/webgl-advanced)
 
   **See [Canvas vs WebGL](#) for more on the differences between these dependencies.**
 </Accordion>
@@ -103,11 +101,11 @@ Check out the runtime subpages for steps on how to get started!
 <Accordion title="React">
   All React runtimes are distributed via npm:
 
-  - **[canvas (Recommended)](https://www.npmjs.com/package/@rive-app/react-canvas)**
+  - [GitHub](https://github.com/rive-app/rive-react)
+  - [canvas](https://www.npmjs.com/package/@rive-app/react-canvas)
   - [canvas-lite](https://www.npmjs.com/package/@rive-app/react-canvas-lite)
   - [webgl](https://www.npmjs.com/package/@rive-app/react-webgl)
 
-  [GitHub](https://github.com/rive-app/rive-react)
 </Accordion>
 
 <Accordion title="iOS/macOS">
@@ -138,7 +136,7 @@ Check out the runtime subpages for steps on how to get started!
 
 <Accordion title="C#">
 
-  - **[UWP (Recommended)](https://dev.azure.com/dotnet/CommunityToolkit/_artifacts/feed/CommunityToolkit-Labs/NuGet/CommunityToolkit.Labs.Uwp.RivePlayer/overview/0.0.1)**
+  - [UWP (Recommended)](https://dev.azure.com/dotnet/CommunityToolkit/_artifacts/feed/CommunityToolkit-Labs/NuGet/CommunityToolkit.Labs.Uwp.RivePlayer/overview/0.0.1)
   - [WinUI](https://dev.azure.com/dotnet/CommunityToolkit/_artifacts/feed/CommunityToolkit-Labs/NuGet/CommunityToolkit.Labs.WinUI.RivePlayer/overview/0.0.1)
   - (High-level API) [RivePlayer Github](https://github.com/CommunityToolkit/Labs-Windows/blob/main/labs/RivePlayer/samples/RivePlayer.Samples/RivePlayer.md)
   - (Low-level API) [RiveSharp Github](https://github.com/rive-app/rive-sharp)
@@ -148,7 +146,8 @@ Check out the runtime subpages for steps on how to get started!
   - [WinUI (High-level)](https://dev.azure.com/dotnet/CommunityToolkit/_artifacts/feed/CommunityToolkit-Labs/NuGet/CommunityToolkit.Labs.WinUI.RivePlayer/overview/0.0.1)
 </Accordion>
 <Accordion title="React Native">
-  - [npm](https://www.npmjs.com/package/rive-react-native), [GitHub](https://github.com/rive-app/rive-react-native) 
+  - [npm](https://www.npmjs.com/package/rive-react-native)
+  - [GitHub](https://github.com/rive-app/rive-react-native) 
 
 
 </Accordion>


### PR DESCRIPTION
There are other [bigger] cleanups to do with this section, but getting these fixes in now.