### PR TITLE
docs: split early access and early access feature into separate snippets

### DIFF
--- a/editor/data-binding/lists.mdx
+++ b/editor/data-binding/lists.mdx
@@ -3,11 +3,11 @@ title: 'Lists'
 description: 'Use Data Binding to generate lists at runtime'
 ---
 
-import { EarlyAccess } from '/snippets/early-access-feature.mdx'
+import { EarlyAccessFeature } from '/snippets/early-access-feature.mdx'
 
-<EarlyAccess featureName="Data Binding Lists">
+<EarlyAccessFeature featureName="Data Binding Lists">
   Further performance enhancements as well as Runtime APIs will be available when released to the general public.
-</EarlyAccess>
+</EarlyAccessFeature>
 
 A List is a way to display a set of items that are dynamically generated based on bound data values that you set up in your View Models. This allows you to build Rive files that can change in real time based on updates to those values. You can use Lists to create:
 

--- a/editor/mcp/integration.mdx
+++ b/editor/mcp/integration.mdx
@@ -3,10 +3,10 @@ title: "Rive MCP Integration"
 sidebarTitle: "MCP Integration"
 ---
 
-import { EarlyAccess } from '/snippets/early-access-feature.mdx'
+import { EarlyAccess } from '/snippets/early-access.mdx'
 
 <EarlyAccess featureName="MCP">
-   This is initially available in the Early Access version of the Mac Desktop app. Windows support is coming.
+   MCP Integration is initially available in the Early Access version of the Mac Desktop app. Windows support is coming.
 </EarlyAccess>
 
 ## Getting started

--- a/snippets/early-access-feature.mdx
+++ b/snippets/early-access-feature.mdx
@@ -1,4 +1,4 @@
-export const EarlyAccess = ({ featureName, children }) => {
+export const EarlyAccessFeature = ({ featureName, children }) => {
   return (
     <Warning>
       {featureName} is in <a href="https://rive.app/blog/early-access-to-unreleased-features" target="_blank" rel="noopener noreferrer">Early Access</a> and is not yet available for production. Runtime support may be limited or unavailable. See <a href="/feature-support">Feature Support</a> for updates.

--- a/snippets/early-access.mdx
+++ b/snippets/early-access.mdx
@@ -1,0 +1,14 @@
+export const EarlyAccess = ({ featureName, children }) => {
+  return (
+    <Warning>
+      {featureName} is in <a href="https://rive.app/blog/early-access-to-unreleased-features" target="_blank" rel="noopener noreferrer">Early Access</a> and is not yet available for production.
+
+      {children && (
+        <>
+          <br />
+          {children}
+        </>
+      )}
+    </Warning>
+  );
+}; 


### PR DESCRIPTION
- Adds usage of new EarlyAccess snippet to MCP Integration