### PR TITLE
Update codesandbox links to include file name

### DIFF
--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -98,7 +98,7 @@ See our documentation on [Loading Assets](/runtimes/loading-assets). This featur
 - Reduces the exported `.riv` binary size.
 - Assets can be reused across multiple Rive files or other areas of your application.
 - Assets can be preloaded and cached to be more readily available before displaying a Rive graphic.
-- Assets can be swapped based on the users’ screen size and resolution, like in this [web JS example](https://codesandbox.io/p/sandbox/cool-dewdney-hlk5xl).
+- Assets can be swapped based on the users’ screen size and resolution, like in this [web JS example](https://codesandbox.io/p/sandbox/cool-dewdney-hlk5xl?file=%2Fsrc%2Findex.tsx%3A87%2C4).
 
 ### Caching your .riv
 

--- a/runtimes/layout.mdx
+++ b/runtimes/layout.mdx
@@ -80,7 +80,7 @@ For more Editor information and how to configure your graphic see [Layouts Overv
   <Tab title="React">
     **Examples**
 
-    - [Layout React Example](https://codesandbox.io/p/devbox/rive-responsive-layouts-react-forked-nmpv39?workspaceId=ws_XXze7Vt5ZRuDr9J37bb5ub)
+    - [Layout React Example](https://codesandbox.io/p/devbox/rive-responsive-layouts-react-forked-nmpv39?file=%2Fsrc%2FApp.tsx%3A24%2C28)
 
     **Steps**
 

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -190,7 +190,7 @@ See below for documentation on how to handle loading in assets at runtime for yo
     ### Examples
 
     - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77)
-    - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w)
+    - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w?file=%2Fsrc%2FApp.js%3A17%2C32)
 
     ### Using the Asset Handler API
 

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -191,7 +191,6 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
     - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77)
     - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w)
-    - [Specify an image asset to load (TypeScript)](https://codesandbox.io/p/sandbox/out-of-band-react-typescript-forked-khxxcy)
 
     ### Using the Asset Handler API
 

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -190,7 +190,7 @@ See below for documentation on how to handle loading in assets at runtime for yo
     ### Examples
 
     - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77)
-    - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w?file=%2Fsrc%2FApp.js%3A17%2C32)
+    - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w?file=%2Fsrc%2FApp.tsx%3A14%2C30)
 
     ### Using the Asset Handler API
 

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -189,7 +189,7 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
     ### Examples
 
-    - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77)
+    - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77?file=%2Fsrc%2FApp.tsx%3A20%2C38)
     - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w?file=%2Fsrc%2FApp.tsx%3A14%2C30)
 
     ### Using the Asset Handler API

--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -16,7 +16,7 @@ This library contains a React component, as well as custom hooks to help integra
 ## Quick Start
 
 
-See our [quick start example](https://codesandbox.io/p/sandbox/rive-quick-start-react-4xy76h) that shows how to play a Rive animation with React.
+See our [quick start example](https://codesandbox.io/p/sandbox/rive-quick-start-react-4xy76h?file=%2Fsrc%2FApp.tsx%3A25%2C) that shows how to play a Rive animation with React.
 
 
 ## Getting Started
@@ -103,7 +103,7 @@ At this time, we highly recommend isolating your usage of `useRive` to its own w
 
 By isolating `useRive` to its own wrapper component, Rive will have a chance to properly clean up, and restart the animation with a new canvas. In a parent component, you can then conditionally render the wrapper component based on any state or prop-based logic.
 
-Check out this example to see this pattern in use: [https://codesandbox.io/s/userive-wrapper-pattern-zx2h3j](https://codesandbox.io/s/userive-wrapper-pattern-zx2h3j)
+Check out [this example CodeSandbox](https://codesandbox.io/p/sandbox/rive-react-swapping-skins-with-solos-ctcnlx?file=%2Fsrc%2FApp.tsx) to see this pattern in use.
 
 ## Resources
 
@@ -112,7 +112,7 @@ Check out this example to see this pattern in use: [https://codesandbox.io/s/use
 **Types**: [https://github.com/rive-app/rive-react/blob/main/src/types.ts](https://github.com/rive-app/rive-react/blob/main/src/types.ts)
 
 **Examples**
-- Simple skinning example: [https://codesandbox.io/p/sandbox/rive-skins-ctcnlx](https://codesandbox.io/p/sandbox/rive-skins-ctcnlx)
+- Simple skinning example: [https://codesandbox.io/p/sandbox/rive-react-swapping-skins-with-solos-ctcnlx](https://codesandbox.io/p/sandbox/rive-react-swapping-skins-with-solos-ctcnlx?file=%2Fsrc%2FApp.tsx)
 - Storybook demo: [https://rive-app.github.io/rive-react/](https://rive-app.github.io/rive-react/)
 - Animated Login Form:
   - Demo: [https://rive-app.github.io/rive-use-cases/?path=/story/example-loginformcomponent--primary](https://rive-app.github.io/rive-use-cases/?path=/story/example-loginformcomponent--primary)

--- a/runtimes/rive-events.mdx
+++ b/runtimes/rive-events.mdx
@@ -120,7 +120,7 @@ Let's use a 5-star rater Rive example to set any text supplied with events and o
 
         ### Examples
 
-        - [Star rating example](https://codesandbox.io/p/sandbox/rive-events-react-forked-ct9k2z)
+        - [Star rating example](https://codesandbox.io/p/sandbox/rive-events-react-forked-ct9k2z?file=%2Fsrc%2FApp.js%3A6%2C44)
 
         ### Adding an Event Listener
 


### PR DESCRIPTION
We're converting all the demos to Typescript. This PR updates the links to make sure the right .tsx file is open. 