### PR TITLE
docs: update overview (sidebar) titles

### DIFF
--- a/editor/animate-mode/animate-mode-overview.mdx
+++ b/editor/animate-mode/animate-mode-overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Animate Mode Overview'
+title: 'Animate Mode - Overview'
+sidebarTitle: 'Overview'
 description: ''
 ---
 

--- a/editor/animate-mode/animate-mode-overview.mdx
+++ b/editor/animate-mode/animate-mode-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Animate Mode - Overview'
+title: 'Animate Mode Overview'
 sidebarTitle: 'Overview'
 description: ''
 ---

--- a/editor/constraints/constraints-overview.mdx
+++ b/editor/constraints/constraints-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Constraints - Overview'
+title: 'Constraints Overview'
 sidebarTitle: 'Overview'
 description: 'Learn how to use constraints in Rive.'
 ---

--- a/editor/constraints/constraints-overview.mdx
+++ b/editor/constraints/constraints-overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Constraints Overview'
+title: 'Constraints - Overview'
+sidebarTitle: 'Overview'
 description: 'Learn how to use constraints in Rive.'
 ---
 

--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Data Binding - Overview'
+title: 'Data Binding Overview'
 sidebarTitle: 'Overview'
 description: 'Connect editor elements to data and code using View Models'
 ---

--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Overview'
+title: 'Data Binding - Overview'
+sidebarTitle: 'Overview'
 description: 'Connect editor elements to data and code using View Models'
 ---
 

--- a/editor/events/overview.mdx
+++ b/editor/events/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Events - Overview'
+title: 'Events Overview'
 sidebarTitle: 'Overview'
 description: ''
 ---

--- a/editor/events/overview.mdx
+++ b/editor/events/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Overview'
+title: 'Events - Overview'
+sidebarTitle: 'Overview'
 description: ''
 ---
 

--- a/editor/fundamentals/overview.mdx
+++ b/editor/fundamentals/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Fundamentals - Overview'
-sidebarTitle: 'Overview'
+title: "Fundamentals Overview"
+sidebarTitle: "Overview"
 description: "In this section, we'll step through a typical workflow from creating an artboard all the way to exporting your first Rive file. Before we get started, check out our brief overview of the interface to familiarise yourself with the various sections and modes."
 ---
 

--- a/editor/fundamentals/overview.mdx
+++ b/editor/fundamentals/overview.mdx
@@ -1,9 +1,8 @@
 ---
-title: 'Overview'
-description: ''
+title: 'Fundamentals - Overview'
+sidebarTitle: 'Overview'
+description: "In this section, we'll step through a typical workflow from creating an artboard all the way to exporting your first Rive file. Before we get started, check out our brief overview of the interface to familiarise yourself with the various sections and modes."
 ---
-
-In this section, we'll step through a typical workflow from creating an artboard all the way to exporting your first Rive file. Before we get started, check out our brief overview of the interface to familiarise yourself with the various sections and modes.
 
 <Info>Prefer to watch a series of short videos to follow visually? Check out our [Rive 101](https://www.youtube.com/playlist?list=PLujDTZWVDSsFGonP9kzAnvryowW098-p3) playlist!</Info>
 

--- a/editor/interface-overview/overview.mdx
+++ b/editor/interface-overview/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Interface - Overview'
-sidebarTitle: 'Overview'
+title: "Interface Overview"
+sidebarTitle: "Overview"
 description: "Rive's interface only shows what is needed when you need it. It is divided into a few main panels, which are described below."
 ---
 

--- a/editor/interface-overview/overview.mdx
+++ b/editor/interface-overview/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Overview'
+title: 'Interface - Overview'
+sidebarTitle: 'Overview'
 description: "Rive's interface only shows what is needed when you need it. It is divided into a few main panels, which are described below."
 ---
 

--- a/editor/layouts/layouts-overview.mdx
+++ b/editor/layouts/layouts-overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Layouts Overview'
+title: 'Layouts - Overview'
+sidebarTitle: 'Overview'
 description: 'Layouts allow you to build responsive UI components in Rive. Make your designs fit, fill, or reflow content based on the space available.'
 ---
 

--- a/editor/layouts/layouts-overview.mdx
+++ b/editor/layouts/layouts-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Layouts - Overview'
+title: 'Layouts Overview'
 sidebarTitle: 'Overview'
 description: 'Layouts allow you to build responsive UI components in Rive. Make your designs fit, fill, or reflow content based on the space available.'
 ---

--- a/editor/manipulating-shapes/manipulating-shapes.mdx
+++ b/editor/manipulating-shapes/manipulating-shapes.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Manipulating Shapes - Overview'
+title: 'Manipulating Shapes Overview'
 sidebarTitle: 'Overview'
 description: 'The Rive editor gives you multiple ways to manipulate your graphics to create the animation that you want. In addition to adding the basic transform properties, you can use bones, groups, meshes, and vertices to give your graphics and animations some added flair.'
 ---

--- a/editor/manipulating-shapes/manipulating-shapes.mdx
+++ b/editor/manipulating-shapes/manipulating-shapes.mdx
@@ -1,12 +1,8 @@
 ---
-title: 'Manipulating Shapes'
-description: ''
+title: 'Manipulating Shapes - Overview'
+sidebarTitle: 'Overview'
+description: 'The Rive editor gives you multiple ways to manipulate your graphics to create the animation that you want. In addition to adding the basic transform properties, you can use bones, groups, meshes, and vertices to give your graphics and animations some added flair.'
 ---
-
-
-# Overview
-
-The Rive editor gives you multiple ways to manipulate your graphics to create the animation that you want. In addition to adding the basic transform properties, you can use bones, groups, meshes, and vertices to give your graphics and animations some added flair.
 
 <CardGroup cols={2}>
   <Card

--- a/editor/share-links/overview.mdx
+++ b/editor/share-links/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Overview'
+title: 'Share Links - Overview'
+sidebarTitle: 'Overview'
 description: 'Share Links are a fast no-code way to get your Rive files running on a website or to present your graphics to a client.'
 ---
 

--- a/editor/share-links/overview.mdx
+++ b/editor/share-links/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Share Links - Overview'
+title: 'Share Links Overview'
 sidebarTitle: 'Overview'
 description: 'Share Links are a fast no-code way to get your Rive files running on a website or to present your graphics to a client.'
 ---

--- a/editor/state-machine/state-machine.mdx
+++ b/editor/state-machine/state-machine.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'State Machine - Overview'
+title: 'State Machine Overview'
 sidebarTitle: 'Overview'
 description: 'Add intelligence to your animations.'
 ---

--- a/editor/state-machine/state-machine.mdx
+++ b/editor/state-machine/state-machine.mdx
@@ -1,11 +1,12 @@
 ---
-title: 'State Machine'
+title: 'State Machine - Overview'
+sidebarTitle: 'Overview'
 description: 'Add intelligence to your animations.'
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-## State Machine Overview
+## Overview
 
 State Machines are a visual way to connect animations together and define the logic that drives the transitions. They allow you to build interactive motion graphics that are ready to be implemented in your product, app, game, or website.
 

--- a/editor/text/text-overview.mdx
+++ b/editor/text/text-overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Text Overview'
+title: 'Text - Overview'
+sidebarTitle: 'Overview'
 description: ''
 ---
 

--- a/editor/text/text-overview.mdx
+++ b/editor/text/text-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Text - Overview'
+title: 'Text Overview'
 sidebarTitle: 'Overview'
 description: ''
 ---

--- a/game-runtimes/bevy/bevy.mdx
+++ b/game-runtimes/bevy/bevy.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Overview'
+title: 'Bevy'
 description: 'Bevy runtime for Rive.'
 ---
 

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Overview'
+title: 'Choose a Renderer - Overview'
+sidebarTitle: 'Overview'
 description: 'Specify a renderer to use at runtime.'
 ---
 

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Choose a Renderer - Overview'
+title: 'Choose a Renderer Overview'
 sidebarTitle: 'Overview'
 description: 'Specify a renderer to use at runtime.'
 ---


### PR DESCRIPTION
- Updates editor overview pages to follow the format:
  - Title: Topic Overview
  - Sidebar title: Overview
- Updates Bevy root page title from Overview to Bevy to follow other game runtimes

## Example - Data Binding

![image](https://github.com/user-attachments/assets/9a17d990-8dec-40ea-acd1-982e21b992b5)

## Expected SEO Changes

The new titles _should_ be used when the docs are crawled. This should update, for example, Data Binding overview from "Overview" to "Data Binding - Overview", while showing "Overview" in the sidebar still.