### PR TITLE
docs(flutter): documentation for v0.14.0 release

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -305,10 +305,7 @@
                 "pages": [
                   "runtimes/flutter/flutter",
                   "runtimes/flutter/rive-native",
-                  "runtimes/flutter/caching-a-rave-file",
-                  "runtimes/flutter/alternative-widget-setup",
-                  "runtimes/flutter/custom-rive-renderobject",
-                  "runtimes/flutter/custom-painter"
+                  "runtimes/flutter/migration-guide"
                 ]
               },
               {

--- a/runtimes/animation-playback.mdx
+++ b/runtimes/animation-playback.mdx
@@ -73,17 +73,19 @@ Starting animations can also be chosen when Rive is instantiated. The first anim
   </Tab>
 
   <Tab title="Flutter">
-    ```javascript
-    // Play the curves animation
-    RiveAnimation.network(
-        'https://cdn.rive.app/animations/vehicles.riv',
-        animations: ['curves'],
-    );
+    ```dart
+    // Create a File, Artboard, and SingleAnimationPainter
+    final file = (await File.asset(
+      'assets/rewards.riv',
+      riveFactory: Factory.rive,
+    ))!;
+    final artboard = file.artboard('Main')!;
+    final animationPainter = SingleAnimationPainter("Artboard Name");
 
-    // Play and mix both the idle and curves animations
-    RiveAnimation.network(
-        'https://cdn.rive.app/animations/vehicles.riv',
-        animations: ['idle', 'curves'],
+    // Later create the widget
+    return RiveArtboardWidget(
+      artboard: artboard,
+      painter: animationPainter,
     );
     ```
   </Tab>
@@ -335,133 +337,13 @@ export default function App() {
   <Tab title="Flutter">
     Flutter handles things a little differently compared to the other runtimes due to its reactive nature.
 
-    Every animation and state machine in Flutter has an underlying controller that manages the state of each animation. When you pass a list of animation names to the RiveAnimation widget, it creates and manages controllers for each.
+    Every animation and state machine in Flutter has an underlying painter that manages the state/painting/advancing.
 
-    In order to access controls for animations, you'll need to instantiate a RiveAnimationController for each animation and pass the controller to the RiveAnimation widget instead of its name. You can mix and match passing in controllers and names, but avoid passing in both for the same animation.
+    In order to access controls for animations, you'll need to create a `SingleAnimationPainter` or `StateMachinePainter` and pass it to the `RiveArtboardWidget`.
 
-    There are a number of controllers provided in the runtime that perform certain tasks. We'll cover these as they become relevant.
+    Or you can create `RiveWidgetController` and pass it to the `RiveWidget` to control playback of state machines with a more feature-rich API (recommended).
 
-    #### Manually controlling a looping animation
-
-
-    [SimpleAnimation](https://pub.dev/documentation/rive/latest/rive/SimpleAnimation-class.html) is a basic controller that provides simple playback control of a single animation. With this controller, you can play, pause, and reset animations.
-
-    In the following example, the `isActive` property of `SimpleAnimation` is used to play and pause a single animation.
-
-    ```dart
-    import 'package:flutter/material.dart';
-    import 'package:rive/rive.dart';
-
-    class PlayPauseAnimation extends StatefulWidget {
-      const PlayPauseAnimation({Key? key}) : super(key: key);
-
-      @override
-      _PlayPauseAnimationState createState() => _PlayPauseAnimationState();
-    }
-
-    class _PlayPauseAnimationState extends State<PlayPauseAnimation> {
-      /// Controller for playback
-      late RiveAnimationController _controller;
-
-      /// Toggles between play and pause animation states
-      void _togglePlay() =>
-          setState(() => _controller.isActive = !_controller.isActive);
-
-      /// Tracks if the animation is playing by whether controller is running
-      bool get isPlaying => _controller.isActive;
-
-      @override
-      void initState() {
-        super.initState();
-        _controller = SimpleAnimation('idle');
-      }
-
-      @override
-      Widget build(BuildContext context) {
-        return Scaffold(
-          appBar: AppBar(
-            title: const Text('Animation Example'),
-          ),
-          body: Center(
-            child: RiveAnimation.network(
-              'https://cdn.rive.app/animations/vehicles.riv',
-              controllers: [_controller],
-              // Update the play state when the widget's initialized
-              onInit: () => setState(() {}),
-            ),
-          ),
-          floatingActionButton: FloatingActionButton(
-            onPressed: _togglePlay,
-            tooltip: isPlaying ? 'Pause' : 'Play',
-            child: Icon(
-              isPlaying ? Icons.pause : Icons.play_arrow,
-            ),
-          ),
-        );
-      }
-    }
-    ```
-
-    ### Repeatedly playing a one-shot animation
-
-    One-shot animations do not loop. [OneShotAnimation](https://pub.dev/documentation/rive/latest/rive/OneShotAnimation-class.html) is a controller that will automatically stop and reset a one-shot animation when it has played through so it can be repeatedly played as required.
-
-    The controller also provides two callbacks: `onStart` and `onStop` that will fire when the animation starts and stops playing respectively.
-
-    The example below demonstrates mixing animation names with controllers. The `idle` and `curves` animations are managed by the runtime and their looping animations will play continuously. `bounce` is a one-shot and is triggered when the button is tapped. The runtime will then play the `bounce` animation, mixing it cleanly with the looping animations.
-
-    ```dart
-    import 'package:flutter/material.dart';
-    import 'package:rive/rive.dart';
-
-    class PlayOneShotAnimation extends StatefulWidget {
-      const PlayOneShotAnimation({Key? key}) : super(key: key);
-
-      @override
-      _PlayOneShotAnimationState createState() => _PlayOneShotAnimationState();
-    }
-
-    class _PlayOneShotAnimationState extends State<PlayOneShotAnimation> {
-      /// Controller for playback
-      late RiveAnimationController _controller;
-
-      /// Is the animation currently playing?
-      bool _isPlaying = false;
-
-      @override
-      void initState() {
-        super.initState();
-        _controller = OneShotAnimation(
-          'bounce',
-          autoplay: false,
-          onStop: () => setState(() => _isPlaying = false),
-          onStart: () => setState(() => _isPlaying = true),
-        );
-      }
-
-      @override
-      Widget build(BuildContext context) {
-        return Scaffold(
-          appBar: AppBar(
-            title: const Text('One-Shot Example'),
-          ),
-          body: Center(
-            child: RiveAnimation.network(
-              'https://cdn.rive.app/animations/vehicles.riv',
-              animations: const ['idle', 'curves'],
-              controllers: [_controller],
-            ),
-          ),
-          floatingActionButton: FloatingActionButton(
-            // disable the button while playing the animation
-            onPressed: () => _isPlaying ? null : _controller.isActive = true,
-            tooltip: 'Play',
-            child: const Icon(Icons.arrow_upward),
-          ),
-        );
-      }
-    }
-    ```
+    This painter concept is extensible, and you can also create your own custom painter, for example, to control multiple animations at once.
   </Tab>
 
   <Tab title="Apple">

--- a/runtimes/artboards.mdx
+++ b/runtimes/artboards.mdx
@@ -56,12 +56,42 @@ Only one artboard can be used at a time.
   </Tab>
 
   <Tab title="Flutter">
-    ```dart
-    RiveAnimation.network(
-        'https://cdn.rive.app/animations/vehicles.riv',
-        artboard: 'Truck'
-    );
-    ```
+  Manually create an artboard:
+
+  ```dart
+  // Default artboard
+  final artboard = riveFile.defaultArtboard();
+  // Artboard named
+  final artboard = riveFile.artboard('Truck');
+  // Artboard at index
+  final artboard = riveFile.artboardAt(0);
+  ```
+
+  Specify the artboard to use in `RiveWidgetController` or `RiveWidgetBuilder`:
+
+  ```dart
+  // Default artboard
+  final artboardSelector = ArtboardSelector.byDefault();
+  // Artboard named
+  final artboardSelector = ArtboardSelector.byName('Truck');
+  // Artboard at index
+  final artboardSelector = ArtboardSelector.byIndex(0);
+
+  // Pass to RiveWidgetController
+  final controller = RiveWidgetController(
+    riveFile,
+    artboardSelector: artboardSelector,
+  );
+
+  // Pass to RiveWidgetBuilder
+  return RiveWidgetBuilder(
+    fileLoader: fileLoader,
+    artboardSelector: ArtboardSelector.byName('Main'),
+    builder: (context, state) {
+      // return a widget
+    },
+  );  
+  ```
   </Tab>
 
   <Tab title="Apple">

--- a/runtimes/caching-a-rive-file.mdx
+++ b/runtimes/caching-a-rive-file.mdx
@@ -11,71 +11,27 @@ Under most circumstances a `.riv` file should load quickly and managing the `Riv
 
 
     <Tab title="Flutter">
-        
-        The following is a basic example to illustrate how to preload a Rive file, and pass the data directly to the `RiveAnimation.direct()` constructor: 
+        In Flutter, you are responsible for managing the lifecycle of a Rive file. You can create a `File` object directly, or use the `FileLoader` convenience class with `RiveWidgetBuilder`. In both cases, you must call `dispose()` on the object when it's no longer needed to free up memory.
 
-        ```javascript
-        class PreloadRive extends StatefulWidget {
-        const PreloadRive({super.key});
+        <Tip>
+        To optimize memory usage, reuse the same `File` object across multiple `RiveWidget` instances if they use the same `.riv` file. This ensures the file is loaded only once and shared in memory.
+        </Tip>
 
-        @override
-        State<PreloadRive> createState() => _PreloadRiveState();
-        }
-
-        class _PreloadRiveState extends State<PreloadRive> {
-        RiveFile? _file; // You can maintain this reference to have a cached version
-
-        @override
-        void initState() {
-            super.initState();
-            preload();
-        }
-
-        Future<void> preload() async {
-            rootBundle.load('assets/little_machine.riv').then(
-            (data) async {
-                // Load the RiveFile from the binary data.
-                setState(() {
-                _file = RiveFile.import(data);
-                });
-            },
-            );
-        }
-
-        @override
-        Widget build(BuildContext context) {
-            return (_file == null)
-                ? const SizedBox.shrink()
-                : RiveAnimation.direct(_file!);
-        }
-        }
-        ```
-
-        ### Other Considerations
+        <Warning>
+        After a `File` is disposed, it cannot be used again. To use the same `.riv` file, create a new `File` object.
+        </Warning>
 
         #### Managing State 
 
-        How the `RiveFile` is kept alive in state and shared to other widgets is up to you and your preferred state management solution. One approach can be to wait for the Rive file to load in `main`, or during the startup screen, and using the [Provider](https://pub.dev/packages/provider) package to expose the data to the whole application.
-
-        Or if the animation is only needed in a nested section of your application, then it might be preferable to delay loading the animation until necessary.
+        How you keep the Rive `File` alive and share it with widgets depends on your state management approach. For global access, load the file in `main` or during app startup, and expose it using a package like [Provider](https://pub.dev/packages/provider). If the file is only needed in a specific part of your app, consider loading the file only when required.
 
         #### Memory
 
-        By managing the RiveFile yourself you can have finer control over the memory used in your application. This will be especially beneficial if the same Rive file is being used in multiple parts of your application, or used simultaneously in multiple `RiveAnimation` widgets.
-
-        You can make use of Flutter DevTools’ [memory tooling](https://docs.flutter.dev/tools/devtools/memory#memory-view-guide) for additional investigation if needed or desired.
+        Managing the file yourself gives you fine-grained control over memory usage, especially when the same Rive file is used in multiple places or simultaneously in several widgets. Use [Flutter DevTools memory tooling](https://docs.flutter.dev/tools/devtools/memory#memory-view-guide) to monitor and optimize memory if needed.
 
         #### Network Assets 
 
-        The easiest way to load a Rive animation over the Internet is by using `RiveAnimation.network(url)`. However, similar considerations apply to a network asset regarding memory and sharing a Rive file across multiple widgets/pages.
-
-        The following can be used to load a Rive file over the network :
-
-        ```javascript
-        final riveFile = await RiveFile.network('YOUR:URL');
-        ```
-
-        The reference can then be kept alive in memory and the `riveFile` can be passed to `RiveAnimation.direct`.
+        To load a Rive file from the Internet, use `File.url('YOUR:URL')`. For network assets, cache the file in memory to avoid repeated downloads and unnecessary decoding of the file.
     </Tab>
 
     <Tab title="React">

--- a/runtimes/flutter/flutter.mdx
+++ b/runtimes/flutter/flutter.mdx
@@ -339,7 +339,7 @@ void dispose() {
 }
 ```
 <Note>
-Because the resources are managed by the `RiveWidgetBuilder`, you will not be able to access the `RiveWidgetController` (and other state) after the widget is disposed. If you need to access the controller after the widget is disposed, consider create the file and controller yourself.
+Because the resources are managed by the `RiveWidgetBuilder`, you will not be able to access the `RiveWidgetController` (and other state) after the widget is disposed. If you need to access the controller after the widget is disposed, consider creating the file and controller yourself.
 
 The exception to this is the `FileLoader`, which you control. This loader can be reused across multiple `RiveWidgetBuilder` instances. The underlying `File` will only be loaded once. The `File` will be disposed when the `FileLoader` is disposed.
 </Note>

--- a/runtimes/flutter/flutter.mdx
+++ b/runtimes/flutter/flutter.mdx
@@ -354,7 +354,7 @@ You can use different renderers for different graphics in your app.
 
 Some considerations when choosing a renderer:
 - If you plan on showing many Rive graphics that are all drawing to different Rive widgets, consider using `Factory.flutter` to reduce the native overhead of allocating native render targets and textures.
-- If you are showing a complex grahic, consider using `Factory.rive` to take advantage of the Rive renderer's optimizations.
+- If you are showing a complex graphic, consider using `Factory.rive` to take advantage of the Rive renderer's optimizations.
 - Vector Feathering is only available with `Factory.rive`, so if you need that feature, use the Rive renderer.
 
 For more information see [Choosing a Renderer](/runtimes/choose-a-renderer/).

--- a/runtimes/flutter/flutter.mdx
+++ b/runtimes/flutter/flutter.mdx
@@ -4,129 +4,398 @@ description: 'Flutter runtime for Rive.'
 ---
 
 import NoteOnFeatureSupport from "/snippets/runtimes/rendering-feature-support.mdx"
+import Interaction from "/snippets/runtimes/animation-control-and-interaction.mdx"
 
 <NoteOnFeatureSupport/>
 
-<Note>
- We're revamping the Rive Flutter runtime. To explore the new API and a version of Rive Flutter that supports the latest features and the Rive Renderer, check out [Rive Native](/runtimes/flutter/rive-native).
-</Note>
+## Overview
 
-## Overview 
+This guide documents how to use the Rive Flutter runtime to easily integrate Rive graphics in your Flutter apps.
 
-This guide documents how to get started using the Flutter runtime library. Rive runtime libraries are open-source. The source is available in its [GitHub repository](https://github.com/rive-app/rive-flutter). This library contains an API for Flutter apps to easily integrate their Rive assets.
+<Info>
+Already using Rive Flutter? See our [Migration Guide](/runtimes/flutter/migration-guide) for information on adopting the latest version.
+</Info>
 
-## Quick Start
+## Quick start
 
-See our [quick start example](https://zapp.run/edit/rive-car-wash-zf160614f170?entry=lib/main.dart&file=lib/main.dart) that shows how to play a Rive animation in Flutter.
+See our [quick start example](https://zapp.run/edit/rive-car-wash-zf160614f170?entry=lib/main.dart&file=lib/main.dart) that shows how to play a Rive graphic in Flutter.
 
-## Getting Started 
+## Getting started
 
-Follow the steps below for a quick start on integrating Rive into your Flutter apps.
+Follow the steps below to integrate Rive into your Flutter apps.
 
 <Steps>
   <Step title="Add the Rive package dependency">
     Check out Rive's [pub.dev](https://pub.dev/packages/rive) page to get the latest version.
 
-    ```json
+    ```yaml
     # pubspec.yaml
     dependencies:
-      rive: 0.13.14
+      rive: ^0.14.0 # or latest version
     ```
+
   </Step>
   <Step title="Import the Rive package">
     Import the Rive runtime library in the file you're looking to integrate Rive animations into.
 
-    ```javascript
+    ```dart
     import 'package:rive/rive.dart';
     ```
+
+    Consider doing a named import to avoid conflicts with other libraries:
+
+    ```dart
+    import 'package:rive/rive.dart' as rive;
+    ```
+
   </Step>
-  <Step title="Add a RiveAnimation widget">
+  <Step title="Initialize Rive">
 
-    There are a few different methods to integrating Rive Animations into your apps easily:
+  <Info>
+  **Important:** You must call `RiveNative.init` at the start of your app, or before you use Rive. For example, in `main.dart`:
+  </Info>
 
-    #### Via URL 
+  ```dart
+  import 'package:rive/rive.dart';
 
-    ```javascript
-    RiveAnimation.network(
-      'https://cdn.rive.app/animations/vehicles.riv',
-    )
-    ```
+  Future<void> main() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await RiveNative.init(); // Call init before using Rive
+    runApp(const MyApp());
+  }
+  ```
+  </Step>  
+  <Step title="Add a Rive widget">
+    There are several ways to render Rive graphics in Flutter. We recommend using the `RiveWidget`, and optionally the `RiveWidgetBuilder`.
+    - The `RiveWidgetBuilder` handles file loading, error states, and resource management automatically.
+    - The `RiveWidget` is responsible for rendering the graphic and exposing common view configuration.
 
-    #### Via Asset Bundle 
+    <Tabs>
+        <Tab title="Using RiveWidgetBuilder">
+        ```dart
+        class ExampleRiveBuilder extends StatefulWidget {
+          const ExampleRiveBuilder({super.key});
 
-    Make sure you add the Rive file to your asset bundle and reference it in `pubspec.yaml`
+          @override
+          State<ExampleRiveBuilder> createState() => _ExampleRiveBuilderState();
+        }
 
-    ```javascript
-    RiveAnimation.asset(
-      'assets/vehicles.riv',
-    )
-    ```
+        class _ExampleRiveBuilderState extends State<ExampleRiveBuilder> {
+          late final fileLoader = FileLoader.fromAsset("assets/vehicles.riv", riveFactory: Factory.rive);
 
-    In `pubspec.yaml`:
+          @override
+          void dispose() {
+            fileLoader.dispose();
+            super.dispose();
+          }
+
+          @override
+          Widget build(BuildContext context) {
+            return RiveWidgetBuilder(
+              fileLoader: fileLoader,
+              builder: (context, state) => switch (state) {
+                RiveLoading() => const Center(child: CircularProgressIndicator()),
+                RiveFailed() => ErrorWidget.withDetails(
+                    message: state.error.toString(),
+                    error: FlutterError(state.error.toString()),
+                  ),
+                RiveLoaded() => RiveWidget(
+                    controller: state.controller,
+                    fit: Fit.cover,
+                  )
+              },
+            );
+          }
+        }
+        ```
+        </Tab>
+        <Tab title="Using RiveWidget directly">
+        ```dart
+        class ExampleBasic extends StatefulWidget {
+          const ExampleBasic({super.key});
+
+          @override
+          State<ExampleBasic> createState() => _ExampleBasicState();
+        }
+
+        class _ExampleBasicState extends State<ExampleBasic> {
+          late File file;
+          late RiveWidgetController controller;
+          bool isInitialized = false;
+
+          @override
+          void initState() {
+            super.initState();
+            initRive();
+          }
+
+          void initRive() async {
+            file = (await File.asset("assets/vehicles.riv", riveFactory: Factory.rive))!;
+            controller = RiveWidgetController(file);
+            setState(() => isInitialized = true);
+          }
+
+          @override
+          void dispose() {
+            file.dispose();
+            controller.dispose();
+            super.dispose();
+          }
+
+          @override
+          Widget build(BuildContext context) {
+            if (!isInitialized) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return RiveWidget(
+              controller: controller,
+              fit: Fit.cover,
+            );
+          }
+        }
+        ```
+        </Tab>
+    </Tabs>
+  </Step>
+  <Step title="Loading from different sources">
+    **From Asset Bundle:**
+
+    Make sure you add the Rive files to your asset bundle and reference them in `pubspec.yaml`:
 
     ```yaml
-    ...
-
-    # To add assets to your application, add an assets section, like this:
+    # pubspec.yaml
     assets:
         - assets/vehicles.riv
     ```
 
-    Via Relative Path
+    ```dart
+    // Using FileLoader (with RiveWidgetBuilder)
+    final fileLoader = FileLoader.fromAsset("assets/vehicles.riv", riveFactory: Factory.rive);
 
-    ```javascript
-    RiveAnimation.file('path/to/local/file.riv')
+    // Using File directly
+    final file = await File.asset("assets/vehicles.riv", riveFactory: Factory.rive);
     ```
 
-    #### Via Direct 
+    **From URL:**
 
-    If you use the same Rive file multiple times in your application, you may want to create a single `RiveFile` instance for that `.riv`, and feed it directly to `RiveAnimation` so that the Rive file is only loaded once.
+    ```dart
+    // Using FileLoader (with RiveWidgetBuilder)
+    final fileLoader = FileLoader.fromUrl("https://cdn.rive.app/animations/vehicles.riv", riveFactory: Factory.rive);
 
-    ```javascript
-    final riveFile = await RiveFile.asset('assets/truck.riv');
-
-    RiveAnimation.direct(riveFile)
+    // Using File directly
+    final file = await File.url("https://cdn.rive.app/animations/vehicles.riv", riveFactory: Factory.rive);
     ```
-  </Step>
+
+    **From Rive File:**
+
+    ```dart
+    // Using FileLoader (with RiveWidgetBuilder)
+    final fileLoader = FileLoader.fromFile(existingFile, riveFactory: Factory.rive);
+    ```
+  </Step>   
 </Steps>
 
-## Complete example 
+## Key components
 
-```javascript
-import 'package:flutter/material.dart';
-import 'package:rive/rive.dart';
+### `RiveWidget`
 
-void main() => runApp(MaterialApp(
-      home: MyRiveAnimation(),
-    ));
+The `RiveWidget` is responsible for displaying Rive graphics.
 
-class MyRiveAnimation extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: RiveAnimation.network(
-          'https://cdn.rive.app/animations/vehicles.riv',
-          fit: BoxFit.cover,
-        ),
-      ),
-    );
-  }
+**Properties:**
+
+- `controller` [**required**]: The `RiveWidgetController` that manages the Rive graphic
+- `fit`: How the artboard should fit within the widget (default: `contain`)
+- `alignment`: How the artboard should be aligned within the widget (default: `center`)
+- `hitTestBehavior`: How pointer events should be handled (default: `opaque`)
+- `cursor`: The cursor to display when hovering over the widget (default: `defer`)
+- `layoutScaleFactor`: Scale factor when using `Fit.layout` (default: `1.0`)
+
+### `RiveWidgetBuilder`
+
+The `RiveWidgetBuilder` is a higher-level widget that handles file loading, error states, and resource management automatically.
+
+**Properties:**
+
+- `fileLoader` [**required**]: The `FileLoader` for loading the Rive file
+- `builder` [**required**]: Function that builds the widget based on state
+- `artboardSelector`: Which artboard to use (default: `ArtboardDefault()`)
+- `stateMachineSelector`: Which state machine to use (default: `StateMachineDefault()`)
+- `dataBind`: How to bind view model data (optional)
+- `controller`: Optional custom controller builder
+- `onLoaded`: Callback when Rive state is loaded
+- `onFailed`: Callback when Rive state fails to load
+
+### `RiveWidgetController`
+
+The `RiveWidgetController` manages the graphic.
+
+**Creating a Controller:**
+
+```dart
+// Using default artboard and state machine
+final controller = RiveWidgetController(file);
+
+// Specifying artboard and state machine
+final controller = RiveWidgetController(
+  file,
+  artboardSelector: ArtboardSelector.byName("MyArtboard"),
+  stateMachineSelector: StateMachineSelector.byName("MyStateMachine"),
+);
+```
+
+**Data Binding:**
+
+```dart
+// Auto-bind with default view model instance
+final viewModelInstance = controller.dataBind(DataBind.auto());
+
+// Bind by specific instance
+final viewModelInstance = controller.dataBind(DataBind.byInstance(myInstance));
+
+// Bind by name
+final viewModelInstance = controller.dataBind(DataBind.byName("MyViewModel"));
+```
+
+### File loading
+
+The `FileLoader` class provides a unified way to load Rive files from different sources.
+
+**Loading from Assets:**
+
+```dart
+final fileLoader = FileLoader.fromAsset(
+  "assets/vehicles.riv",
+  riveFactory: Factory.rive,
+);
+```
+
+**Loading from URL:**
+
+```dart
+final fileLoader = FileLoader.fromUrl(
+  "https://example.com/animation.riv",
+  riveFactory: Factory.rive,
+);
+```
+
+**Loading from Existing File:**
+
+```dart
+final fileLoader = FileLoader.fromFile(
+  existingFile,
+  riveFactory: Factory.rive,
+);
+```
+
+Or you can load files directly using the `File` class:
+
+```dart
+// Load from asset
+final file = await File.asset("assets/vehicles.riv", riveFactory: Factory.rive);
+// Load from URL
+final file = await File.url("https://example.com/animation.riv", riveFactory:
+Factory.rive);
+// Load from path
+final file = await File.path("/path/to/animation.riv", riveFactory: Factory.rive);
+// Load from bytes
+final file = await File.decode(bytes, riveFactory: Factory.rive);
+```
+
+## Error handling
+
+The Rive Flutter package provides specific exception types for different error scenarios:
+
+- `RiveFileLoaderException`: Thrown when file loading fails
+- `RiveArtboardException`: Thrown when artboard selection fails
+- `RiveStateMachineException`: Thrown when state machine selection fails
+- `RiveDataBindException`: Thrown when data binding fails
+
+## Resource management
+
+### Manual resource management (`RiveWidget`)
+
+When using `RiveWidget` directly, you are responsible for managing all resources:
+
+```dart
+@override
+void dispose() {
+  // Dispose resources in reverse order of creation
+  viewModelInstance.dispose();
+  controller.dispose();
+  file.dispose();
+  super.dispose();
 }
 ```
 
-See subsequent runtime pages to learn how to control animation playback, state machines, and more.
+### Automatic resource management (`RiveWidgetBuilder`)
 
+When using `RiveWidgetBuilder`, the widget automatically manages most resources. You only need to dispose the file loader:
+
+```dart
+@override
+void dispose() {
+  fileLoader.dispose();
+  super.dispose();
+}
+```
 <Note>
- Using Impeller and noticing visual bugs in your app? See [our notes on rendering](/runtimes/choose-a-renderer/overview#note-on-rendering-in-flutter) with Impeller for some triaging tips
+Because the resources are managed by the `RiveWidgetBuilder`, you will not be able to access the `RiveWidgetController` (and other state) after the widget is disposed. If you need to access the controller after the widget is disposed, consider create the file and controller yourself.
+
+The exception to this is the `FileLoader`, which you control. This loader can be reused across multiple `RiveWidgetBuilder` instances. The underlying `File` will only be loaded once. The `File` will be disposed when the `FileLoader` is disposed.
 </Note>
+
+## Specifying a renderer
+
+When creating a Rive `File` or `FileLoader`, you need to specify a factory to use:
+- `Factory.rive` for the Rive renderer
+- `Factory.flutter` for the Flutter renderer (Skia or Impeller)
+
+You can use different renderers for different graphics in your app.
+
+Some considerations when choosing a renderer:
+- If you plan on showing many Rive graphics that are all drawing to different Rive widgets, consider using `Factory.flutter` to reduce the native overhead of allocating native render targets and textures.
+- If you are showing a complex grahic, consider using `Factory.rive` to take advantage of the Rive renderer's optimizations.
+- Vector Feathering is only available with `Factory.rive`, so if you need that feature, use the Rive renderer.
+
+For more information see [Choosing a Renderer](/runtimes/choose-a-renderer/).
+
+## Troubleshooting
+
+If you encounter issues with Rive in Flutter, consider the following:
+- Ensure you have called `RiveNative.init()` before using any Rive features.
+- Check the console for any error messages related to Rive.
+- Make sure your Rive files are correctly referenced in `pubspec.yaml` and exist in the specified paths.
+- If using `RiveWidgetBuilder`, ensure you handle all possible states (loading, loaded, failed) in the builder function.
+
+### Build errors
+
+If you encounter build errors related to Rive, ensure that:
+- You have the correct version of the Rive package in your `pubspec.yaml`.
+- You have run `flutter pub get` to fetch the latest dependencies.
+
+If you're still having issues, please see the [Troubleshooting section](/runtimes/flutter/rive-native#troubleshooting) in the Rive Native documentation.
+
+## Manually building Rive native libraries
+
+Rive automatically downloads the native libraries for you as part of the `rive_native` plugin.
+
+However, if you need to manually build the native libraries, see the [build section](/runtimes/flutter/rive-native#building-rive-native) in the Rive Native documentation.
+
+## Next steps
+
+Now that you have Rive integrated into your Flutter app, you can explore more advanced features like:
+
+<Interaction/>
+
 ## Resources
 
-GitHub: [https://github.com/rive-app/rive-flutter](https://github.com/rive-app/rive-flutter)
+Rive Flutter:
 
-API Docs: [https://pub.dev/documentation/rive/latest/](https://pub.dev/documentation/rive/latest/)
+- [GitHub](https://github.com/rive-app/rive-flutter)
+- [pub.dev](https://pub.dev/packages/rive)
+- [Example app](https://github.com/rive-app/rive-flutter/tree/master/example/)
 
-Examples:
+Rive Native:
 
-- Demo app: [https://github.com/rive-app/rive-flutter/tree/master/example/lib](https://github.com/rive-app/rive-flutter/tree/master/example/lib)
-- Find the Dog (game): [https://github.com/rive-app/find-the-dog](https://github.com/rive-app/find-the-dog)
+- [Rive Native overview](/runtimes/flutter/rive-native)
+- [pub.dev](https://pub.dev/packages/rive_native)

--- a/runtimes/flutter/migration-guide.mdx
+++ b/runtimes/flutter/migration-guide.mdx
@@ -118,8 +118,8 @@ Vector Feathering only works with the Rive Renderer.
 - Replace `RiveFile.import` with `File.decode()` which returns a `Future<File>`
 - Replace `mainArtboard` with `defaultArtboard()`
 - Replace `artboardByName(name)` with `artboard(name)`
-- Replace `RiveFile.network` with `RiveFile.url`
-- Replace `RiveFile.file` with `RiveFile.path`
+- Replace `RiveFile.network` with `File.url`
+- Replace `RiveFile.file` with `File.path`
 
 #### Widget Migration
 

--- a/runtimes/flutter/migration-guide.mdx
+++ b/runtimes/flutter/migration-guide.mdx
@@ -1,0 +1,489 @@
+---
+title: 'Migration Guide'
+description: 'Learn how to migrate your Flutter app when upgrading between major versions of the Rive Flutter runtime, including breaking changes and new features.'
+---
+
+## Version 0.14.0
+
+This is a significant update for Rive Flutter. We've completely removed all of the Dart code that was used for the Rive runtime and replaced it with our underlying [C++ Runtime](https://github.com/rive-app/rive-runtime). See the [Rive Native for Flutter](/runtimes/flutter/rive-native) page for more details.
+
+This has resulted in a numbers of changes to the underlying API, and a large portion of the code base that was previously accessible through Dart is now implemented in C++ through FFI.
+
+### What's New in 0.14.0
+
+This release of Rive Flutter adds support for:
+
+- [Rive Renderer](https://rive.app/renderer)
+- [Data Binding](/editor/data-binding/)
+- [Layouts](/editor/layouts/layouts-overview)
+- [Scrolling](/editor/layouts/scrolling)
+- [N-Slicing](/editor/layouts/n-slicing)
+- [Vector Feathering](https://rive.app/blog/introducing-vector-feathering)
+- All other features added to Rive that did not make it to the previous versions of Rive Flutter
+- Includes the latest fixes and improvements for the Rive C++ runtime
+- Adds prebuilt libraries, with the ability to build manually. See the [rive_native](https://pub.dev/packages/rive_native) package for more information
+- Removes the `rive_common` package and replaces it with `rive_native`
+
+Now that Rive Flutter makes use of the core Rive C++ runtime, you can expect new Rive features to be supported sooner for Rive Flutter.
+
+<Note>
+All your Rive graphics will still look and function the same as they did before.
+</Note>
+
+
+### Requirements
+
+#### Dart and Flutter Versions
+
+This release bumps to these versions:
+
+```yaml
+sdk: ">=3.5.0 <4.0.0"
+flutter: ">=3.3.0"
+```
+
+#### Required Setup
+
+**Important:** You must call `RiveNative.init` at the start of your app, or before you use Rive. For example, in `main.dart`:
+
+```dart
+import 'package:rive/rive.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await RiveNative.init(); // Call init before using Rive
+  runApp(const MyApp());
+}
+```
+
+### Migration Guide
+
+#### Quick Migration Checklist
+
+1. ✅ Update your `pubspec.yaml` dependencies to use version `0.14.0` or later
+   ```yaml
+   dependencies:
+     rive: ^0.14.0 # or latest version
+   ```
+2. ✅ Add `RiveNative.init()` to your `main()` function, or call before using Rive.
+3. ✅ Replace `Rive` and `RiveAnimation` widgets with `RiveWidget` or `RiveWidgetBuilder`
+4. ✅ Update your controllers to use the new API, see `RiveWidgetController`, `StateMachine`, and `Artboard`
+5. ✅ Review and update any custom asset loading code
+6. ✅ Test your graphics and interactions
+
+#### Removed Classes
+
+The following classes have been completely removed:
+
+- `Rive` and `RiveAnimation` widgets → Use `RiveWidget` and `RiveWidgetBuilder`
+- `RiveAnimationController` and its subclasses → Use `RiveWidgetController`, `SingleAnimationPainter`, and `StateMachinePainter`
+- `OneShotAnimation` and `SimpleAnimation` → Use `SingleAnimationPainter` to play individual animations
+- `StateMachineController` → Use `StateMachine` instead (can be accessed via `RiveWidgetController.stateMachine`)
+- `RiveEvent` → Replaced with `Event`
+- `SMITrigger` → Replaced with `TriggerInput`
+- `SMIBool` → Replaced with `BooleanInput`
+- `SMINumber` → Replaced with `NumberInput`
+- `FileAssetLoader` → Replaced with optional callback when creating a `File`
+
+#### Loading Rive Files
+
+`RiveFile` has been removed and replaced with `File`. Important changes:
+
+<Tabs>
+    <Tab title="New API">
+    ```dart New API
+    final file = await File.decode(bytes, factory: Factory.rive);
+    final artboard = file.defaultArtboard();
+    final artboard = file.artboard('MyArtboard');
+    ```
+    </Tab>
+    <Tab title="Old API">
+    ```dart Old API
+    final file = await RiveFile.import(bytes);
+    final artboard = file.mainArtboard;
+    final artboard = file.artboardByName('MyArtboard');
+    ```
+    </Tab>
+</Tabs>
+
+The provided `Factory` determines the renderer that will be used. Use `Factory.rive` for the Rive renderer or `Factory.flutter` for the shipped Flutter renderer (Skia or Impeller).
+
+<Warning>
+Vector Feathering only works with the Rive Renderer.
+</Warning>
+
+**Key Changes:**
+
+- Creating a Rive File now requires a factory (`Factory.rive` or `Factory.flutter`)
+- Replace `RiveFile.import` with `File.decode()` which returns a `Future<File>`
+- Replace `mainArtboard` with `defaultArtboard()`
+- Replace `artboardByName(name)` with `artboard(name)`
+- Replace `RiveFile.network` with `RiveFile.url`
+- Replace `RiveFile.file` with `RiveFile.path`
+
+#### Widget Migration
+
+See the updated example app for a complete migration guide, including how to use the new `RiveWidget` and `RiveWidgetBuilder` APIs.
+
+| Old Widget                 | New Widget   | Notes              |
+| -------------------------- | ------------ | ------------------ |
+| `Rive`/`RiveAnimation` | `RiveWidget`/`RiveWidgetBuilder` | Direct replacement |
+
+<Tabs>
+    <Tab title="New API - Option 1">
+    ```dart Using RiveWidgetBuilder
+    class SimpleAssetAnimation extends StatefulWidget {
+        const SimpleAssetAnimation({Key? key}) : super(key: key);
+
+        @override
+        State<SimpleAssetAnimation> createState() => _SimpleAssetAnimationState();
+    }
+
+    class _SimpleAssetAnimationState extends State<SimpleAssetAnimation> {
+        late final fileLoader = FileLoader.fromAsset(
+            'assets/off_road_car.riv',
+            riveFactory: Factory.rive,
+        );
+
+        @override
+        void dispose() {
+            fileLoader.dispose();
+            super.dispose();
+        }
+
+        @override
+        Widget build(BuildContext context) {
+            return Scaffold(
+                appBar: AppBar(
+                    title: const Text('Simple Animation'),
+                ),
+                body: Center(
+                    child: RiveWidgetBuilder(
+                        fileLoader: fileLoader,
+                        builder: (context, state) => switch (state) {
+                            RiveLoading() => const CircularProgressIndicator(),
+                            RiveFailed() => Text('Failed to load: ${state.error}'),
+                            RiveLoaded() => RiveWidget(
+                                controller: state.controller,
+                                fit: Fit.cover,
+                            ),
+                        },
+                    ),
+                ),
+            );
+        }
+    }
+    ```
+    </Tab>
+    <Tab title="New API - Option 2">
+    ```dart Using RiveWidget directly
+    class SimpleAssetAnimation extends StatefulWidget {
+        const SimpleAssetAnimation({Key? key}) : super(key: key);
+
+        @override
+        State<SimpleAssetAnimation> createState() => _SimpleAssetAnimationState();
+    }
+
+    class _SimpleAssetAnimationState extends State<SimpleAssetAnimation> {
+        File? file;
+        RiveWidgetController? controller;
+        bool isInitialized = false;
+
+        @override
+        void initState() {
+            super.initState();
+            initRive();
+        }
+
+        void initRive() async {
+            file = (await File.asset('assets/off_road_car.riv', riveFactory: Factory.rive))!;
+            controller = RiveWidgetController(file!);
+            setState(() => isInitialized = true);
+        }
+
+        @override
+        void dispose() {
+            controller?.dispose();
+            file?.dispose();
+            super.dispose();
+        }
+
+        @override
+        Widget build(BuildContext context) {
+            return Scaffold(
+                appBar: AppBar(
+                    title: const Text('Simple Animation'),
+                ),
+                body: Center(
+                    child: isInitialized && controller != null
+                        ? RiveWidget(
+                            controller: controller!,
+                            fit: Fit.cover,
+                        )
+                        : const CircularProgressIndicator(),
+                ),
+            );
+        }
+    }
+    ```
+    </Tab>    
+    <Tab title="Old API">
+    ```dart Old API
+    class SimpleAssetAnimation extends StatelessWidget {
+        const SimpleAssetAnimation({Key? key}) : super(key: key);
+
+        @override
+        Widget build(BuildContext context) {
+            return Scaffold(
+                appBar: AppBar(
+                    title: const Text('Simple Animation'),
+                ),
+                body: const Center(
+                    child: RiveAnimation.asset(
+                        'assets/off_road_car.riv',
+                        fit: BoxFit.cover,
+                    ),
+                ),
+            );
+        }
+    }
+    ```
+    </Tab>
+</Tabs>
+
+#### Controller Migration
+
+| Old Controller                           | New Controller           | Notes                       |
+| ---------------------------------------- | ------------------------ | --------------------------- |
+| `RiveAnimationController`                | `RiveWidgetController`   | Main controller for widgets |
+| `StateMachineController`                 | `StateMachine`           | Direct state machine access |
+| `OneShotAnimation` and `SimpleAnimation` | `SingleAnimationPainter` | For individual animations   |
+
+Example using the new `RiveWidgetController`:
+
+```dart Using RiveWidgetController
+final file = await File.asset('assets/off_road_car.riv', riveFactory: Factory.rive);
+final controller = RiveWidgetController(file!);
+final artboard = controller.artboard; // access the loaded artboard
+final viewModelInstance = controller.dataBind(DataBind.auto()); // auto data binding
+```
+
+Optionally specify which Artboard and State Machine to use:
+
+```dart Specifying Artboard and State Machine
+final file = await File.asset('assets/off_road_car.riv', riveFactory: Factory.rive);
+final controller = RiveWidgetController(
+  file,
+  artboardSelector: ArtboardSelector.byName('Main'),
+  stateMachineSelector: StateMachineSelector.byName('State Machine 1'),
+);
+```
+
+
+#### Handling State Machine Inputs
+
+<Tip>
+Consider using [Data Binding](editor/data-binding/overview) for more advanced use cases
+</Tip>
+
+`StateMachineController` has been removed and replaced with `StateMachine`. Important changes:
+
+<Tabs>
+    <Tab title="New API">
+    ```dart State Machine Inputs: New API
+    stateMachine.trigger('myTrigger');
+    stateMachine.boolean('myBool');
+    stateMachine.number('myNumber');
+    ```
+    </Tab>
+    <Tab title="Old API">
+    ```dart State Machine Inputs: Old API
+    controller.getTriggerInput('myTrigger');
+    controller.getBooleanInput('myBool');
+    controller.getNumberInput('myNumber');
+    ```
+    </Tab>
+</Tabs>
+
+You can access the `stateMachine` from the `RiveWidgetController`:
+
+```dart
+final controller = RiveWidgetController(file);
+final stateMachine = controller.stateMachine;
+```
+
+<Info>
+It is recommended to manually dispose inputs when no longer needed: `input.dispose()`
+</Info>
+
+##### Nested Inputs
+
+You can access nested inputs by providing an optional `path` parameter:
+
+```dart Nested Inputs
+stateMachine.boolean('myBool', path: 'nested/path');
+stateMachine.number('myNumber', path: 'nested/path');
+stateMachine.trigger('myTrigger', path: 'nested/path');
+```
+
+#### Handling Rive Events
+
+<Tip>
+Consider using [Data Binding](/editor/data-binding/overview) instead of events for more advanced use cases.
+</Tip>
+
+`RiveEvent` has been removed and replaced with `Event`. `Event` is a sealed class with two options:
+
+- `OpenUrlEvent`
+- `GeneralEvent`
+
+Registering an event listener:
+
+<Tabs>
+    <Tab title="New API">
+    ```dart Rive Events: New API
+    // New API
+    final controller = RiveWidgetController(_riveFile!);
+    controller?.stateMachine.addEventListener(_onRiveEvent);
+
+    void _onRiveEvent(Event event) {
+        // Do something with the event
+    }
+    ```
+    </Tab>
+    <Tab title="Old API">
+    ```dart Rive Events: Old API
+    // Old API
+    final controller =
+        StateMachineController.fromArtboard(artboard, 'State Machine 1')!;
+    controller.addEventListener(_onRiveEvent);
+
+    void _onRiveEvent(RiveEvent event) {
+        // Do something with the event
+    }
+    ```
+    </Tab>
+</Tabs>
+
+Accessing `properties` returns `Map<String, CustomProperty>`. `CustomProperty` is also a sealed class with options:
+
+- `CustomNumberProperty`
+- `CustomBooleanProperty`
+- `CustomStringProperty`
+
+All of these have a `value` field. On the `Event` class, there are convenient accessors:
+
+```dart
+// Convenient accessors
+event.property(name);           // Returns a CustomProperty
+event.numberProperty(name);     // Returns a CustomNumberProperty
+event.booleanProperty(name);    // Returns a CustomBooleanProperty
+event.stringProperty(name);     // Returns a CustomStringProperty
+```
+
+#### Layout Changes
+
+##### BoxFit → Fit
+
+Previously we used Flutter's `BoxFit` class. Now we use our own `Fit` which includes an extra option:
+
+```dart
+// Old API
+BoxFit.contain
+
+// New API
+Fit.contain
+Fit.layout  // New option for layout-based fitting
+```
+
+#### Asset Loading Changes
+
+The `FileAssetLoader` class and all its subclasses have been removed:
+
+- `CDNAssetLoader`
+- `LocalAssetLoader`
+- `CallbackAssetLoader`
+- `FallbackAssetLoader`
+
+##### Out-of-band Asset Loading
+
+<Tabs>
+    <Tab title="New API">
+    ```dart Out-of-band Asset Loading: New API
+    // New API
+    assetLoader: (asset, bytes) { /* sync work only but can call async functions */ }
+    riveFactory.decodeImage(bytes) // or asset.decode(bytes)
+    asset.renderImage(someImage) // returns bool for success
+    ```
+    </Tab>
+    <Tab title="Old API">
+    ```dart Out-of-band Asset Loading: Old API
+    // Old API
+    assetLoader: (asset, bytes) async { /* async work */ }
+    ImageAsset.parseBytes(bytes)
+    asset.image = someImage;
+    ```
+    </Tab>
+</Tabs>
+
+**Key Changes:**
+
+- `assetLoader` can no longer be an asynchronous lambda
+- `ImageAsset.parseBytes(bytes)` → `riveFactory.decodeImage(bytes)` or `asset.decode(bytes)`
+- `FontAsset.parseBytes(bytes)` → `riveFactory.decodeFont(bytes)` or `asset.decode(bytes)`
+- `AudioAsset.parseBytes(bytes)` → `riveFactory.decodeAudio(bytes)` or `asset.decode(bytes)`
+- `ImageAsset.image = value` → `ImageAsset.renderImage(value)` (returns boolean)
+- `FontAsset.font = value` → `FontAsset.font(value)` (returns boolean)
+- `AudioAsset.audio = value` → `AudioAsset.audio(value)` (returns boolean)
+
+#### Text Run Updates
+
+<Tip>
+We recommend using [Data Binding](/editor/data-binding/overview) instead to update text at runtime.
+</Tip>
+
+It's no longer possible to access a `TextValueRun` object directly. Use these methods instead to access the String value:
+
+```dart Get/Set Text Run Value
+final controller = RiveWidgetController(riveFile);
+final artboard = controller.artboard;
+
+// Get a text run value
+artboard.getText(value)
+artboard.getText(value, path: path)
+
+// Set a text run value
+artboard.setText(value)
+artboard.setText(value, path: path)
+```
+
+### Known Missing Features
+
+These features are not available in `v0.14.0` but may be added in future releases:
+
+- Automatic Rive CDN asset loading
+- `speedMultiplier`
+- `useArtboardSize`
+- `clipRect`
+- `isTouchScrollEnabled`
+- `dynamicLibraryHelper`
+
+### Removed Code Paths
+
+All of the "runtime" Dart code has been removed from these paths:
+
+- `src/controllers`
+- `src/core`
+- `src/generated`
+- `rive_core`
+- `utilities`
+
+### Getting Help
+
+If you encounter issues during migration:
+
+1. Check the [Rive Flutter documentation](https://rive.app/docs/flutter)
+2. Review the [Data Binding guide](/editor/data-binding/overview)
+3. Visit the [Rive community forums](https://community.rive.app)
+4. Report issues on the [GitHub repository](https://github.com/rive-app/rive-flutter)
+

--- a/runtimes/flutter/migration-guide.mdx
+++ b/runtimes/flutter/migration-guide.mdx
@@ -66,8 +66,8 @@ Future<void> main() async {
      rive: ^0.14.0 # or latest version
    ```
 2. ✅ Add `RiveNative.init()` to your `main()` function, or call before using Rive.
-3. ✅ Replace `Rive` and `RiveAnimation` widgets with `RiveWidget` or `RiveWidgetBuilder`
-4. ✅ Update your controllers to use the new API, see `RiveWidgetController`, `StateMachine`, and `Artboard`
+3. ✅ Replace `Rive` and `RiveAnimation` widgets with [`RiveWidget`](/runtimes/flutter/flutter#rivewidget) or [`RiveWidgetBuilder`](/runtimes/flutter/flutter#rivewidgetbuilder)
+4. ✅ Update your controllers to use the new API, see [`RiveWidgetController`](/runtimes/flutter/flutter#rivewidgetcontroller)
 5. ✅ Review and update any custom asset loading code
 6. ✅ Test your graphics and interactions
 

--- a/runtimes/flutter/rive-native.mdx
+++ b/runtimes/flutter/rive-native.mdx
@@ -1,32 +1,37 @@
 ---
 title: 'Rive Native for Flutter'
-description: 'A Flutter runtime that integrates the Rive Renderer and the core Rive C++ runtime.'
+description: 'A Flutter plugin that integrates the Rive Renderer and the core Rive C++ runtime. Used by the Rive Flutter runtime.'
 ---
 
 import NoteOnFeatureSupport from "/snippets/runtimes/rendering-feature-support.mdx"
 
-<NoteOnFeatureSupport/>
-
-[Rive Native](https://pub.dev/packages/rive_native) is a new runtime that enables you to display and interact with Rive graphics in your Flutter app, powered by the [Rive Renderer](https://rive.app/renderer).
-
 ## Rive Native vs Rive
 
-`rive_native` does not replace the current [Rive Flutter runtime](https://pub.dev/packages/rive) (`rive`). Instead, we are working on integrating `rive_native` into the `rive` package. You can use `rive_native` independently if desired, and the API will remain largely consistent between `rive_native` and `rive`. However, the `rive` package may expose additional APIs or functionality in the future.
+[Rive Native](https://pub.dev/packages/rive_native) (`rive_native`) is a Flutter plugin that integrates the Rive Renderer and the core Rive C++ runtime.
 
-We encourage you to start using `rive_native` today and share your feedback with us.
+The [Rive Flutter runtime](https://pub.dev/packages/rive) (`rive`) is built on top of `rive_native`. We recommend including the `rive` package as a dependecy, as that will automatically include `rive_native`, while also providing a user-friendly API for working with Rive assets in Flutter.
 
-### Key Differences Between `rive_native` and `rive`
 
+<Note>
+Rive Native replaces the [Rive Common](https://pub.dev/packages/rive_common) (`rive_common`) plugin that Rive Flutter previously used for native operations.
+</Note>
+
+### Understanding Rive Native
+
+Rive Native acts as the bridge between Flutter and the Rive C++ runtime, allowing you to use Rive graphics in your Flutter applications.
 
 - **C++ Runtime Integration**:  
-  `rive_native` is built on Rive's [C++ runtime](https://github.com/rive-app/rive-runtime) via FFI, replacing the Dart implementation. This ensures a consistent experience across platforms and the Rive Editor, while unlocking performance improvements and new features exclusive to the C++ runtime, such as:  
-  - [Responsive Layouts](/editor/layouts/)  
-  - [Scrolling](/editor/layouts/scrolling)  
-  - [N-Slicing](/editor/layouts/n-slicing)  
+  `rive_native` is built on Rive's [C++ runtime](https://github.com/rive-app/rive-runtime) via FFI. This ensures a consistent experience across platforms and the Rive Editor, while unlocking performance improvements and new features exclusive to the C++ runtime, such as:  
+  - [Data Binding](/editor/data-binding/)
+  - [Responsive Layouts](/editor/layouts/)
+  - [Scrolling](/editor/layouts/scrolling)
+  - [N-Slicing](/editor/layouts/n-slicing)
   - [Vector Feathering](https://rive.app/blog/introducing-vector-feathering)
 
 - **Rive Renderer Support**:  
-  `rive_native` introduces the [Rive Renderer](https://rive.app/renderer) to Flutter. While you can still use the Flutter-based renderer (Dart/Impeller), the Rive Renderer is recommended for performance-critical use cases. Some features, like Vector Feathering, are only supported with the Rive Renderer. For more details, see our [Feature Support page](/feature-support).
+  `rive_native` bring the [Rive Renderer](https://rive.app/renderer) to Flutter. While you can still use the Flutter-based renderer (Dart/Impeller), the Rive Renderer is recommended for performance-critical use cases. For more information see [Choosing a Renderer](/runtimes/choose-a-renderer/overview).
+  
+  Some features, like Vector Feathering, are only supported with the Rive Renderer. See the [Feature Support page](/feature-support) for more details.
 
 ---
 
@@ -41,8 +46,6 @@ flutter create .            # Create the platform folders
 flutter pub get             # Fetch dependencies
 flutter run                 # Run the example app
 ```
-
-A higher-level declarative API is under development to simplify working with Rive graphics in Flutter.
 
 For an example implementation, see the `rive_player.dart` file in `rive_native/example/rive_player.dart`.
 
@@ -59,24 +62,11 @@ For an example implementation, see the `rive_player.dart` file in `rive_native/e
 | Linux    | ❌               | ❌             |
 | Web      | ✅               | ✅             |
 
-> **Note**: Android support is currently limited to `arm` and `arm64` architectures.
-
 ---
 
 ## Feature Support
 
-The following runtime features are supported by `rive_native`:
-
-| Feature                          | Support |
-|----------------------------------|---------|
-| Set State Machine Inputs         | ✅       |
-| Set State Machine Nested Inputs  | ✅       |
-| Updating Text Runs               | ✅       |
-| Updating Nested Text Runs        | ✅       |
-| Responsive Layouts               | ✅       |
-| Rive Audio                       | ✅       |
-| Out-of-Band Assets               | ✅       |
-| Rive Events                      | ✅       |
+See the [Feature Support page](/feature-support) for details.
 
 ---
 

--- a/runtimes/inputs.mdx
+++ b/runtimes/inputs.mdx
@@ -167,108 +167,40 @@ inputs.forEach(i => {
   </Tab>
 
   <Tab title="Flutter">
-    ### Inputs
 
-    State machine controllers are used to retrieve a state machine's inputs which can then be used to interact with, and drive the state of a state machine.
+  Inputs are retrieved from a `StateMachine` instance.
 
-    State machine controllers require a reference to an artboard when being instantiated. The `RiveAnimation` widget provides a callback `onInit(Artboard artboard)` that is called when the Rive file has loaded and is initialized for playback:
+  Access the state machine directly from the `RiveWidgetController`:
 
-    ```dart
-    void _onRiveInit(Artboard artboard) {}
+  ```dart
+  final riveController = RiveWidgetController(riveFile);
+  final stateMachine = riveController.stateMachine;
 
-    RiveAnimation.network(
-        'https://cdn.rive.app/animations/vehicles.riv',
-        fit: BoxFit.cover,
-        onInit: _onRiveInit,
-    );
-    ```
+  final myTrigger = stateMachine.trigger('myTrigger');
+  final myBool = stateMachine.boolean('myBool');
+  final myNumber = stateMachine.number('myNumber');
+  ```
 
-    In the `onInit` callback, you can create an instance of a `StateMachineController` and then retrieve the inputs you're interested in by their name. Specific inputs can be retrieved using `findInput()` or all inputs with the `inputs` property.
+  Interact with the inputs:
+  
+  ```dart
+  myTrigger.fire(); // Trigger input
+  myBool.value = true; // Set boolean input
+  myNumber.value = 42.0; // Set number input
+  ```
 
-    ```dart
-    SMITrigger? _bump;
+  When you're done with the inputs, dispose them:
+  ```dart
+  myTrigger.dispose();
+  myBool.dispose();
+  myNumber.dispose();
+  ```
 
-    void _onRiveInit(Artboard artboard) {
-        // Get State Machine Controller for the state machine called "bumpy"
-        final controller = StateMachineController.fromArtboard(artboard, 'bumpy');
-        artboard.addController(controller!);
-        // Get a reference to the "bump" state machine input
-        _bump = controller.getTriggerInput('bump');
-    }
-    ```
+  The State Machine is owned by the controller. When you dispose the controller, the state machine will also be disposed.
 
-    In the above snippet, the `bump` input is retrieved, which is an `SMITrigger`. This type of input has a `fire()` method to activate the trigger.
-
-    ```dart
-    class SimpleStateMachine extends StatefulWidget {
-        const SimpleStateMachine({Key? key}) : super(key: key);
-
-        @override
-        _SimpleStateMachineState createState() => _SimpleStateMachineState();
-    }
-
-    class _SimpleStateMachineState extends State<SimpleStateMachine> {
-        SMITrigger? _bump;
-
-        void _onRiveInit(Artboard artboard) {
-            final controller = StateMachineController.fromArtboard(artboard, 'bumpy');
-            artboard.addController(controller!);
-            _bump = controller.getTriggerInput('bump')!;
-        }
-
-        void _hitBump() => _bump?.fire();
-
-        @override
-        Widget build(BuildContext context) {
-            return Scaffold(
-                appBar: AppBar(
-                    title: const Text('Simple Animation'),
-                ),
-                body: Center(
-                    child: GestureDetector(
-                        child: RiveAnimation.network(
-                            'https://cdn.rive.app/animations/vehicles.riv',
-                            fit: BoxFit.cover,
-                            onInit: _onRiveInit,
-                        ),
-                        onTap: _hitBump,
-                    ),
-                ),
-            );
-        }
-    }
-    ```
-In the complete example above, every time the `RiveAnimation` is tapped, it fires the `bump` input trigger and the state machine reacts appropriately.
-
-**Note**: There are two other state machine input types to be aware of as well: `SMIBool` and `SMINumber`. These both have a `value` property that can get and set the value.
-
-```javascript
-// Example state machine input declarations
-SMIBool _boolExampleInput;
-SMINumber _numberExampleInput;
-
-...
-
-// Extracting inputs from the StateMachineController
-void _onRiveInit(Artboard artboard) {
-  final controller = StateMachineController.fromArtboard(artboard, 'example');
-  artboard.addController(controller!);
-  _boolExampleInput = controller.getBoolInput('exampleBool')!;
-  _numberExampleInput = controller.getNumberInput('exampleNum')!;
-}
-
-...
-
-// Getting/setting state machine input values
-if (_boolExampleInput.value == false) {
-  _boolExampleInput.value = true;
-}
-if (_numberExampleInput.value >= 100) {
-  _numberExampleInput.value = 0;
-}
-```
-
-
+  ```dart
+  controller.dispose(); 
+  ```
   </Tab>
 
   <Tab title="Apple">
@@ -409,26 +341,17 @@ If you load in the **Menu** artboard at runtime, and want to get/set an input on
     To set the **Volume** input for the above example:
 
     ```dart
-    // Load the Rive file
-    final file = await RiveFile.asset('assets/your_rive_file.riv');
-    // Create a Rive Artboard instance
-    final artboard = file.artboardByName('ArtboardName')!.instance();
-    // Create a state machine controller
-    final controller = StateMachineController.fromArtboard(artboard, 'StateMachineName');
-    // Add the controller to the artboard
-    artboard.addController(controller!);
-
-    ...
-
-    // Get the nested input named 'volume' from the artboard
-    final volumeInput = artboard.getNumberInput('volume', 'Volume Molecule/Volume Component')!;
+    // Get the nested input named 'volume' from the state machine
+    final controller = RiveWidgetController(riveFile);
+    final stateMachine = controller.stateMachine;
+    final volumeInput = stateMachine.number('volume', path: 'Volume Molecule/Volume Component')!;
     volumeInput.value = 80.0;
     ```
 
     **All options:**
-    - `getBoolInput(name, path)`
-    - `getTriggerInput(name, path)`
-    - `getNumberInput(name, path)`
+    - `number(name, path: 'path/to/input')`
+    - `bool(name, path: 'path/to/input')`
+    - `trigger(name, path: 'path/to/input')`
   </Tab>
 
   <Tab title="Apple">

--- a/runtimes/layout.mdx
+++ b/runtimes/layout.mdx
@@ -117,7 +117,25 @@ For more Editor information and how to configure your graphic see [Layouts Overv
   </Tab>
 
   <Tab title="Flutter">
-    Coming soon! This feature depends on an upcoming new Rive Flutter runtime—stay tuned for updates.
+    Pass the `Fit.layout` to the `RiveWidget` widget. This will automatically scale and resize the artboard to match the widget size.
+    You can also set the `layoutScaleFactor` to control the scale of the artboard. This is useful for adjusting the size of the artboard when using `Fit.layout`.
+
+    ```dart
+    return RiveWidget(
+      controller: controller,
+      fit: Fit.layout,
+      layoutScaleFactor: 2.0, // Optional: 2x scale of the layout,
+    );
+    ```
+    
+
+    Alternatively, you can also set the `fit` and `layoutScaleFactor` properties directly on any `RivePainter`, such as the `RiveWidgetController`:
+
+    ```dart
+    final controller = RiveWidgetController(riveFile);
+    controller.fit = Fit.layout;
+    controller.layoutScaleFactor = 2.0; // Optional: 2x scale of the layout
+    ```
   </Tab>
 
   <Tab title="Apple">
@@ -291,26 +309,23 @@ If the graphic doesn’t use Rive’s Layout feature, you can configure the layo
   </Tab>
 
     <Tab title="Flutter">
-    <Warning>
-     The current Rive Flutter runtime does not support `Fit.Layout`. The next major release will support this which will be a breaking change.
-    </Warning>
-    The fit and alignment options behave like their counterparts in Flutter (see `BoxFit` and `Size` as examples).
-
-    Bounds options are absent; Flutter's layout engine and options are the preferred way to handle positioning Rive content.
+    Pass the `Fit` and `Alignment` to the `RiveWidget` widget.
 
     ```dart
-    // Fill the canvas, cropping Rive if necessary
-    var widget = const RiveAnimation.network(
-      'https://cdn.rive.app/animations/vehicles.riv',
-      fit: BoxFit.cover,
+    return RiveWidget(
+      controller: controller,
+      fit: Fit.contain,
+      alignment: Alignment.center,
     );
+    ```
+    
 
-    // Fit to the width and align to the top of the canvas
-    widget = const RiveAnimation.network(
-      'https://cdn.rive.app/animations/vehicles.riv',
-      fit: BoxFit.fitWidth,
-      alignment: Alignment.topCenter,
-    );
+    Alternatively, you can also the set `fit` and `alignment` properties directly on any `RivePainter`, such as the `RiveWidgetController`:
+
+    ```dart
+    final controller = RiveWidgetController(riveFile);
+    controller.fit = Fit.contain;
+    controller.alignment = Alignment.center;
     ```
   </Tab>
 

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -218,155 +218,63 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
         ### Using the Asset Handler API
 
-        When instantiating a `RiveFile`, add an `assetLoader` callback property to the list of parameters. This callback will be called for every asset the runtime detects from the `.riv` file on load, and will be responsible for either handling the load of an asset at runtime or passing on the responsibility and giving the runtime a chance to load it otherwise.
+        When instantiating a `File`, add an `assetLoader` callback to the list of parameters. This callback will be called for every asset the runtime detects from the `.riv` file on load, and will be responsible for either handling the load of an asset at runtime or passing on the responsibility and giving the runtime a chance to load it otherwise.
 
-        An instance where you may want to handle loading an asset is if an asset in the file is marked as **Referenced**, and you need to provide an actual asset to render for the graphic, as Rive does not embed it in the `.riv` and thus cannot load it.
+        ```dart Font Asset Example
+        final fontFile = await File.asset(
+            'assets/acqua_text_out_of_band.riv',
+            riveFactory: Factory.rive,
+            assetLoader: (asset, bytes) {
+                // Replace font assets that are not embedded in the rive file
+                if (asset is FontAsset && bytes == null) {
+                    final urls = [
+                        'https://cdn.rive.app/runtime/flutter/IndieFlower-Regular.ttf',
+                        'https://cdn.rive.app/runtime/flutter/comic-neue.ttf',
+                        'https://cdn.rive.app/runtime/flutter/inter.ttf',
+                        'https://cdn.rive.app/runtime/flutter/inter-tight.ttf',
+                        'https://cdn.rive.app/runtime/flutter/josefin-sans.ttf',
+                        'https://cdn.rive.app/runtime/flutter/send-flowers.ttf',
+                    ];
 
-        An instance where you may want to give the runtime a chance to load the asset is if the asset in the file is marked as **Hosted**, and want to pass the responsibility of loading it to the runtime (which will call into a Rive CDN to do so).
-
-        ```dart
-        final riveAsset = await RiveFile.asset(
-            'assets/acqua_text.riv',
-            assetLoader: CallbackAssetLoader(
-                (asset, bytes) async {
-                if (asset is FontAsset) {
-                    asset.font = _fontCache[Random().nextInt(_fontCache.length)];
-                    _fontAssets.add(asset);
-                    return true;
+                    // pick a random url from the list of fonts
+                    http.get(Uri.parse(urls[Random().nextInt(urls.length)])).then((res) {
+                        if (mounted) {
+                            asset.decode(
+                                Uint8List.view(res.bodyBytes.buffer),
+                            );
+                            setState(() {
+                                // force rebuild in case the Rive graphic is no longer advancing
+                            });
+                        }
+                    });
+                    return true; // Tell the runtime not to load the asset automatically
+                } else {
+                    // Tell the runtime to proceed with loading the asset if it exists
+                    return false;
                 }
-                return false;
-                },
-            ),
-            );
+            },
+        );
         ```
 
         Your provided callback will be passed an `asset` and `bytes`.
 
         - `asset` - Reference to a `FileAsset` object. You can grab a number of properties from this object, such as the name, asset type, and more. You'll also use this to set a new Rive specific asset for dynamically loaded content. Types: `FontAsset`, `ImageAsset`, and `AudioAsset`.
-        - `bytes` - Array of bytes for the asset (if possible, such as if it's an embedded asset)
-
-        **Important**: Note that the return value is a `boolean`, which is where you need to return `true` if you intend on handling and loading in an asset yourself, or `false` if you do not want to handle asset loading for that given asset yourself, and attempt to have the runtime try to load the asset.
+        - `bytes` - Array of bytes for the asset (if it's available as an embedded asset)
 
         **Example Usage**
+        - See the Rive Flutter example app that shows how to pre-cache fonts and images, and dynamically swap them out at runtime.
 
-        Load and cache a collection of fonts. Here we demonstrate loading from Rive's CDN, but you can load these font files any way you desire.
+        <Info>
+        **Important**: Note that the return value is a `boolean`, which is where you need to return:
+        -  `true` if you intend on handling and loading in an asset yourself
+        - or `false` if you do not want to handle asset loading for that given asset yourself, and attempt to have the runtime try to load the asset
+        </Info>
 
-        ```dart
-        // Load a random font asset by using a decodeFont API to feed to a
-        // setFont API on the asset provided in assetLoader
-        /// Create a local cache of random fonts
-        Future<void> _warmUpCache() async {
-            final futures = <Future>[];
+        <Warning>
+        Once the `File` is disposed, the `FileAsset` will no longer be valid and would be dangerous to use.
+        </Warning>
 
-            loadFont(url) async {
-            final res = await http.get(Uri.parse(url));
-            final body = Uint8List.view(res.bodyBytes.buffer);
-            final font = await FontAsset.parseBytes(body);
-
-            if (font != null) {
-                _fontCache.add(font);
-            }
-            }
-
-            for (var url in [
-            'https://cdn.rive.app/runtime/flutter/IndieFlower-Regular.ttf',
-            'https://cdn.rive.app/runtime/flutter/comic-neue.ttf',
-            'https://cdn.rive.app/runtime/flutter/inter.ttf',
-            'https://cdn.rive.app/runtime/flutter/inter-tight.ttf',
-            'https://cdn.rive.app/runtime/flutter/josefin-sans.ttf',
-            'https://cdn.rive.app/runtime/flutter/send-flowers.ttf',
-            ]) {
-            futures.add(loadFont(url));
-            }
-
-            await Future.wait(futures);
-        }
-        ```
-
-        Swap out the font dynamically:
-
-        ```dart
-        class RiveRandomCachedFont extends StatefulWidget {
-        const RiveRandomCachedFont({
-            Key? key,
-            required this.fontCache,
-        }) : super(key: key);
-
-        final List fontCache;
-
-        @override
-        State<_RiveRandomCachedFont> createState() => RiveRandomCachedFontState();
-        }
-
-        class RiveRandomCachedFontState extends State<RiveRandomCachedFont> {
-        List get _fontCache => widget.fontCache;
-
-        @override
-        void initState() {
-            super.initState();
-            _loadRiveFile();
-        }
-
-        RiveFile? _riveFontSampleFile;
-        final List<FontAsset?> _fontAssets = [];
-
-        Future<void> _loadRiveFile() async {
-
-            final riveAsset = await RiveFile.asset(
-            'assets/acua_text.riv',
-            // Provide an asset loader and manage the font assets manually.
-            assetLoader: CallbackAssetLoader(
-                (asset, bytes) async {
-                if (asset is FontAsset) {
-                    asset.font = _fontCache[Random().nextInt(_fontCache.length)];
-                    _fontAssets.add(asset);
-                    return true;
-                }
-                return false;
-                },
-            ),
-            );
-
-            setState(() {
-            // Keep a reference to the font asset, to swap out the font at any point.
-            _riveFontSampleFile = riveAsset;
-            });
-        }
-
-        @override
-        Widget build(BuildContext context) {
-            if (_riveFontSampleFile == null) {
-            return const Center(child: CircularProgressIndicator());
-            }
-
-            return Column(
-            children: [
-                Expanded(
-                child: RiveAnimation.direct(
-                    _riveFontSampleFile!, // Pass in the Rive file
-                    stateMachines: const ['State Machine 1'],
-                    fit: BoxFit.cover,
-                ),
-                ),
-                Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: ElevatedButton(
-                    onPressed: () {
-                    for (var element in _fontAssets) {
-                        element?.font = _fontCache[Random().nextInt(_fontCache.length)];
-                    }
-                    },
-                    child: const Text('Random font asset'),
-                ),
-                ),
-            ],
-            );
-        }
-        }
-        ```
     </Tab>
-
-
     <Tab title="Apple">
 
         ### Examples

--- a/runtimes/rive-events.mdx
+++ b/runtimes/rive-events.mdx
@@ -235,201 +235,51 @@ Let's use a 5-star rater Rive example to set any text supplied with events and o
     </Tab>
 
     <Tab title="Flutter">
+    `Event` is a sealed class with two options:
 
-        ### Adding an Event Listener
+    - `OpenUrlEvent`
+    - `GeneralEvent`
 
-        After creating a `StateMachineController` instance, you'll use the `addEventListener` / `removeEventListener` API and provide a callback to subscribe to Rive events.
+    You need to register an event listener on a `StateMachine` instance:
 
-        The API signature:
+    ```dart
+    final controller = RiveWidgetController(_riveFile!);
+    controller?.stateMachine.addEventListener(_onRiveEvent);
 
-        ```dart
-        void addEventListener(OnEvent callback)
-        void removeEventListener(OnEvent callback)
-        typedef OnEvent = void Function(RiveEvent);
-        ```
-
-        <Note>
-         You may add multiple event listener callbacks if you need to, but all event listeners need to be removed. All event listeners will be removed when the controller is disposed.
-        </Note>
-        Rive's event object provided to the callback will vary depending on the type of event (i.e. `RiveGeneralEvent` vs `RiveOpenURLEvent`, and others in the future). These derive from `RiveEvent` which has:
-
-        - `name` - Name of the event.
-        - `secondsDelay` - Time since the event was reported and the callback received the event.
-        - `properties` - Custom properties are extra data that can be supplied with an event at design time.
-
-        The `RiveOpenURLEvent` has additional fields: `url` and `target` (enum of type `OpenUrlTarget`).
-
-        For example, a sample callback to handle logging a Rive event may look like the following:
-
-        ```javascript
-        void onRiveEvent(RiveEvent event) {
-        print(event);
-        }
-
-        ...
-
-        RiveAnimation.asset(
-        'assets/rating.riv',
-        onInit: (Artboard artboard) {
-            // Get State Machine Controller for the state machine
-            final controller = StateMachineController.fromArtboard(artboard, 'State Machine 1');
-            controller.addEventListener(onRiveEvent);
-            artboard.addController(controller!);
-        },
-        )
-        ```
-
-        #### Example Usage - Star Rating
-
-        This example demonstrates how to retrieve custom properties set on a Rive event and update a Flutter UI component.
-
-        <Note>
-         Note that a Rive event could be triggered **during** a Flutter frame update. Calling `setState` at this stage will result in an exception being thrown by Flutter. Instead you should schedule a `setState` to be called on the next frame using `WidgetsBinding.instance.addPostFrameCallback`
-        </Note>
-        ```javascript
-        class EventStarRating extends StatefulWidget {
-        const EventStarRating({super.key});
-
-        @override
-        State<EventStarRating> createState() => _EventStarRatingState();
-        }
-
-        class _EventStarRatingState extends State<EventStarRating> {
-        late StateMachineController _controller;
-
-        @override
-        void initState() {
-            super.initState();
-        }
-
-        String ratingValue = 'Rating: 0';
-
-        void onInit(Artboard artboard) async {
-            _controller =
-                StateMachineController.fromArtboard(artboard, 'State Machine 1')!;
-            artboard.addController(_controller);
-
-            _controller.addEventListener(onRiveEvent);
-        }
-
-        void onRiveEvent(RiveEvent event) {
-            // Access custom properties defined on the event
-            var rating = event.properties['rating'] as double;
-            // Schedule the setState for the next frame, as an event can be
-            // triggered during a current frame update
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-            setState(() {
-                ratingValue = 'Rating: $rating';
-            });
-            });
-        }
-
-        @override
-        void dispose() {
-            _controller.removeEventListener(onRiveEvent);
-            _controller.dispose();
-            super.dispose();
-        }
-
-        @override
-        Widget build(BuildContext context) {
-            return Scaffold(
-            appBar: AppBar(
-                title: const Text('Event Star Rating'),
-            ),
-            body: Column(
-                children: [
-                Expanded(
-                    child: RiveAnimation.asset(
-                    'assets/rating_animation.riv',
-                    onInit: onInit,
-                    ),
-                ),
-                Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text(
-                    ratingValue,
-                    style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
-                    ),
-                )
-                ],
-            ),
-            );
-        }
-        }
-        ```
-
-        #### Example Usage - Open a URL
-
-        A common action you may want to do is open a URL from a Rive Event. For that Rive provides a custom event type `RiveOpenURLEvent`.
-
-        ```javascript
-        class EventOpenUrlButton extends StatefulWidget {
-        const EventOpenUrlButton({super.key});
-
-        @override
-        State<EventOpenUrlButton> createState() => _EventOpenUrlButtonState();
-        }
-
-        class _EventOpenUrlButtonState extends State<EventOpenUrlButton> {
-        late StateMachineController _controller;
-
-        @override
-        void initState() {
-            super.initState();
-        }
-
-        void onInit(Artboard artboard) async {
-            _controller = StateMachineController.fromArtboard(artboard, 'button')!;
-            artboard.addController(_controller);
-
-            _controller.addEventListener(onRiveEvent);
-        }
-
-        void onRiveEvent(RiveEvent event) {
-            if (event is RiveOpenURLEvent) {
-            try {
-                final Uri url = Uri.parse(event.url);
-                launchUrl(url);
-            } on Exception catch (e) {
-                debugPrint(e.toString());
-            }
-            }
-        }
-
-        @override
-        void dispose() {
-            _controller.removeEventListener(onRiveEvent);
-            _controller.dispose();
-            super.dispose();
-        }
-
-        @override
-        Widget build(BuildContext context) {
-            return Scaffold(
-            appBar: AppBar(
-                title: const Text('Event Open URL'),
-            ),
-            body: Column(
-                children: [
-                Expanded(
-                    child: RiveAnimation.asset(
-                    'assets/url_event_button.riv',
-                    onInit: onInit,
-                    ),
-                ),
-                const Center(
-                    child: Padding(
-                    padding: EdgeInsets.all(8.0),
-                    child: Text('Open URL: https://rive.app'),
-                    ),
-                ),
-                ],
-            ),
-            );
-        }
-        }
+    void _onRiveEvent(Event event) {
+        // Do something with the event
+    }
     ```
+
+    Accessing `properties` returns `Map<String, CustomProperty>`. `CustomProperty` is also a sealed class with options:
+
+    - `CustomNumberProperty`
+    - `CustomBooleanProperty`
+    - `CustomStringProperty`
+
+    All of these have a `value` field. On the `Event` class, there are convenient accessors:
+
+    ```dart
+    // Convenient accessors
+    event.property(name);           // Returns a CustomProperty
+    event.numberProperty(name);     // Returns a CustomNumberProperty
+    event.booleanProperty(name);    // Returns a CustomBooleanProperty
+    event.stringProperty(name);     // Returns a CustomStringProperty
+    ```
+
+     It's important to remove the event listener when no longer needed to avoid memory leaks:
+
+    ```dart
+    stateMachine.removeEventListener(_onRiveEvent);
+    ```
+
+    Or the event listeners will also be disposed when the `StateMachine` is disposed.
+
+    ```dart
+    stateMachine.dispose();
+    ```
+
+    If you dispose the `RiveWidgetController`, that will also dispose the `StateMachine` and remove all event listeners.
     </Tab>
 
     <Tab title="Apple">

--- a/runtimes/state-machines.mdx
+++ b/runtimes/state-machines.mdx
@@ -58,60 +58,83 @@ State machines are instantiated by providing a state machine name to the Rive ob
   </Tab>
 
   <Tab title="Flutter">
-    #### Flutter
+  
+    There are a number of ways to play/select a state machine in Flutter.
 
-    To autoplay a state machine by default, simply set the `stateMachines` property at instantiation:
+    #### When using `RiveWidgetController` (recommended)
 
+    When you create a `RiveWidgetController` it will use the default state machine, or you can specify a state machine by name or index.
+    
     ```dart
-    RiveAnimation.network(
-        'https://cdn.rive.app/animations/vehicles.riv',
-        fit: BoxFit.cover,
-        stateMachines: ['bumpy'],
+    // Default state machine
+    var controller = RiveWidgetController(riveFile);
+    // By name
+    controller = RiveWidgetController(
+      riveFile,
+      stateMachineSelector: StateMachineSelector.byName("State Machine 1"),
+    );
+    // By index
+    controller = RiveWidgetController(
+      riveFile,
+      stateMachineSelector: StateMachineSelector.byIndex(0),
     );
     ```
 
-    In the above snippet, at instantiation time, the runtime will create a `StateMachineController` reference implicitly and immediately play the state machine.
-
-    If you'd like further control over the state machine in cases where you may want to prevent autoplaying the state machine, you can instead pass your own reference to a `StateMachineController` to the `RiveAnimation` widget at instantiation time with the `isActive` property set to `false`. Below is an example of what this might look like:
+    Passing this controller to a `RiveWidget` will automatically play the state machine.
 
     ```dart
-    class _ExampleState extends State<ExampleState> {
-      /// Controller for playback
-      late StateMachineController _controller;
-
-      void _onInit(Artboard artboard) {
-        var ctrl =
-          StateMachineController.fromArtboard(artboard, 'some-state-machine')!;
-        ctrl.isActive = false;
-        artboard.addController(ctrl);
-        _controller = ctrl;
-      }
-
-      @override
-      Widget build(BuildContext context) {
-        return Scaffold(
-          appBar: AppBar(
-            title: const Text('Play/Pause Example'),
-          ),
-          body: Center(
-            child: RiveAnimation.asset('assets/example.riv', onInit: _onInit),
-          ),
-          floatingActionButton: FloatingActionButton(
-            // Play/Pause the state machine
-            onPressed: () => {
-              _controller.isActive
-                  ? _controller.isActive = false
-                  : _controller.isActive = true
-            },
-            tooltip: 'Play/Pause',
-            child: const Icon(Icons.arrow_upward),
-          ),
-        );
-      }
+    @override
+    Widget build(BuildContext context) {
+      return RiveWidget(controller: controller);
     }
     ```
+  
+    You can mark the controller as `active` to play/pause the state machine (advancing and drawing):
 
-    As you change the `isActive` property of the `StateMachineController`, you'll see that the current state may pause advancing through the render loop. This is useful in cases where you may want to load in your Rive on screen, but delay playing until a loading sequence occurs, or some data comes back for your application.
+    ```dart
+    final controller = RiveWidgetController(riveFile);
+    controller.active = false;
+    ```
+
+    The `StateMachineSelector` can also be passed to `RiveWidgetBuilder` to specify which state machine to use:
+    
+    ```dart
+    return RiveWidgetBuilder(
+      fileLoader: fileLoader,
+      stateMachineSelector: StateMachineSelector.byIndex(0),
+      builder: (context, state) => switch (state) {
+        /// ...
+      },
+    );
+    ```
+
+    #### When using `StateMachinePainter`
+
+    When using `StateMachinePainter`, you can specify the state machine to use by passing an optional name.
+    ```dart
+    // Default state machine
+    final painter = rive.StateMachinePainter(withStateMachine: _withStateMachine);
+    // By name
+    painter = rive.StateMachinePainter(
+      withStateMachine: _withStateMachine,
+      stateMachineName: 'State Machine 1  ',
+    );    
+    ```
+
+    #### Creating a state machine directly
+
+    Create the state machine directly from an `Artboard`:
+
+    ```dart
+    final artboard = riveFile.defaultArtboard()!;
+    // Default state machine
+    var stateMachine = artboard.defaultStateMachine();
+    // By name
+    stateMachine = artboard.stateMachine('State Machine 1');
+    // By index
+    stateMachine = artboard.stateMachineAt(0);
+    ```    
+
   </Tab>
 
   <Tab title="Apple">
@@ -234,29 +257,7 @@ We can set a callback to determine when the state machine changes.
 ```
   </Tab>
   <Tab title="Flutter">
-If you'd like to know which state a state machine is in, or when a state machine transitions to another state, you can provide a callback to `StateMachineController`. The callback has the name of the state machine and the name of the animation associated with the state transitioned to:
-
-```javascript
- void _onRiveInit(Artboard artboard) {
-  final controller = StateMachineController.fromArtboard(
-    artboard,
-    'bumpy',
-    onStateChange: _onStateChange,
-  );
-  artboard.addController(controller!);
-  _bump = controller.getTriggerInput('bump');
-}
-
-void _onStateChange(
-  String stateMachineName,
-  String stateName,
-) =>
-    setState(
-      () => message = 'State Changed in $stateMachineName to $stateName',
-    );
-```
-
-
+  Not supported. This is a legacy feature and we strongly recommend using [Data Binding](/runtimes/data-binding) or [Events](/runtimes/rive-events) instead.
   </Tab>
   <Tab title="Apple">
 This runtime allows for delegates that can be set on the `RiveViewModel`. If provided, these delegate functions will be fired whenever a matching event is triggered to be able to hook into and listen for certain events in the Rive animation cycle.

--- a/runtimes/text.mdx
+++ b/runtimes/text.mdx
@@ -206,33 +206,26 @@ You can identify an exported component if it's surrounded by square brackets. Th
     </Tab>
 
     <Tab title="Flutter">
+        Get/set the text run value on an `Artboard` instance.
 
-        Find the `TextValueRun` component with a given **name** on a Rive `Artboard` and update the text value.
+        <Tip>
+        We recommend using [Data Binding](/editor/data-binding/overview) instead to update text at runtime.
+        </Tip>
 
-        To make this more convenient you can create an extension.
+        ```dart Get/Set Text Run Value
+        final controller = RiveWidgetController(riveFile);
+        final artboard = controller.artboard;
 
-        ```dart
-        extension _TextExtension on Artboard {
-        TextValueRun? textRun(String name) => component<TextValueRun>(name);
-        }
+        // Get a text run value
+        artboard.getText(value)
+        // Optional path parameter to get a text run value at a nested artboard level
+        artboard.getText(value, path: path)
+
+        // Set a text run value
+        artboard.setText(value)
+        // Optional path parameter to set a text run value at a nested artboard level
+        artboard.setText(value, path: path)
         ```
-
-        Get a reference to the `Artboard`, find the text run named *"MyRun"*, and update the text value:
-
-        ```dart
-        RiveAnimation.asset(
-        'assets/hello_world_text.riv',
-        animations: const ['Timeline 1'],
-        onInit: (artboard) {
-            final textRun = artboard.textRun('MyRun')!; // find text run named "MyRun"
-            print('Run text used to be ${textRun.text}');
-            textRun.text = 'Hi Flutter Runtime!';
-        },
-        )
-        ```
-
-        Or get a reference to the artboard by calling: `riveFile.mainArtboard`, see [Alternative Widget Setup](/runtimes/flutter/alternative-widget-setup).
-
     </Tab>
 
     <Tab title="Apple">
@@ -493,6 +486,25 @@ The path is then: `ArtboardWithUniqueName/ButtonWithUniqueName`
         ```
     </Tab>
 
+    <Tab title="Flutter">
+        Get/set a nested text run value on an `Artboard` instance.
+
+        <Tip>
+        We recommend using [Data Binding](/editor/data-binding/overview) instead to update text at runtime.
+        </Tip>
+
+        ```dart Get/Set Text Run Value
+        final controller = RiveWidgetController(riveFile);
+        final artboard = controller.artboard;
+
+        //Use the path parameter to get a text run value at a nested artboard level
+        artboard.getText(value, path: path)
+
+        // Use the path parameter to set a text run value at a nested artboard level
+        artboard.setText(value, path: path)
+        ```
+    </Tab>
+
     <Tab title="Apple">
 
         ### Reading Text
@@ -597,10 +609,13 @@ The path is then: `ArtboardWithUniqueName/ButtonWithUniqueName`
 
 ### Semantics for Accessibility
 
+<Tip>
+We recommend using [Data Binding](/editor/data-binding/overview) instead as you'll be able to do a two way text binding.
+</Tip>
+
 As Rive Text does not make use of the underlying platform text APIs, additional steps need to be taken to ensure it can be read by screen readers.
 
 The following code snippets provide guidance on how to add semantic labels to your Rive animations. Please see the respective platform/SDKs developer documentation for additional information regarding accessibility concerns.
-
 
 <Tabs>
     <Tab title="Flutter">
@@ -609,28 +624,17 @@ The following code snippets provide guidance on how to add semantic labels to yo
         ```
         ...
 
-        String semanticLabel = '';
+        final controller = RiveWidgetController(riveFile);
+        final textValue = controller.artboard.getText('some_text_run_name').value;
+        String semanticLabel = textValue;
 
         ...
 
         Semantics(
-        label: semanticLabel,
-        child: RiveAnimation.asset(
-            'assets/hello_world_text.riv',
-            animations: const ['Timeline 1'],
-            onInit: (artboard) {
-            final run = artboard.component<TextValueRun>("MyRun");
-            setState(() {
-                // Calling setState is needed to ensure the Semantics widget
-                // rebuilds with the new value.
-                semanticLabel = run?.text ?? "";
-            });
-            },
-        ),
+            label: semanticLabel,
+            child: RiveWidget(controller: controller);
         ),
         ```
-
-        Or you can read the `.riv` file yourself and instance the artboard, see Alternative Widget Setup.
     </Tab>
 
     <Tab title="Web (JS)">

--- a/snippets/runtimes/animation-control-and-interaction.mdx
+++ b/snippets/runtimes/animation-control-and-interaction.mdx
@@ -1,7 +1,4 @@
 <CardGroup cols={2}>
-  <Card title="Animation Playback" href="/runtimes/animation-playback" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>}>
-    Configuring runtime animation playback properties.
-  </Card>
   <Card title="Layout" href="/runtimes/layout"  icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>}>
     Controlling your Rive graphic's layout (fit and alignment) at runtime.
   </Card>


### PR DESCRIPTION
- Rewrite the Flutter documentation to support the new Flutter API for version 0.14.0 (major release)
- Significant changes in how you use Rive Flutter 
- Migration Guide
- Removes legacy examples