### PR TITLE
docs(unity): add min unity version support

### DIFF
--- a/game-runtimes/unity/unity.mdx
+++ b/game-runtimes/unity/unity.mdx
@@ -1,19 +1,24 @@
 ---
-title: 'Unity'
-description: 'Unity runtime for Rive.'
+title: "Unity"
+description: "Unity runtime for Rive."
 ---
 
-
 <Note>
- The Rive Unity runtime is currently in **Technical Preview** for Mac and Windows installs of Unity. We're hoping to gather feedback about the API and feature-set as we expand platform support. Please reach out to us on our [Community](https://community.rive.app/c/support/) or through our [Support Channel](https://rive.atlassian.net/servicedesk/customer/portals).
+  The Rive Unity runtime is currently in **Technical Preview** for Mac and Windows installs of Unity. We're hoping to gather feedback about the API and feature-set as we expand platform support. Please reach out to us on our [Community](https://community.rive.app/c/support/) or through our [Support Channel](https://rive.atlassian.net/servicedesk/customer/portals).
 </Note>
 
 <Note>
- See [Feature Support](#feature-support) below for an updated list of Rive features in Unity.
+  See [Feature Support](#feature-support) below for an updated list of Rive features in Unity.
 </Note>
-## Rendering Support 
 
-The rive-unity runtime uses the [Rive Renderer](https://rive.app/renderer) and is up to date with the latest C++ runtime version of Rive.
+
+## Unity Version Support
+
+The package supports Unity LTS versions from 2021 upwards (including Unity 6).
+
+## Rendering Support
+
+The rive-unity runtime uses the [Rive Renderer](https://rive.app/renderer) and is up to date with the latest C\+\+ runtime version of Rive.
 
 - [WebGL](https://github.com/rive-app/rive-unity/blob/main/WEBGL.md)
 - Metal on Mac
@@ -34,23 +39,23 @@ If you encounter any errors or unexpected crashes while integrating the Rive Uni
 You can find more details on where to find your Editor.log file in the [Unity docs](https://docs.unity3d.com/Manual/LogFiles.html).
 
 <Note>
- Note that it is best to grab the Editor.log file immediately after a crash has occurred
+  Note that it is best to grab the Editor.log file immediately after a crash has occurred
 </Note>
-## Feature Support 
 
-The rive-unity runtime uses the latest Rive C++ runtime. For more details on runtime support, see the [Feature Support](/feature-support) page. Refer to the following table for what is currently supported in the Unity runtime.
+## Feature Support
 
-| **Feature** | **Supported** |
-| --- | --- |
-| [Animation Playback](/runtimes/animation-playback) | ✅ |
-| [Fit & Alignment​](/runtimes/layout#fit) | ✅ |
-| [Listeners​](./listeners) | ✅ |
-| [Setting State Machine Inputs​](./state-machines) | ✅ |
-| [Listening to Events](./rive-events) | ✅ |
-| [Updating text at runtime](/runtimes/text) | ✅ |
-| [Out-of-band assets](./loading-assets) | ✅ |
-| [Procedural rendering](./procedural-rendering) | ✅ |
-| PNG images | ✅ |
-| JPEG images | ✅ |
-| WEBP images | ✅ |
+The rive-unity runtime uses the latest Rive C\+\+ runtime. For more details on runtime support, see the [Feature Support](/feature-support) page. Refer to the following table for what is currently supported in the Unity runtime.
 
+| **Feature**                                        | **Supported** |
+| -------------------------------------------------- | ------------- |
+| [Animation Playback](/runtimes/animation-playback) | ✅             |
+| [Fit & Alignment​](/runtimes/layout#fit)           | ✅             |
+| [Listeners​](./listeners)                          | ✅             |
+| [Setting State Machine Inputs​](./state-machines)  | ✅             |
+| [Listening to Events](./rive-events)               | ✅             |
+| [Updating text at runtime](/runtimes/text)         | ✅             |
+| [Out-of-band assets](./loading-assets)             | ✅             |
+| [Procedural rendering](./procedural-rendering)     | ✅             |
+| PNG images                                         | ✅             |
+| JPEG images                                        | ✅             |
+| WEBP images                                        | ✅             |


### PR DESCRIPTION
This PR updates the docs to mention the minimum version of Unity supported by the Rive Unity package.