### PR TITLE
docs(feature-support): add text follow path

### DIFF
--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -20,7 +20,7 @@ We may include notes on migrating to newer versions if a new feature warrants re
         | Flutter (rive_native) | ✅ `v0.0.1-dev.7+` |            
         | Apple | ✅ `6.7.4+` |
         | Android | ✅ `10.0.4` |
-        | C++ | 🚧 Coming soon |
+        | C++ | ✅  Supported |
         | Unity | ✅ `0.3.5+` |
         | Unreal | 🚧 Coming soon |
     </Accordion>


### PR DESCRIPTION
Adds a new accordion on the "Feature Support" page for Text Follow Path.