### PR TITLE
fix(runtimes): update external react-native github links

### DIFF
--- a/runtimes/react-native/react-native.mdx
+++ b/runtimes/react-native/react-native.mdx
@@ -64,7 +64,7 @@ See subsequent runtime pages to learn how to control animation playback, state m
 
 ## Resources
 
-Github: https://github.com/rive-app/rive-react-native Examples:
+Github: [https://github.com/rive-app/rive-react-native](https://github.com/rive-app/rive-react-native) Examples:
 
-- Demo App: https://github.com/rive-app/rive-react-native/tree/main/example
-- Weather App: https://github.com/rive-app/weather-app-mobile
+- Demo App: [https://github.com/rive-app/rive-react-native/tree/main/example](https://github.com/rive-app/rive-react-native/tree/main/example)
+- Weather App: [https://github.com/rive-app/weather-app-mobile](https://github.com/rive-app/weather-app-mobile)

--- a/runtimes/react-native/react-native.mdx
+++ b/runtimes/react-native/react-native.mdx
@@ -64,7 +64,7 @@ See subsequent runtime pages to learn how to control animation playback, state m
 
 ## Resources
 
-Github: [https://github.com/rive-app/rive-react-native](#resources) Examples:
+Github: https://github.com/rive-app/rive-react-native Examples:
 
-- Demo App: [https://github.com/rive-app/rive-react-native/tree/main/example](#resources)
-- Weather App: [https://github.com/rive-app/weather-app-mobile](#resources) 
+- Demo App: https://github.com/rive-app/rive-react-native/tree/main/example
+- Weather App: https://github.com/rive-app/weather-app-mobile


### PR DESCRIPTION
The links are not pointing to anything, making the experience annoying. Is it on purpose or a mistake?