### PR TITLE
docs(data-binding): add early access callout

### DIFF
--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -5,6 +5,9 @@ description: 'Connect editor elements to data and code using View Models'
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
+import EarlyAccess from '/snippets/early-access-feature.mdx'
+
+<EarlyAccess />
 
 # What is Data Binding?
 

--- a/snippets/early-access-feature.mdx
+++ b/snippets/early-access-feature.mdx
@@ -1,0 +1,1 @@
+<Note>This feature is currently available in [Early Access](https://rive.app/blog/early-access-to-unreleased-features). Runtime support may be limited or unavailable. See [Feature Support](/feature-support) for updates.</Note>


### PR DESCRIPTION
Adds a reusable early access feature snippet, first used in the Data Binding overview.

Addresses #72.