### PR TITLE
chore: add caching to feature support page

### DIFF
--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -382,6 +382,20 @@ We may include notes on migrating to newer versions if a new feature warrants re
             - Avoid complex transforms repeatedly on the `<canvas>` elements that display Rive animations (or `<RiveComponent />` in the React runtimes)
             - We recommend using `@rive-app/webgl` to display mesh on Firefox for best performance
     </Accordion>
+    <Accordion title="Caching a Rive File">
+        | **Runtime** | **Version** |
+        | --- | --- |
+        | Web | ✅ Supported |
+        | React | ✅ Supported |
+        | React Native | Not yet supported |
+        | Flutter | ✅  Supported |
+        | Flutter (rive_native) | ✅ Supported |
+        | Apple | ✅ Supported |
+        | Android | ✅ Supported |
+        | C++ | ✅  Supported |
+        | Unity | Not supported |
+        | Unreal | Not supported |
+    </Accordion>
     <Accordion title="Raster Assets">
         | **Runtime** | **Version** |
         | --- | --- |

--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -393,8 +393,8 @@ We may include notes on migrating to newer versions if a new feature warrants re
         | Apple | ✅ Supported |
         | Android | ✅ Supported |
         | C++ | ✅  Supported |
-        | Unity | Not supported |
-        | Unreal | Not supported |
+        | Unity | ✅  Supported |
+        | Unreal | Not yet supported |
     </Accordion>
     <Accordion title="Raster Assets">
         | **Runtime** | **Version** |


### PR DESCRIPTION
This adds caching a .riv to the feature support docs. This seems like an old feature and I'm having a hard time finding when it first got supported in each runtime so I didn't include a version. 

![CleanShot 2025-06-11 at 11 48 18](https://github.com/user-attachments/assets/fe3af60a-36a0-4f6a-ad2f-52002748e6f9)

resolves #45 
