### PR TITLE
docs(early-access): add anchor

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -402,6 +402,11 @@
           "anchor": "Blog",
           "href": "https://rive.app/blog",
           "icon": "newspaper"
+        },
+        {
+          "anchor": "Early Access",
+          "href": "https://rive.app/blog/early-access-to-unreleased-features",
+          "icon": "road-barrier"
         }
       ]
     }


### PR DESCRIPTION
Adds an anchor below "Blog" that links to the Early Access blog post.