### PR TITLE
docs(react): add databinding docs

### DIFF
--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -60,7 +60,25 @@ To begin, we need to get a reference to a particular view model. This can be don
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        Use the `useViewModel` hook to get a reference to a view model. You need to pass the `rive` object obtained from `useRive`.
+
+        ```typescript
+        import { useRive, useViewModel } from '@rive-app/react-webgl2';
+
+        const { rive, RiveComponent } = useRive({
+            src: 'your_file.riv',
+            // ... other options
+        });
+
+        // Option 1: Get the default ViewModel for the artboard
+        const defaultViewModel = useViewModel(rive); 
+
+        // Option 2: Get the default ViewModel explicitly
+        const defaultViewModelExplicit = useViewModel(rive, { useDefault: true }); 
+
+        // Option 3: Get a ViewModel by its name
+        const namedViewModel = useViewModel(rive, { name: 'MyViewModelName' });
+        ```
     </Tab>
     <Tab title="Apple">
         ```swift
@@ -215,7 +233,69 @@ Once we have a reference to a view model, it can be used to create an instance. 
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        Use the `useViewModelInstance` hook to create a view model instance from a view model returned by the `useViewModel` hook.
+
+        ```typescript
+        import { useRive, useViewModel, useViewModelInstance } from '@rive-app/react-webgl2';
+
+        const { rive, RiveComponent } = useRive({
+            src: 'your_file.riv',
+            artboard: 'MyArtboard',
+            stateMachine: 'MyStateMachine',
+            // ... other options
+        });
+
+        const viewModel = useViewModel(rive, { name: 'MyViewModelName' }); 
+        // Or: const viewModel = useViewModel(rive); // Default VM
+
+        // Get default instance without binding
+        const defaultUnbound = useViewModelInstance(viewModel, { useDefault: true }); 
+
+        // Get named instance without binding
+        const namedUnbound = useViewModelInstance(viewModel, { name: 'MyInstanceName' });
+
+        // Create new blank instance without binding
+        const newUnbound = useViewModelInstance(viewModel, { useNew: true });
+        ```
+
+        You can also bind the view model instance directly to the Rive instance by passing the `rive` object to the `useViewModelInstance` hook.
+
+        ```typescript
+        import { useRive, useViewModel, useViewModelInstance } from '@rive-app/react-webgl2';
+
+        const { rive, RiveComponent } = useRive({
+            src: 'your_file.riv',
+            artboard: 'MyArtboard',
+            stateMachine: 'MyStateMachine',
+            autoBind: false, // Disable auto binding so we can manually bind later
+            // ... other options
+        });
+
+        const viewModel = useViewModel(rive, { name: 'MyViewModelName' }); 
+
+        // Get default instance (implicit) and bind it
+        const defaultBound = useViewModelInstance(viewModel, { rive });
+
+        // Get named instance and bind it
+        const namedBound = useViewModelInstance(viewModel, { name: 'MyInstanceName', rive });
+
+        // Create a new blank instance and bind it
+        const newBound = useViewModelInstance(viewModel, { useNew: true, rive });
+        ```
+
+        If you set `autoBind: true` in `useRive`, you can access the automatically bound default instance directly via `rive.viewModelInstance` once Rive is loaded, without needing `useViewModel` or `useViewModelInstance`.
+
+        ```typescript
+        const { rive, RiveComponent } = useRive({
+            src: 'your_file.riv',
+            artboard: 'MyArtboard',
+            stateMachine: 'MyStateMachine',
+            autoBind: true,
+        });
+
+        // Once loaded, the instance is available:
+        const boundInstance = rive?.viewModelInstance; 
+        ```
     </Tab>    
     <Tab title="Apple">
     ```swift
@@ -408,7 +488,7 @@ It is preferred to assign to a state machine, as this will automatically apply t
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        For React, no additional steps are needed to bind the view model instance to the Rive component. Passing the `rive` object to `useViewModelInstance` handles this automatically.
     </Tab>    
     <Tab title="Apple">
         ```swift
@@ -521,8 +601,19 @@ Alternatively, you may prefer to use auto-binding. This will automatically bind 
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
-    </Tab>    
+            ```typescript
+            const { rive, RiveComponent } = useRive({
+                src: 'your_file.riv',
+                artboard: 'MyArtboard',
+                stateMachine: 'MyStateMachine',
+                autoBind: true, // Enable auto-binding
+                // ... other options
+            });
+
+            // Once loaded, the instance is available:
+            const boundInstance = rive?.viewModelInstance; 
+            ```
+    </Tab>   
     <Tab title="Apple">
         ```swift
         let riveViewModel = RiveViewModel(...)
@@ -626,7 +717,11 @@ Property descriptors can be inspected on a view model to discover at runtime whi
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+    ```typescript
+    // Access properties from the view model returned by useViewModel
+    const viewModel = useViewModel(rive);
+    console.log(viewModel?.properties);
+    ```
     </Tab>    
     <Tab title="Apple">
         ```swift
@@ -704,7 +799,91 @@ View model instances have mutable properties. References to these properties can
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        Use the specific hook for a given property type to get and set property values. 
+       
+        - `useViewModelInstanceBoolean`: Read/write boolean properties
+        - `useViewModelInstanceString`: Read/write string properties  
+        - `useViewModelInstanceNumber`: Read/write number properties
+        - `useViewModelInstanceColor`: Read/write color properties with additional RGB/alpha methods
+        - `useViewModelInstanceEnum`: Read/write enum properties with available values
+        - `useViewModelInstanceTrigger`: Fire trigger events with optional callbacks
+        
+        These hooks return the current `value` and a function to update it (`setValue`, `setRgb`, `trigger`). The `value` will be null if the property is not found or provided with an invalid viewModelInstance.
+
+
+        ```typescript
+        import {
+            useViewModelInstanceBoolean,
+            useViewModelInstanceString,
+            useViewModelInstanceNumber,
+            useViewModelInstanceEnum,
+            useViewModelInstanceColor,
+            useViewModelInstanceTrigger
+        } from '@rive-app/react-webgl2';
+
+        // Assuming viewModelInstance is obtained via useViewModelInstance or rive.viewModelInstance
+
+        // Boolean
+        const { value: isActive, setValue: setIsActive } = useViewModelInstanceBoolean(
+            'isToggleOn', // Property path
+            viewModelInstance
+        );
+        // Set: setIsActive(true);
+
+        // String
+        const { value: userName, setValue: setUserName } = useViewModelInstanceString(
+            'user/name', // Property path
+            viewModelInstance
+        );
+        // Set: setUserName('Rive');
+
+        // Number
+        const { value: score, setValue: setScore } = useViewModelInstanceNumber(
+            'levelScore', // Property path
+            viewModelInstance
+        );
+        // Set: setScore(100);
+
+        // Enum
+        const { value: status, setValue: setStatus, values: statusOptions } = useViewModelInstanceEnum(
+            'appStatus', // Property path
+            viewModelInstance
+        );
+        // Set: setStatus('loading'); 
+        // Get available options: statusOptions is an array like ['idle', 'loading', 'error']
+
+        // Color
+        const { 
+            value: themeColor, // Raw number value like -3267805
+            setRgb: setThemeColorRgb, // Set RGB components (0-255 values)
+            setAlpha: setThemeColorAlpha, // Set alpha component (0-255)
+            setOpacity: setThemeColorOpacity, // Set opacity (0.0-1.0)
+            setRgba: setThemeColorRgba, // Set all components at once
+            setValue: setThemeColorValue // Set raw color value
+        } = useViewModelInstanceColor(
+            'ui/themeColor', // Property path
+            viewModelInstance
+        );
+        // Set RGB: setThemeColorRgb(0, 128, 255); // Set to a blue color
+        // Set Alpha: setThemeColorAlpha(128); // Set to 50% opacity
+        // Set Opacity: setThemeColorOpacity(0.5); // Set to 50% opacity
+        // Set RGBA: setThemeColorRgba(0, 128, 255, 255); // Blue with full opacity
+        // Set Value: setThemeColorValue(-3267805); // Set using raw color value
+
+        // Trigger (No value, just a trigger function)
+        const { trigger: playEffect } = useViewModelInstanceTrigger(
+            'playButtonEffect', // Property path
+            viewModelInstance,
+            { 
+                // Optional callback to be called when the trigger is fired
+                onTrigger: () => {
+                    console.log('Trigger Fired!');
+                }
+            }
+        );
+        // Trigger: playEffect(); 
+        ```
+        The `value` returned by each hook will update automatically when the property changes in the Rive graphic.
     </Tab>    
     <Tab title="Apple">
         ```swift
@@ -973,7 +1152,25 @@ You can observe changes over time to property values, either by using listeners 
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        The React hooks handle observability automatically. When a property's value changes within the Rive instance (either because you set it via a hook or due to an internal binding), the `value` returned by the corresponding hook (e.g., `useViewModelInstanceString`) updates. This state change triggers a re-render of your React component, allowing you to react to the new value.
+
+        For Triggers, you can provide an `onTrigger` callback directly to the `useViewModelInstanceTrigger` hook, which fires when the trigger is activated in the Rive instance.
+
+        ```typescript
+        import { useViewModelInstanceTrigger } from '@rive-app/react-webgl2';
+
+        // Assuming viewModelInstance is available
+        const { trigger } = useViewModelInstanceTrigger(
+            'showPopup', 
+            viewModelInstance,
+            { 
+                onTrigger: () => {
+                    console.log('Show Popup Trigger Fired!');
+                    // Show your popup UI
+                }
+            }
+        );
+        ```
     </Tab>        
     <Tab title="Apple">
         ```swift
@@ -1184,7 +1381,17 @@ Enums are string typed. The Rive file contains a list of enums. Each enum in tur
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        ```typescript
+        const { rive } = useRive({
+            src: 'your_file.riv',
+            artboard: 'MyArtboard',
+            stateMachine: 'MyStateMachine',
+            autoBind: true
+            // ... other options
+        });
+        const enums = rive?.enums();
+        console.log(enums);
+        ```
     </Tab>    
     <Tab title="Android">
         ```kotlin
@@ -1256,7 +1463,27 @@ View models can have properties of type view model, allowing for arbitrary nesti
     ```
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+        Access nested properties by providing the full path (separated by `/`) as the first argument to the property hooks.
+
+        ```typescript
+        import { useViewModelInstanceString, useViewModelInstanceNumber } from '@rive-app/react-webgl2';
+
+        // Accessing 'settings/theme/name' (String)
+        const { value: themeName, setValue: setThemeName } = useViewModelInstanceString(
+            'settings/theme/name', 
+            viewModelInstance
+        );
+
+        // Accessing 'settings/volume' (Number)
+        const { value: volume, setValue: setVolume } = useViewModelInstanceNumber(
+            'settings/volume', 
+            viewModelInstance
+        );
+
+        console.log('Current theme:', themeName);
+        // setThemeName('Dark Mode');
+        // setVolume(80);
+        ```
     </Tab>    
     <Tab title="Apple">
         ```swift
@@ -1344,7 +1571,7 @@ View models can have properties of type view model, allowing for arbitrary nesti
     <YouTube id="G6IWCZ1IG10" timestamp="1243" />
     </Tab>
     <Tab title="React">
-        <DataBindingReact></DataBindingReact>
+      See the `DataBinding` story in the [Rive React repo](https://github.com/rive-app/rive-react) for a demo.
     </Tab>
     <Tab title="Apple">
         See the [Data Binding view](https://github.com/rive-app/rive-ios/blob/main/Example-iOS/Source/Examples/SwiftUI/DataBindingView.swift) in the Example app for a demo.

--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -808,7 +808,7 @@ View model instances have mutable properties. References to these properties can
         - `useViewModelInstanceEnum`: Read/write enum properties with available values
         - `useViewModelInstanceTrigger`: Fire trigger events with optional callbacks
         
-        These hooks return the current `value` and a function to update it (`setValue`, `setRgb`, `trigger`). The `value` will be null if the property is not found or provided with an invalid viewModelInstance.
+        These hooks return the current `value` and a function to update it (`setValue`, `setRgb`, `trigger`). The `value` will be null if the property is not found or if the hook is provided with an invalid viewModelInstance.
 
 
         ```typescript

--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -44,7 +44,7 @@ We may include notes on migrating to newer versions if a new feature warrants re
         | **Runtime** | **Version** |
         | --- | --- |
         | Web | ✅ `2.26.6+` |
-        | React | 🚧 Partial support; hooks coming soon |
+        | React | ✅ `4.20.0+` |
         | React Native | ✅ `9.3.0+` |
         | Flutter | 🚧 Coming soon |
         | Flutter (rive_native) | ✅ `0.0.1-dev.8+` |            


### PR DESCRIPTION
This PR adds docs for the new databinding hooks in the React package. It also updates the feature support page to mention the supported version for databinding.