### PR TITLE
fix(app-runtimes): update react native out-of-band example link

### DIFF
--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -601,7 +601,7 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
     <Tab title="React Native">
         ### Examples
-        - [Out of bands example](https://github.com/rive-app/rive-react-native/blob/main/example/src/OutOfBandAssets.tsx)
+        - [Out of bands example](https://github.com/rive-app/rive-react-native/blob/main/example/app/(examples)/OutOfBandAssets.tsx)
 
         ### Using the Referenced Assets API
 


### PR DESCRIPTION
Updates the old React Native example link for out-of-band assets with the updated URL.