### PR TITLE
refactor(feature-support): use Vector Feathering feature naming

### DIFF
--- a/editor/share-links/overview.mdx
+++ b/editor/share-links/overview.mdx
@@ -7,7 +7,7 @@ description: 'Share Links are a fast no-code way to get your Rive files running 
 Share the current version of the file you're working with share links. Note that this is not the same as giving someone access to the live file with all its revision history. This link will be a frozen version of the file in its current state. If you make changes to the file, you'll need to generate a new share link. 
 
 <Warning>
-Certain features, such as Feathers, are only supported through the Rive Renderer. See our [Feature Support](/feature-support) page for more information.
+Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering), are only supported through the Rive Renderer. See our [Feature Support](/feature-support) page for more information.
 </Warning>
 
 ## Creating a share link
@@ -33,7 +33,7 @@ Other options include:
 - **Enable**: Disable the link to prevent others from viewing it.
 - **Rive Renderer**: Toggle between using the Rive Renderer (recommended) and the Canvas renderer.
 
-<Note>Certain features, such as Feathers, are only available using the Rive Renderer.</Note>
+<Note>Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering), are only available using the Rive Renderer. See our [Feature Support](/feature-support) page for more information.</Note>
 
 ## Integrations
 

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -7,7 +7,7 @@ description: 'Specify a renderer to use at runtime.'
 Rive makes use of various different renderers depending on platform and runtime. We're working towards unifying the default renderer used across all platforms/runtimes with the [Rive Renderer](https://rive.app/renderer).
 
 <Warning>
-Certain features, such as Feathers, are only supported through the Rive Renderer. See our [Feature Support](/feature-support) page for more information.
+Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering), are only supported through the Rive Renderer. See our [Feature Support](/feature-support) page for more information.
 </Warning>
 
 ## Renderer Options and Default 

--- a/runtimes/flutter/rive-native.mdx
+++ b/runtimes/flutter/rive-native.mdx
@@ -23,10 +23,10 @@ We encourage you to start using `rive_native` today and share your feedback with
   - [Responsive Layouts](/editor/layouts/)  
   - [Scrolling](/editor/layouts/scrolling)  
   - [N-Slicing](/editor/layouts/n-slicing)  
-  - Feathering  
+  - [Vector Feathering](https://rive.app/blog/introducing-vector-feathering)
 
 - **Rive Renderer Support**:  
-  `rive_native` introduces the [Rive Renderer](https://rive.app/renderer) to Flutter. While you can still use the Flutter-based renderer (Dart/Impeller), the Rive Renderer is recommended for performance-critical use cases. Some features, like Feathering, are only supported with the Rive Renderer. For more details, see our [Feature Support page](/feature-support).
+  `rive_native` introduces the [Rive Renderer](https://rive.app/renderer) to Flutter. While you can still use the Flutter-based renderer (Dart/Impeller), the Rive Renderer is recommended for performance-critical use cases. Some features, like Vector Feathering, are only supported with the Rive Renderer. For more details, see our [Feature Support page](/feature-support).
 
 ---
 

--- a/runtimes/react-native/migration-guide.mdx
+++ b/runtimes/react-native/migration-guide.mdx
@@ -8,7 +8,7 @@ description: 'This document provides a step-by-step guide to help you migrate fr
 This release updates the underlying [Rive Android](https://github.com/rive-app/rive-android) runtime from v9.x.x to v10.x.x, which includes the following changes:
 - The [Rive Renderer](https://rive.app/blog/rive-renderer-now-open-source-and-available-on-all-platforms) is now the default renderer on Android. For iOS, the Rive Renderer was already the default. 
 - Removal of the Skia renderer for Android. For iOS Skia was removed in v8.0.0
-- Support for Feathering
+- Support for [Vector Feathering](https://rive.app/blog/introducing-vector-feathering)
 - Smaller APK sizes and improved performance on Android
 
 ### Breaking Changes

--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -4,7 +4,7 @@ Check below to see if a given feature used by your Rive asset is supported yet a
 
 <Warning>
 Certain features require the use of the Rive Renderer at runtime. See our documentation on [choosing a renderer](/runtimes/choose-a-renderer/).
-Currently, the only feature that requires the Rive Renderer is **Feathers**.
+Currently, the only feature that requires the Rive Renderer is **[Vector Feathering](https://rive.app/blog/introducing-vector-feathering)**.
 </Warning>
 
 We may include notes on migrating to newer versions if a new feature warrants recent API changes.
@@ -54,7 +54,7 @@ We may include notes on migrating to newer versions if a new feature warrants re
         | Unity | ✅ `0.3.6-canary.27`  |
         | Unreal | ✅ `0.3.0a-gh` |
     </Accordion>
-    <Accordion title="Feathers">
+    <Accordion title="Vector Feathering">
         <Warning>
         This feature is only supported with the Rive Renderer. See [Choose a Renderer](/runtimes/choose-a-renderer/).
         </Warning>


### PR DESCRIPTION
Updates feature naming and adds links out to the Vector Feathering page (not hosted on docs).