### PR TITLE
Remove webgl from the docs

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,6 +1,8 @@
 {
-  "systemParams": "darwin-arm64-127",
-  "modulesFolders": [],
+  "systemParams": "darwin-arm64-120",
+  "modulesFolders": [
+    "node_modules"
+  ],
   "flags": [],
   "linkedModules": [],
   "topLevelPatterns": [],

--- a/runtimes/getting-started.mdx
+++ b/runtimes/getting-started.mdx
@@ -10,7 +10,7 @@ The Rive runtimes are open-source libraries that allow you to load and control y
 
 <NoteOnFeatureSupport/>
 
-## How to use this guide 
+## How to use this guide
 
 In this section you'll find runtime subpages that provide all the needed information and resources to get started on your platform of choice. See [Installation and Getting Started](#installation-and-getting-started) below.
 
@@ -27,28 +27,28 @@ You'll also find pages dedicated to controlling your animation at runtime. For e
     This guide documents how to get started using the Web runtime library.
   </Card>
   <Card title="React Runtime" href="./react" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    This guide documents how to get started using the React runtime library. 
+    This guide documents how to get started using the React runtime library.
   </Card>
   <Card title="React Native Runtime" href="./react-native" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    This guide documents how to get started using the React Native runtime library. 
+    This guide documents how to get started using the React Native runtime library.
   </Card>
   <Card title="Apple Runtime" href="./apple" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    This guide documents how to get started using the Apple runtime library. 
+    This guide documents how to get started using the Apple runtime library.
   </Card>
   <Card title="Android" href="./android"icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>}>
-    This guide documents how to get started using the Android runtime library. 
+    This guide documents how to get started using the Android runtime library.
   </Card>
   <Card title="Flutter Runtime" href="./flutter" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    This guide documents how to get started using the Flutter runtime library. 
+    This guide documents how to get started using the Flutter runtime library.
   </Card>
   <Card title="Unity" href="../game-runtimes/unity" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    This guide documents how to get started using the Unity runtime library. 
+    This guide documents how to get started using the Unity runtime library.
   </Card>
   <Card title="Bevy" href="../game-runtimes/bevy" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    This guide documents how to get started using the Bevy runtime library. 
+    This guide documents how to get started using the Bevy runtime library.
   </Card>
   <Card title="Unreal" href="../game-runtimes/unreal" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>}>
-    This guide documents how to get started using the Unreal runtime library. 
+    This guide documents how to get started using the Unreal runtime library.
   </Card>
 </CardGroup>
 
@@ -75,7 +75,7 @@ These sections provide details on how to interact with your Rive animations at r
  </CardGroup>
 
 
-## Versioning 
+## Versioning
 
 As we publish updates to our Rive editor, we will occasionally push updated runtimes to support the new features. See [Feature Support](/feature-support) for the required minimum runtime version needed for specific features.
 
@@ -95,8 +95,8 @@ Check out the runtime subpages for steps on how to get started!
   - [canvas](https://www.npmjs.com/package/@rive-app/canvas)
   - [canvas-lite](https://www.npmjs.com/package/@rive-app/canvas-lite)
   - [canvas (advanced)](https://www.npmjs.com/package/@rive-app/canvas-advanced)
-  - [webgl](https://www.npmjs.com/package/@rive-app/webgl)
-  - [webgl (advanced)](https://www.npmjs.com/package/@rive-app/webgl-advanced)
+  - [webgl](https://www.npmjs.com/package/@rive-app/webgl2)
+  - [webgl (advanced)](https://www.npmjs.com/package/@rive-app/webgl2-advanced)
 
   **See [Canvas vs WebGL](#) for more on the differences between these dependencies.**
 </Accordion>
@@ -107,7 +107,7 @@ Check out the runtime subpages for steps on how to get started!
   - [GitHub](https://github.com/rive-app/rive-react)
   - [canvas](https://www.npmjs.com/package/@rive-app/react-canvas)
   - [canvas-lite](https://www.npmjs.com/package/@rive-app/react-canvas-lite)
-  - [webgl](https://www.npmjs.com/package/@rive-app/react-webgl)
+  - [webgl](https://www.npmjs.com/package/@rive-app/react-webgl2)
 
 </Accordion>
 
@@ -150,7 +150,7 @@ Check out the runtime subpages for steps on how to get started!
 </Accordion>
 <Accordion title="React Native">
   - [npm](https://www.npmjs.com/package/rive-react-native)
-  - [GitHub](https://github.com/rive-app/rive-react-native) 
+  - [GitHub](https://github.com/rive-app/rive-react-native)
 
 
 </Accordion>

--- a/runtimes/react/migrating-from-v0-to-v1.mdx
+++ b/runtimes/react/migrating-from-v0-to-v1.mdx
@@ -3,6 +3,6 @@ title: 'Migrating from 0.x.x to 1.x.x'
 description: 'Migrating to 1.x.x'
 ---
 
-Before v1.0.0 of `rive-react`, the React runtime wrapped the `@rive-app/canvas` runtime dependency, using the backing `CanvasRenderingContext2D`. In order for the React runtime to support some upcoming advanced drawing features like Mesh Deformations, it needed to use the `@rive-app/webgl` runtime.
+Before v1.0.0 of `rive-react`, the React runtime wrapped the `@rive-app/canvas` runtime dependency, using the backing `CanvasRenderingContext2D`. In order for the React runtime to support some upcoming advanced drawing features like Mesh Deformations, it needed to use the `@rive-app/webgl2` runtime.
 
 The major version bump to v1.0.0 involves no breaking API changes, but rather internally uses a different backing context with WebGL. If you have issues, please log them to the issues tab of the `rive-react` runtime [here](https://github.com/rive-app/rive-react/issues).

--- a/runtimes/react/migrating-from-v1-to-v3.mdx
+++ b/runtimes/react/migrating-from-v1-to-v3.mdx
@@ -14,7 +14,7 @@ For the most part, if you're using v1.x.x of `rive-react`, you should be able to
 Previous to v2.x.x, you could use Rive in React via the `rive-react` package. This package was a wrapper around the `@rive-app/webgl` dependency. In version 2.x.x+, we enable the React runtime to wrap around both the `@rive-app/webgl` and `@rive-app/canvas` dependencies through 2 main new React packages:
 
 - **(Recommended)** `@rive-app/react-canvas`
-- `@rive-app/react-webgl`
+- `@rive-app/react-webgl2`
 
 The `rive-react` package will still be published to regularly along with the above packages, but it has both of the web runtime dependencies set as `dependencies` and may result in a larger bundle. Because of this, we recommend switching from `rive-react` to `@rive-app/react-canvas` or the WebGL variant if you need to use a WebGL backing context.
 
@@ -36,12 +36,12 @@ npm i @rive-app/react-canvas
 
 ## Prop Spreading
 
-The React runtime provides a `RiveComponent` whether you use the default export or the `useRive` hook provided. This component should be passed into the JSX to render the canvas out. The DOM encompasses a wrapping div around the canvas that helps to handle the styling and sizing of the canvas. Most props spread on the `RiveComponent` would be spread onto that wrapping `<div>` element. Starting in v2.x.x, certain props will be spread onto the wrapping `<div>` that concern styling (i.e `className` and `style`), but any other props will now be spread onto the `<canvas>` element, so that you can set `role`, `aria-*` attributes, etc. 
+The React runtime provides a `RiveComponent` whether you use the default export or the `useRive` hook provided. This component should be passed into the JSX to render the canvas out. The DOM encompasses a wrapping div around the canvas that helps to handle the styling and sizing of the canvas. Most props spread on the `RiveComponent` would be spread onto that wrapping `<div>` element. Starting in v2.x.x, certain props will be spread onto the wrapping `<div>` that concern styling (i.e `className` and `style`), but any other props will now be spread onto the `<canvas>` element, so that you can set `role`, `aria-*` attributes, etc.
 
 **Before:**
 
 ```javascript
-<RiveComponent className="foo" aria-label="Label" /> 
+<RiveComponent className="foo" aria-label="Label" />
 ```
 
 Would render the (simplified) DOM such as:

--- a/runtimes/react/migrating-from-v3-to-v4.mdx
+++ b/runtimes/react/migrating-from-v3-to-v4.mdx
@@ -7,7 +7,7 @@ Starting in v4 of our React runtimes, Rive will support Rive Text at runtime, wh
 
 - React
   - `@rive-app/react-canvas`
-  - `@rive-app/react-webgl`
+  - `@rive-app/react-webgl2`
 
 ## Major Changes
 

--- a/runtimes/react/parameters-and-return-values.mdx
+++ b/runtimes/react/parameters-and-return-values.mdx
@@ -5,7 +5,7 @@ description: 'Rive React API.'
 
 ## Hooks
 
-### useRive 
+### useRive
 
 The `useRive` hook is the recommended way to hook into the Rive runtime for full control, especially when using the Rive State Machine. See below for parameters to pass in and the return values.
 
@@ -14,7 +14,7 @@ The `useRive` hook is the recommended way to hook into the Rive runtime for full
 - `riveParams` - See below for a set of parameters passed to the `Rive` object at instantiation from the Web runtime. `null` and `undefined` can be passed to conditionally display the .riv file
 - `opts` - *(Optional)* See below for a set of options specific to `rive-react`
 
-#### Parameters 
+#### Parameters
 
 **UseRiveParameters**
 
@@ -28,7 +28,7 @@ Most of these parameters come from the underlying web runtime configuration item
 
 - `useDevicePixelRatio` - *(optional)* If `true`, the hook will scale the resolution of the animation based on the [devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio). Defaults to `true`. NOTE: Requires the `setContainerRef` ref callback to be passed to an element wrapping a canvas element. If you use the `RiveComponent`, then this will happen automatically
 - `fitCanvasToArtboardHeight` - *(optional)* If `true`, then the canvas will resize based on the height of the artboard. Defaults to `false`
-- `useOffscreenRenderer` - *(optional)* If `true`, the Rive instance will share (or create if one does not exist) an offscreen `WebGL` context. This allows you to display multiple Rive animations on one screen to work around some browser limitations regarding multiple concurrent WebGL contexts. If `false`, each Rive instance will have its own dedicated `WebGL` context and you may need to be cautious of the browser limitations just mentioned. We recommend **not** changing this default prop, so you don't have to manage WebGL contexts. Destroying a React component does not guarantee the browser cleans up the WebGL context that was created when the canvas was mounted. Only relevant when using `@rive-app/react-webgl`. Defaults to `true`
+- `useOffscreenRenderer` - *(optional)* If `true`, the Rive instance will share (or create if one does not exist) an offscreen `WebGL` context. This allows you to display multiple Rive animations on one screen to work around some browser limitations regarding multiple concurrent WebGL contexts. If `false`, each Rive instance will have its own dedicated `WebGL` context and you may need to be cautious of the browser limitations just mentioned. We recommend **not** changing this default prop, so you don't have to manage WebGL contexts. Destroying a React component does not guarantee the browser cleans up the WebGL context that was created when the canvas was mounted. Only relevant when using `@rive-app/react-webgl2`. Defaults to `true`
 
 #### Return Values
 
@@ -104,9 +104,9 @@ The `useRiveFile` hook is designed for initializing and managing a `RiveFile` in
 
 The main benefit of this hook is that it allows you to create a `RiveFile` instance that you can reuse across components without needing to fetch it again from the `src` URL or reload it from the `buffer`. This improves performance by eliminating redundant network requests and loading times, especially when creating multiple Rive instances from the same source. Unlike passing the `buffer` and `src` parameters to the `useRive` hook directly—which still requires parsing under the hood to create the `RiveFile` object—this hook returns an already parsed `RiveFile` object, including any loaded assets.
 
-`useRiveFile(params: UseRiveFileParameters): RiveFileState` 
+`useRiveFile(params: UseRiveFileParameters): RiveFileState`
 
-#### Parameters 
+#### Parameters
 
 **UseRiveFileParameters**
 
@@ -130,6 +130,6 @@ The main benefit of this hook is that it allows you to create a `RiveFile` insta
 
 The `RiveComponent` default export and the `RiveComponent` returned from the `useRive` hook are both to be rendered in the JSX of a component. As noted previously, all attributes and event handlers that can be passed to a `canvas` element can also be passed to the `Rive` component and used in the same manner.
 
-One thing to note is that `style`/`className` props set on the component will be passed onto the containing `<div>` element, rather than the underlying `<canvas>` itself. The reason for this is that the containing `<div>` element handles resizing and layout for you, and thus, all styles should be passed onto this element. 
+One thing to note is that `style`/`className` props set on the component will be passed onto the containing `<div>` element, rather than the underlying `<canvas>` itself. The reason for this is that the containing `<div>` element handles resizing and layout for you, and thus, all styles should be passed onto this element.
 
 The `<canvas>` element will still receive any other props passed into the component, such as `aria-*` attributes, `role`'s, etc. You can also set children content inside the component for fallback scenarios where the `<canvas>` element cannot be shown.

--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -29,11 +29,10 @@ Follow the steps below for a quick start on integrating Rive into your React app
 
     - **(Recommended)** `@rive-app/react-canvas` - Wraps the `@rive-app/canvas` dependency. Unless you specifically need a `WebGL` backing renderer, we recommend you use this dependency when using Rive in your apps for quick and fast usage.
     - `@rive-app/react-canvas-lite` - Similar to `@rive-app/react-canvas`, but [smaller](../web/canvas-vs-webgl). This is recommended if the Rive graphic does not use [Rive Text](/editor/text/)
-    - `@rive-app/react-webgl` - Wraps the `@rive-app/webgl` dependency. In the future, we may have advanced rendering features that are only supported by using `WebGL`. At the moment, however, due to the size of the dependency (with Skia), we do not recommend it unless you have specific needs here. We are currently working on improving the performance and size with the [Rive Renderer](https://rive.app/renderer).
-    - `@rive-app/react-webgl2` - Wraps the `@rive-app/webgl2` dependency. It uses the Rive Renderer with a WebGL2 context and has a much smaller build size than `rive-app/react-webgl`. In a future major release, this package may be deprecated, and `@rive-app/react-webgl` will make use of the Rive Renderer completely, without an added Skia dependency.
+    - `@rive-app/react-webgl2` - Wraps the `@rive-app/webgl2` dependency. It uses the Rive Renderer with a WebGL2 context.
 
     <Note>
-    To take advantage of trying out the Rive Renderer with react-webgl2 , you should [enable the draft](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome) `WEBGL_shader_pixel_local_storage` Chrome Extension (by adding WebGL Draft Extensions), otherwise, Rive will fall back to an MSAA solution (also with WebGL2) on browsers without the extension support. Current work is underway with major browsers to support this extension by default in consumer's browsers.
+    To take full advantage of the Rive Renderer with react-webgl2 , you should [enable the draft](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome) `WEBGL_shader_pixel_local_storage` Chrome Extension (by adding WebGL Draft Extensions), otherwise, Rive will fall back to an MSAA solution (also with WebGL2) on browsers without the extension support. Current work is underway with major browsers to support this extension by default in consumer's browsers.
     </Note>
 
     ```bash

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -7,7 +7,7 @@ description: ''
 
 The JS/WASM runtime provides various packages which are published to npm. For simple usage and smaller package sizes, we recommend starting with `@rive-app/canvas` (more on that below). On the web, Rive offers the ability to use a backing `CanvasRenderingContext2D` context or `WebGL` context associated with a `<canvas>` element for rendering Rive animations.
 
-**Note:** The high-level API and the logic for creating a Rive instance in your script remain the same for the `@rive-app/webgl` and `@rive-app/canvas` packages. That means if you decide one runtime package is better for your use case over the other, you only need to switch the dependency, but not the usage. See more below on each of the different runtimes for JS/WASM and when to use which package.
+**Note:** The high-level API and the logic for creating a Rive instance in your script remain the same for the `@rive-app/webgl2` and `@rive-app/canvas` packages. That means if you decide one runtime package is better for your use case over the other, you only need to switch the dependency, but not the usage. See more below on each of the different runtimes for JS/WASM and when to use which package.
 
 ### (Recommended) @rive-app/canvas
 
@@ -40,27 +40,7 @@ This solution will be preferable if you **do not** have a need for the following
   - If your Rive file may include Rive Text components, rendering the graphic should not cause any app errors, or cease to render. Rive Text will just not appear within the graphic
   - You can still make use of text within your graphic by importing text externally as SVG
 
-### @rive-app/webgl
-
-
-An easy-to-use high-level Rive API using a WebGL2 context. Some benefits of this package:
-
-- Highest fidelity with edit-time experience.
-- Requests the Web Assembly (WASM) backing dependency for you
-- Currently uses Skia for rendering, but in a future major version release will be replaced with the new Rive Renderer
-
-**A note about WebGL:** Most browsers limit the number of concurrent WebGL contexts by page/domain. Using Rive, this means that the browser limit impacts the number of `new Rive({...})` instances created.
-
-If you're planning on displaying Rive content in a list/grid or many times on the same page, it's up to you to manage the lifecycle of the provided context and `canvas` element. If you need to display many animations (i.e grids/lists), consider using the `@rive-app/canvas` package which uses the `CanvasRenderingContext2D` renderer and does not have a context limitation, or consider the `@rive-app/webgl-advanced` package, which will allow you to display multiple Rive graphics on one canvas with full control over the render loop.
-
-<Note>
- It is recommended to set the `useOffscreenRenderer: true` property in the Rive parameters when creating a `new Rive({...})` object, especially when rendering multiple Rive objects on the page.
-</Note>
 ### @rive-app/webgl2
-
-<Note>
- This is a preview of using the [Rive Renderer](https://rive.app/renderer) with a WebGL2 context. In a future major release, this package may be deprecated and `@rive-app/webgl` will make use of the Rive Renderer completely, without an added Skia dependency
-</Note>
 
 An easy-to-use high-level Rive API using a WebGL2 context. Some benefits of this package:
 
@@ -70,7 +50,7 @@ An easy-to-use high-level Rive API using a WebGL2 context. Some benefits of this
 - A much smaller build than `@rive-app/webgl`, which currently adds a larger Skia dependency
 
 <Note>
- To take advantage of trying out the Rive Renderer, you should [enable the draft](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome) `WEBGL_shader_pixel_local_storage` Chrome Extension (by adding WebGL Draft Extensions in the link above), otherwise, Rive will fall back to an MSAA solution (also with WebGL2) on browsers without the extension support. Current work is underway with major browsers to support this extension by default in consumer's browsers.
+ To take full advantage of the Rive Renderer, you should [enable the draft](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome) `WEBGL_shader_pixel_local_storage` Chrome Extension (by adding WebGL Draft Extensions in the link above), otherwise, Rive will fall back to an MSAA solution (also with WebGL2) on browsers without the extension support. Current work is underway with major browsers to support this extension by default in consumer's browsers.
 </Note>
 
 **A note about WebGL:** Most browsers limit the number of concurrent WebGL contexts by page/domain. Using Rive, this means that the browser limit impacts the number of `new Rive({...})` instances created.
@@ -84,9 +64,7 @@ If you're planning on displaying Rive content in a list/grid or many times on th
 For more information about the Rive Renderer, see the [Choose a Renderer](../choose-a-renderer/) section.
 
 ### @rive-app/webgl2-advanced
-<Note>
- This is a preview of using the [Rive Renderer](https://rive.app/renderer) with a WebGL2 context. In a future major release, this package may be deprecated and `@rive-app/webgl-advanced` will make use of the Rive Renderer completely, without an added Skia dependency
-</Note>
+
 A low-level Rive API using a WebGL2 context. It has the same benefits as the regular `@rive-app/webgl2` package plus:
 
 - Full control over the update and render loop.
@@ -130,16 +108,6 @@ This solution will be preferable if you **do not** have a need for the following
 - [Rive Text](/editor/text/)
   - If your Rive file may include Rive Text components, rendering the graphic should not cause any app errors, or cease to render. Rive Text will just not appear within the graphic
   - You can still make use of text within your graphic by importing text externally as SVG
-
-### @rive-app/webgl-advanced
-
-A low-level Rive API using a WebGL2 context. It has the same benefits as the regular `@rive-app/webgl` package plus:
-
-- Full control over the update and render loop.
-- Allows for rendering multiple Rive graphics to a single canvas.
-- Allows deeper control and manipulation of the components in a Rive hierarchy.
-
-See an example of usage here: [CodeSandbox](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp)
 
 ### *-single versions
 

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -41,7 +41,7 @@ If you’ve decided that the low-level JS APIs are what you need for your app, r
 
 ### Loading in WASM
 
-The first step to setting up the low-level Rive APIs is to load in the Rive WASM file from either the `@rive-app/canvas-advanced` or `@rive-app/webgl2-advanced` libraries (by default, we recommend `@rive-app/canvas-advanced` for a smaller dependency, unless you need to use WebGL2). When the WASM file is loaded into your app, you'll gain access to necessary APIs such as the renderer for canvas/WebGL, along with relevant JS classes generated from underlying CPP bindings via [rive-cpp](https://github.com/rive-app/rive-cpp), the core c++ runtime used as the base for several other Rive runtimes. You'll use these classes to construct your rendering scene in the canvas below.
+The first step to setting up the low-level Rive APIs is to load in the Rive WASM file from either the `@rive-app/canvas-advanced` or `@rive-app/webgl2-advanced` libraries (by default, we recommend `@rive-app/canvas-advanced` for a smaller dependency, unless you need to use WebGL). When the WASM file is loaded into your app, you'll gain access to necessary APIs such as the renderer for canvas/WebGL, along with relevant JS classes generated from underlying CPP bindings via [rive-cpp](https://github.com/rive-app/rive-cpp), the core c++ runtime used as the base for several other Rive runtimes. You'll use these classes to construct your rendering scene in the canvas below.
 
 You can load the Rive WASM file via [unpkg](https://unpkg.com/) (hosts our NPM modules for the JS runtimes), which will make a network call to the CDN, or you can choose to host the WASM file on your own servers. With `unpkg`, the URL will look something like this:
 

--- a/runtimes/web/migrating-from-rive-js.mdx
+++ b/runtimes/web/migrating-from-rive-js.mdx
@@ -5,16 +5,16 @@ description: 'Migration guide from the rive-js package'
 
 Previously, the web runtime would deploy to the [rive-js](https://www.npmjs.com/package/rive-js) package on npm. We have since moved away from this one-package model and into a place where you can import from several different packages based on your API/rendering-level needs.
 
-- @rive-app/webgl
-- @rive-app/webgl-advanced
+- @rive-app/webgl2
+- @rive-app/webgl2-advanced
 - @rive-app/canvas
 - @rive-app/canvas-advanced
 
 In addition to these new packages, there are `*-single` version packages for each of the above that have the WASM encoded in the JS. See [the web runtime docs](https://github.com/rive-app/rive-wasm/blob/master/WEB_RUNTIMES.md) to help you decide which runtime package you may need for your project.
 
- We changed the package model to choose which renderer to use (i.e., [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) vs. [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API)), impacting bundle size and performance. In addition, all of the new web runtime packages will support the latest Rive features, such as raster assets. 
+ We changed the package model to choose which renderer to use (i.e., [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) vs. [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API)), impacting bundle size and performance. In addition, all of the new web runtime packages will support the latest Rive features, such as raster assets.
 
-In any case, there should be no changes in high-level API usage required as far as using the `rive` instance. You only need to change the package you install in your project and the associated places you import it. 
+In any case, there should be no changes in high-level API usage required as far as using the `rive` instance. You only need to change the package you install in your project and the associated places you import it.
 
 For instance, instead of the following integration:
 
@@ -33,7 +33,7 @@ const foo = new rive.Rive({
 You could replace this with:
 
 ```bash
-npm i @rive-app/canvas 
+npm i @rive-app/canvas
 ```
 
 ```typescript

--- a/runtimes/web/migrating-from-v1-to-v2.mdx
+++ b/runtimes/web/migrating-from-v1-to-v2.mdx
@@ -8,8 +8,8 @@ Starting in v2 of our Web (JS) runtimes, Rive will support Rive Text at runtime,
 - Web (JS) / WASM
   - `@rive-app/canvas`
   - `@rive-app/canvas-advanced`
-  - `@rive-app/webgl`
-  - `@rive-app/webgl-advanced`
+  - `@rive-app/webgl2`
+  - `@rive-app/webgl2-advanced`
   - ...and other `@rive-app/*-single` variants
 
 ## Major Changes

--- a/runtimes/web/preloading-wasm.mdx
+++ b/runtimes/web/preloading-wasm.mdx
@@ -5,7 +5,7 @@ description: ''
 
 ## Background
 
-When rending a `new Rive()` instance from the `@rive-app/*` packages, or the `<RiveComponent />` from the `@rive-app/react-*` packages, your browser is making a network request to `https://unpkg.com/@rive-app/canvas@x.x.x/rive.wasm` which retrieves a [Web Assembly](https://developer.mozilla.org/en-US/docs/WebAssembly) (WASM) file that contains Rive-specific APIs to build the render loop. [unkpg](https://unpkg.com/) is a global CDN that quickly allows for loading in NPM packages, which in this case includes a WASM file. This allows for a smaller bundle size when pulling in the Rive JS-based runtimes, while only loading in WASM when Rive instances are created. 
+When rending a `new Rive()` instance from the `@rive-app/*` packages, or the `<RiveComponent />` from the `@rive-app/react-*` packages, your browser is making a network request to `https://unpkg.com/@rive-app/canvas@x.x.x/rive.wasm` which retrieves a [Web Assembly](https://developer.mozilla.org/en-US/docs/WebAssembly) (WASM) file that contains Rive-specific APIs to build the render loop. [unkpg](https://unpkg.com/) is a global CDN that quickly allows for loading in NPM packages, which in this case includes a WASM file. This allows for a smaller bundle size when pulling in the Rive JS-based runtimes, while only loading in WASM when Rive instances are created.
 
 While `unpkg` should provide WASM quickly and can cache across sites that load from this CDN, you may want to preload and host the WASM file yourself for any of the following reasons:
 
@@ -19,7 +19,7 @@ Depending on the JS-based runtime you're using (i.e. JS, React, etc.), follow th
 
 ### JS
 
-If you're using the base `@rive-app/canvas` or `@rive-app/webgl` or any of the plain JS-variant Rive runtimes, import the WASM resource into your app, as well as the `RuntimeLoader` API:
+If you're using the base `@rive-app/canvas` or `@rive-app/webgl2` or any of the plain JS-variant Rive runtimes, import the WASM resource into your app, as well as the `RuntimeLoader` API:
 
 ```javascript
 import riveWASMResource from '@rive-app/canvas/rive.wasm';
@@ -41,7 +41,7 @@ The `RuntimeLoader` is a singleton that manages loading in the WASM file behind 
 
 ### React
 
-If you're using `@rive-app/react-canvas` or `@rive-app/react-webgl`, import the WASM resource into your app, as well as the `RuntimeLoader` API:
+If you're using `@rive-app/react-canvas` or `@rive-app/react-webgl2`, import the WASM resource into your app, as well as the `RuntimeLoader` API:
 
 ```javascript
 import riveWASMResource from '@rive-app/canvas/rive.wasm';

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -45,7 +45,7 @@ export interface RiveParameters {
 - `artboard?` - *(optional)* Name of the artboard to use.
 - `animations?` - *(optional)* Name or list of names of animations to play.
 
-<Note> 
+<Note>
  Currently, Rive will play the first timeline animation it finds if no `stateMachines` or `animations` parameter is provided, however, in a future major version of `rive-wasm`, the default will be to play the first state machine it finds.
 </Note>
 
@@ -60,7 +60,7 @@ export interface RiveParameters {
 
 - `layout?` - *(optional)* Layout object to define how animations are displayed on the canvas.
 - `autoplay?` - *(optional)* If true, the animation will automatically start playing when loaded. Defaults to false.
-- `useOffscreenRenderer?` - *(optional)* Boolean flag to determine whether to use a shared offscreen WebGL context rather than create its own WebGL context for this instance of Rive. This is only relevant for the `@rive-app/webgl` package. If you are displaying multiple Rive animations, it is highly encouraged to set this flag to `true`. Defaults to `false`.
+- `useOffscreenRenderer?` - *(optional)* Boolean flag to determine whether to use a shared offscreen WebGL context rather than create its own WebGL context for this instance of Rive. This is only relevant for the `@rive-app/webgl2` package. If you are displaying multiple Rive animations, it is highly encouraged to set this flag to `true`. Defaults to `false`.
 - `enableRiveAssetCDN?` - *(optional)* Allow the runtime to automatically load assets hosted in Rive's CDN. Enabled by default.
 - `shouldDisableRiveListeners?` - *(optional)* Boolean flag to disable setting up Rive Listeners on the `<canvas>` element, thus preventing any event listeners from being set up on the element.
   - **Note:** Rive Listeners by default are not set up on a `<canvas>` element if there is no playing state machine, or a state machine without any Rive Listeners set up on the state machine
@@ -204,7 +204,7 @@ export enum EventType {
   Play = "play", // When Rive plays an entity or resumes the render loop
   Pause = "pause", // When Rive pauses the render loop and playing entity
   Stop = "stop", // When Rive stops the render loop and playing entity
-  Loop = "loop", // (Singular animations only) When Rive loops an animation 
+  Loop = "loop", // (Singular animations only) When Rive loops an animation
   Advance = "advance", // When Rive advances the animation in a frame
   StateChange = "statechange", // When a Rive state change is detected
   RiveEvent = "riveevent", // When a Rive Event gets reported
@@ -287,7 +287,7 @@ This effectively removes all event listening subscriptions for a single particul
 
 Scrubs through (a) linear timeline animation(s) by a specified amount of seconds.
 
-<Note> 
+<Note>
 Note: This will not do anything if you are playing through a state machine. This only applies if you are using instantiated animations through the `animations` property.
 </Note>
 ### cleanup()
@@ -296,7 +296,7 @@ Note: This will not do anything if you are playing through a state machine. This
 
 This API is **important** to call, as it will stop the animation render loop, and clean up all created instances for the Rive file, artboard, linear timeline animation(s), state machine, and the renderer. The reason it's important to delete these instances is because these entities hold generated C++ references through WASM behind-the-scenes, and therefore will not automatically get garbage collected like normal JS objects, and must be "cleaned up" manually, to prevent memory leaks. Once you are done with the Rive instance (i.e., a state machine has finished running, a user is navigating off the page, etc.), call `.cleanup()` to ensure all underlying memory allocated is freed up.
 
-<Note> 
+<Note>
 If you want to present a different Artboard from the same Rive file dynamically, you can call `cleanupInstances()` which will only delete the Artboard, animation, and state machine instances (but not the Rive file or renderer object, which you can still reuse).
 </Note>
 
@@ -355,7 +355,7 @@ This sets the layout bounds to the current canvas size. You may want to call thi
 
 This resets the `<canvas>` width and height properties to render at its current bounding rect size (CSS `height` and `width` properties) with the browser's `devicePixelRatio` in mind. This prevents blurry output on high-dpi screens (i.e., a `<canvas>` that is 500x500 on the page may render with an internal area size of 1000x1000 while still maintaining its original canvas size). This calls `resizeToCanvas()` implicitly. It's recommended to call this in the `onLoad` callback.
 
-<Note> 
+<Note>
 In a future major version of this runtime, this API may be called internally on initialization by default, with an option to opt-out if you have specific `width` and `height` properties you want to set on the canvas
 </Note>
 ```typescript
@@ -397,7 +397,7 @@ const riveInstance = new rive.Rive({
   canvas: document.getElementById('canvas'),
   autoplay: true,
   stateMachines: 'bumpy',
-  onLoad: () => {  
+  onLoad: () => {
     // Get the inputs via the name of the state machine
     const inputs = riveInstance.stateMachineInputs('bumpy');
     // Find the input you want to set a value for, or trigger
@@ -452,7 +452,7 @@ function draw(time) {
   lastTime = time;
 
   renderer.clear();
-  
+
   if (artboard) {
     if (stateMachine) {
       stateMachine.advance(elapsedSeconds);
@@ -508,7 +508,7 @@ const riveInstance = new rive.Rive({
   canvas: document.getElementById('canvas'),
   autoplay: true,
   stateMachines: 'bumpy',
-  onLoad: () => {  
+  onLoad: () => {
     // Log the contents of the Rive file
     console.log(riveInstance.contents);
   },


### PR DESCRIPTION
This gets rid of references, wherever possible, to the `webgl` packages in favor of `webgl2`. 

Note: This PR does NOT update the [Feature Support](https://rive.app/docs/runtimes/advanced-topic/format) page, which is going to require some extra thought. 