### PR TITLE
docs(mcp): add note about requiring ea to be open

### DIFF
--- a/editor/mcp/integration.mdx
+++ b/editor/mcp/integration.mdx
@@ -28,7 +28,7 @@ You can connect the Rive Editor to AI tools through MCP (Model Context Protocol)
   <Step title="Set up Cursor">
     Create a [Cursor](https://www.cursor.com/) account and install the app.
   </Step>
-  <Step title="Save The configuration">
+  <Step title="Save the configuration">
     Save the following JSON snippet to your computer as `mcp.json`.
   ```json
   {
@@ -59,6 +59,10 @@ You can connect the Rive Editor to AI tools through MCP (Model Context Protocol)
       <Step title="Verify connection">
         If everything was installed correctly, you should see Rive as an available MCP server
         ![](/images/editor/cursor-mcp-connection.png)
+
+        <Note>
+        For the Rive server to be available, you must have the Rive Early Access app opened.
+        </Note>
       </Step>
       <Step title="Enable connection">
         Turn the MCP connection `On`


### PR DESCRIPTION
The Rive MCP server will be unavailable if the app is not opened; this should help users troubleshoot if the server is not available / visible.