### PR TITLE
fix: Data binding title

### DIFF
--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Overview'
+title: 'Data Binding Overview'
 description: 'Connect editor elements to data and code using View Models'
 ---
 


### PR DESCRIPTION
As requested on Slack - our search results just show "Overview". This will better capture the article's contents.