### PR TITLE
docs: add version numbers for list-image-artboard data binding in react and unity

### DIFF
--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -18,14 +18,14 @@ We may include notes on migrating to newer versions if a new feature warrants re
         | **Runtime** | **Version** |
         | --- | --- |
         | Web | ✅ `2.30.3+` |
-        | React | 🚧 Lists and images supported `4.21.6+` |
+        | React | ✅ `4.22.0+` |
         | React Native | Not yet supported |
         | Flutter | ✅ `0.14.0-dev.1` |
         | Flutter (rive_native) | ✅ `0.0.4` |
         | Apple | 🚧 Lists and images supported `v6.10.0+`  |
         | Android | 🚧 Coming soon |
         | C++ | ✅ Supported |
-        | Unity | 🚧 Coming soon  |
+        | Unity |  ✅ `v0.3.7-canary.142` |
         | Unreal | Not yet supported |
     </Accordion>
     <Accordion title="Right to Left Layouts & Text">


### PR DESCRIPTION
This PR updates the feature support page to include the package versions for lists, images, and artboard data binding in the React and Unity packages.