### PR TITLE
docs(unity): add fallbackToAssignedAssets overload

### DIFF
--- a/game-runtimes/unity/runtime-asset-swapping.mdx
+++ b/game-runtimes/unity/runtime-asset-swapping.mdx
@@ -51,8 +51,6 @@ private void OnDestroy()
 }
 ```
 
-
-
 #### Overload With Fallback
 
 An overload of `Rive.File.Load()` includes a `fallbackToAssignedAssets` parameter.&#x20;
@@ -116,3 +114,16 @@ When working with runtime asset swapping, we recommend following these best prac
    * Call `Unload()` on your assets when they're no longer needed
 
    * Call `Dispose()` on the Rive file when you're done with it
+
+
+
+## Creating Out-of-Band Assets Dynamically
+
+If you have an asset—such as an image, font, or audio file—that isn't in your Unity project at build time (for example, if you're loading bytes from a CDN), you can create an out-of-band asset at runtime using the `OutOfBandAsset.Create<T>()` method.  Here, the `bytes` parameter should be the raw file data for the asset.
+
+This works for fonts, images, and audio, as long as you use the appropriate type (`FontOutOfBandAsset`, `ImageOutOfBandAsset`, or `AudioOutOfBandAsset`).
+
+```
+byte[] imageBytes = /* fetched from a CDN or elsewhere */;
+var myImageAsset = OutOfBandAsset.Create<ImageOutOfBandAsset>(imageBytes);
+```

--- a/game-runtimes/unity/runtime-asset-swapping.mdx
+++ b/game-runtimes/unity/runtime-asset-swapping.mdx
@@ -53,7 +53,7 @@ private void OnDestroy()
 
 #### Overload With Fallback
 
-An overload of `Rive.File.Load()` includes a `fallbackToAssignedAssets` parameter.&#x20;
+An overload of `Rive.File.Load()` includes a `fallbackToAssignedAssets` parameter.
 
 If set to `true `and your custom loader doesn't handle a certain asset, the runtime will look for references assigned to your Rive asset in the Unity Inspector and automatically load them if they exist. This is handy when you only want to replace some assets and rely on default references for the rest.
 
@@ -117,7 +117,7 @@ When working with runtime asset swapping, we recommend following these best prac
 
 ## Creating Out-of-Band Assets Dynamically
 
-If you have an asset—such as an image—that isn't in your Unity project at build time (for example, if you're loading bytes from a CDN), you can create an out-of-band asset at runtime using the `OutOfBandAsset.Create<T>()` method.  Here, the `bytes` parameter should be the raw file data for the asset.
+If you have an asset that isn't in your Unity project at build time (for example, if you're loading an image from a CDN), you can create an out-of-band asset at runtime using the `OutOfBandAsset.Create<T>()` method.  Here, the `bytes` parameter should be the raw file data for the asset.
 
 This works for fonts, images, and audio, as long as you use the appropriate type (`FontOutOfBandAsset`, `ImageOutOfBandAsset`, or `AudioOutOfBandAsset`).
 

--- a/game-runtimes/unity/runtime-asset-swapping.mdx
+++ b/game-runtimes/unity/runtime-asset-swapping.mdx
@@ -51,13 +51,27 @@ private void OnDestroy()
 }
 ```
 
+
+
+#### Overload With Fallback
+
+An overload of `Rive.File.Load()` includes a `fallbackToAssignedAssets` parameter.&#x20;
+
+If set to `true `and your custom loader doesn't handle a certain asset, the runtime will look for references assigned to your Rive asset in the Unity Inspector and automatically load them if they exist. This is handy when you only want to replace some assets and rely on default references for the rest.
+
+```csharp
+var file = File.Load(myRiveAsset, MyCustomAssetLoader, fallbackToAssignedAssets: true);
+```
+
 ## Asset Types
 
 You can swap these types of assets at runtime:
 
-- `FontOutOfBandAsset`: For font files
-- `ImageOutOfBandAsset`: For image files
-- `AudioOutOfBandAsset`: For audio files
+* `FontOutOfBandAsset`: For font files
+
+* `ImageOutOfBandAsset`: For image files
+
+* `AudioOutOfBandAsset`: For audio files
 
 ## Asset Reference Types
 
@@ -96,6 +110,9 @@ private bool AssetLoaderDelegate(EmbeddedAssetReference assetReference)
 When working with runtime asset swapping, we recommend following these best practices:
 
 1. Always call `Load()` on your Out-Of-Band asset before using it in the callback
+
 2. Dispose of resources properly:
-   - Call `Unload()` on your assets when they're no longer needed
-   - Call `Dispose()` on the Rive file when you're done with it
+
+   * Call `Unload()` on your assets when they're no longer needed
+
+   * Call `Dispose()` on the Rive file when you're done with it

--- a/game-runtimes/unity/runtime-asset-swapping.mdx
+++ b/game-runtimes/unity/runtime-asset-swapping.mdx
@@ -115,11 +115,9 @@ When working with runtime asset swapping, we recommend following these best prac
 
    * Call `Dispose()` on the Rive file when you're done with it
 
-
-
 ## Creating Out-of-Band Assets Dynamically
 
-If you have an asset—such as an image, font, or audio file—that isn't in your Unity project at build time (for example, if you're loading bytes from a CDN), you can create an out-of-band asset at runtime using the `OutOfBandAsset.Create<T>()` method.  Here, the `bytes` parameter should be the raw file data for the asset.
+If you have an asset—such as an image—that isn't in your Unity project at build time (for example, if you're loading bytes from a CDN), you can create an out-of-band asset at runtime using the `OutOfBandAsset.Create<T>()` method.  Here, the `bytes` parameter should be the raw file data for the asset.
 
 This works for fonts, images, and audio, as long as you use the appropriate type (`FontOutOfBandAsset`, `ImageOutOfBandAsset`, or `AudioOutOfBandAsset`).
 


### PR DESCRIPTION
This PR adds docs about a new File.Load overload that lets users fall back to assets assigned in the inspector when using the AssetLoaderCallback.