### PR TITLE
docs(editor): reorganize editor sections & add Scroll Constraint page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -123,6 +123,16 @@
                 ]
               },
               {
+                "group": "Text",
+                "pages": [
+                  "editor/text/text-overview",
+                  "editor/text/text-runs",
+                  "editor/text/text-styles",
+                  "editor/text/text-modifiers",
+                  "editor/text/fonts"
+                ]
+              },
+              {
                 "group": "Constraints",
                 "pages": [
                   "editor/constraints/constraints-overview",
@@ -132,7 +142,8 @@
                   "editor/constraints/rotation-constraint",
                   "editor/constraints/transform-constraint",
                   "editor/constraints/translation-constraint",
-                  "editor/constraints/follow-path-constraint"
+                  "editor/constraints/follow-path-constraint",
+                  "editor/constraints/scroll-constraint"
                 ]
               },
               {
@@ -170,6 +181,18 @@
                   "editor/data-binding/overview"
                 ]
               },
+              {
+                "group": "Layouts",
+                "pages": [
+                  "editor/layouts/layouts-overview",
+                  "editor/layouts/layout-tools",
+                  "editor/layouts/layout-parameters",
+                  "editor/layouts/layout-styles",
+                  "editor/layouts/layout-animation",
+                  "editor/layouts/n-slicing",
+                  "editor/layouts/scrolling"
+                ]
+              },
               "editor/keyboard-shortcuts",
               {
                 "group": "Exporting",
@@ -184,28 +207,6 @@
                 "pages": [
                   "editor/share-links/overview",
                   "editor/share-links/framer-and-rive"
-                ]
-              },
-              {
-                "group": "Text",
-                "pages": [
-                  "editor/text/text-overview",
-                  "editor/text/text-runs",
-                  "editor/text/text-styles",
-                  "editor/text/text-modifiers",
-                  "editor/text/fonts"
-                ]
-              },
-              {
-                "group": "Layouts",
-                "pages": [
-                  "editor/layouts/layouts-overview",
-                  "editor/layouts/layout-tools",
-                  "editor/layouts/layout-parameters",
-                  "editor/layouts/layout-styles",
-                  "editor/layouts/layout-animation",
-                  "editor/layouts/n-slicing",
-                  "editor/layouts/scrolling"
                 ]
               },
               "editor/tagging"

--- a/editor/constraints/scroll-constraint.mdx
+++ b/editor/constraints/scroll-constraint.mdx
@@ -1,0 +1,9 @@
+---
+title: 'Scroll Constraints'
+---
+
+Scroll Constraints are special types of Constraints that apply to Layout objects and allow their children to scroll. This supports building content that scrolls as well as scroll bars.
+
+Learn more about [Layouts](/editor/layouts/layouts-overview).
+
+Learn more about [Scrolling](/editor/layouts/scrolling).


### PR DESCRIPTION
This PR adds 2 updates:
- Reorganizes the main sections under Editor.  Moves Text up near the other core tools and object types. Moves Layout up so that the "in Editor tools" are grouped more closely together.
- Added a Scroll Constraints page for completeness, but its just a landing page which links to Layouts & Scrolling pages.