### PR TITLE
docs(web): update codesandbox to typescript

### DIFF
--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -98,7 +98,7 @@ See our documentation on [Loading Assets](/runtimes/loading-assets). This featur
 - Reduces the exported `.riv` binary size.
 - Assets can be reused across multiple Rive files or other areas of your application.
 - Assets can be preloaded and cached to be more readily available before displaying a Rive graphic.
-- Assets can be swapped based on the users’ screen size and resolution, like in this [web JS example](https://codesandbox.io/p/sandbox/cool-dewdney-hlk5xl?file=%2Fsrc%2Findex.tsx%3A87%2C4).
+- Assets can be swapped based on the users’ screen size and resolution, like in this [web JS example](https://codesandbox.io/p/sandbox/cool-dewdney-hlk5xl?file=%2Fsrc%2Findex.ts).
 
 ### Caching your .riv
 

--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -98,7 +98,7 @@ See our documentation on [Loading Assets](/runtimes/loading-assets). This featur
 - Reduces the exported `.riv` binary size.
 - Assets can be reused across multiple Rive files or other areas of your application.
 - Assets can be preloaded and cached to be more readily available before displaying a Rive graphic.
-- Assets can be swapped based on the users’ screen size and resolution, like in this [web JS example](https://codesandbox.io/p/sandbox/cool-dewdney-hlk5xl).
+- Assets can be swapped based on the users’ screen size and resolution, like in this [web JS example](https://codesandbox.io/p/sandbox/cool-dewdney-hlk5xl?file=%2Fsrc%2Findex.tsx).
 
 ### Caching your .riv
 

--- a/runtimes/caching-a-rive-file.mdx
+++ b/runtimes/caching-a-rive-file.mdx
@@ -95,7 +95,7 @@ Under most circumstances a `.riv` file should load quickly and managing the `Riv
     </Tab>
 
     <Tab title="Web">
-        The following is a basic example to illustrate how to preload a Rive file, and pass the data to multiple Rive instances. Try it out on [CodeSandbox](https://codesandbox.io/p/sandbox/rive-quick-start-js-forked-g675my?file=%2Fsrc%2Findex.mjs).
+        The following is a basic example to illustrate how to preload a Rive file, and pass the data to multiple Rive instances. Try it out on [CodeSandbox](https://codesandbox.io/p/sandbox/rive-quick-start-js-forked-g675my?file=%2Fsrc%2Findex.ts%3A4%2C1).
 
         ```javascript
         const rive = require("@rive-app/canvas");

--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -1742,7 +1742,7 @@ For more information on list properties, see the [Data Binding List Property](/e
 
          **Examples**
 
-        - [Controlling lists with JS](https://codesandbox.io/p/sandbox/suspicious-hertz-2lg4m8?file=%2Fsrc%2Findex.tsx)
+        - [Controlling lists with JS](https://codesandbox.io/p/sandbox/suspicious-hertz-2lg4m8?file=%2Fsrc%2Findex.ts)
 
         ```javascript
         const rive = new rive.Rive({
@@ -2303,7 +2303,7 @@ Enums are string typed. The Rive file contains a list of enums. Each enum in tur
 # Examples
 <Tabs>
     <Tab title="Web">
-    See [this video](https://youtu.be/G6IWCZ1IG10?t=1243) for an intro to data binding using the Web runtime along with this [CodeSandbox example](https://codesandbox.io/p/sandbox/rive-data-binding-quick-start-js-6v2ltn?file=%2Fsrc%2Findex.tsx).
+    See [this video](https://youtu.be/G6IWCZ1IG10?t=1243) for an intro to data binding using the Web runtime along with this [CodeSandbox example](https://codesandbox.io/p/sandbox/rive-data-binding-quick-start-js-6v2ltn?file=%2Fsrc%2Findex.ts).
 
     <YouTube id="G6IWCZ1IG10" timestamp="1243" />
     </Tab>

--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -1742,7 +1742,7 @@ For more information on list properties, see the [Data Binding List Property](/e
 
          **Examples**
 
-        - [Controlling lists with JS](https://codesandbox.io/p/sandbox/suspicious-hertz-2lg4m8?file=%2Fsrc%2Findex.mjs)
+        - [Controlling lists with JS](https://codesandbox.io/p/sandbox/suspicious-hertz-2lg4m8?file=%2Fsrc%2Findex.tsx)
 
         ```javascript
         const rive = new rive.Rive({
@@ -2303,7 +2303,7 @@ Enums are string typed. The Rive file contains a list of enums. Each enum in tur
 # Examples
 <Tabs>
     <Tab title="Web">
-    See [this video](https://youtu.be/G6IWCZ1IG10?t=1243) for an intro to data binding using the Web runtime along with this [CodeSandbox example](https://codesandbox.io/p/sandbox/rive-data-binding-quick-start-js-6v2ltn?file=%2Fsrc%2Findex.mjs%3A25%2C35).
+    See [this video](https://youtu.be/G6IWCZ1IG10?t=1243) for an intro to data binding using the Web runtime along with this [CodeSandbox example](https://codesandbox.io/p/sandbox/rive-data-binding-quick-start-js-6v2ltn?file=%2Fsrc%2Findex.tsx).
 
     <YouTube id="G6IWCZ1IG10" timestamp="1243" />
     </Tab>

--- a/runtimes/flutter/alternative-widget-setup.mdx
+++ b/runtimes/flutter/alternative-widget-setup.mdx
@@ -4,20 +4,20 @@ description: 'Techniques and considerations to cache a Rive File in Flutter.'
 ---
 
 
-The easiest way to integrate Rive animations and state machines into your application is via the `RiveAnimation` widget mentioned throughout the runtime help docs. However, there are cases where you may want to set up animation or state machine controllers associated with the Rive widget before the Artboard is rendered. Check out below for other ways to integrate Rive into your Flutter applications: 
+The easiest way to integrate Rive animations and state machines into your application is via the `RiveAnimation` widget mentioned throughout the runtime help docs. However, there are cases where you may want to set up animation or state machine controllers associated with the Rive widget before the Artboard is rendered. Check out below for other ways to integrate Rive into your Flutter applications:
 
-## Alternative Methods 
+## Alternative Methods
 
-### File loading 
+### File loading
 
 If you want to load in the `.riv` file from the `rootBundle`, you'll need to import the data yourself. The main pattern here is:
 
 <Steps>
-  <Step title="Load in the bytes of the `.riv` file"></Step>
-  <Step title="Use the `RiveFile` class to parse the data and get a reference to the file"></Step>
-  <Step title="Create a reference to the Artboard you want to display, from that file"></Step>
-  <Step title="(Optional) Associate controllers to an Artboard (i.e `StateMachineController`)"></Step>
-  <Step title="Render the `Rive` widget with the artboard reference"></Step>
+  <Step title="Load in the bytes of the `.riv` file" />
+  <Step title="Use the `RiveFile` class to parse the data and get a reference to the file" />
+  <Step title="Create a reference to the Artboard you want to display, from that file" />
+  <Step title="(Optional) Associate controllers to an Artboard (i.e `StateMachineController`)" />
+  <Step title="Render the `Rive` widget with the artboard reference" />
 </Steps>
 
 <Steps>
@@ -89,7 +89,7 @@ If you want to load in the `.riv` file from the `rootBundle`, you'll need to imp
   </Step>
 </Steps>
 
-### Complete Example 
+### Complete Example
 
 Altogether, this pattern might look like the following snippet below:
 

--- a/runtimes/layout.mdx
+++ b/runtimes/layout.mdx
@@ -17,7 +17,7 @@ For more Editor information and how to configure your graphic see [Layouts Overv
   <Tab title="Web">
     **Examples**
 
-    - [Layout JS example](https://codesandbox.io/p/devbox/rive-responsive-layout-js-forked-m77nlw?file=%2Fsrc%2Findex.mjs%3A10%2C1)
+    - [Layout JS example](https://codesandbox.io/p/devbox/rive-responsive-layout-js-forked-m77nlw?file=%2Fsrc%2Findex.tsx%3A10%2C1)
 
     **Steps**
 

--- a/runtimes/layout.mdx
+++ b/runtimes/layout.mdx
@@ -17,7 +17,7 @@ For more Editor information and how to configure your graphic see [Layouts Overv
   <Tab title="Web">
     **Examples**
 
-    - [Layout JS example](https://codesandbox.io/p/devbox/rive-responsive-layout-js-forked-m77nlw?file=%2Fsrc%2Findex.tsx%3A10%2C1)
+    - [Layout JS example](https://codesandbox.io/p/devbox/rive-responsive-layout-js-forked-m77nlw?file=%2Fsrc%2Findex.ts%3A10%2C1)
 
     **Steps**
 

--- a/runtimes/layout.mdx
+++ b/runtimes/layout.mdx
@@ -80,7 +80,7 @@ For more Editor information and how to configure your graphic see [Layouts Overv
   <Tab title="React">
     **Examples**
 
-    - [Layout React Example](https://codesandbox.io/p/devbox/rive-responsive-layouts-react-forked-nmpv39?workspaceId=ws_XXze7Vt5ZRuDr9J37bb5ub)
+    - [Layout React Example](https://codesandbox.io/p/devbox/rive-responsive-layouts-react-forked-nmpv39?file=%2Fsrc%2FApp.tsx)
 
     **Steps**
 

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -76,8 +76,8 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
         ### Examples
 
-        - [Specify a font asset to load](https://codesandbox.io/p/devbox/rive-out-of-band-fonts-js-forked-kml2wd?file=%2Fsrc%2Findex.tsx)
-        - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-js-forked-23jx8m?file=%2Fsrc%2Findex.tsx)
+        - [Specify a font asset to load](https://codesandbox.io/p/devbox/rive-out-of-band-fonts-js-forked-kml2wd?file=%2Fsrc%2Findex.ts)
+        - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-js-forked-23jx8m?file=%2Fsrc%2Findex.ts)
         - [Out of band assets (fonts) - webgl2 advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy?file=%2Fsrc%2Findex.ts)
 
         ### Using the Asset Handler API

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -76,9 +76,9 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
         ### Examples
 
-        - [Specify a font asset to load](https://codesandbox.io/p/devbox/rive-out-of-band-fonts-js-forked-kml2wd?workspaceId=ws_XXze7Vt5ZRuDr9J37bb5ub)
-        - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-js-forked-23jx8m)
-        - [Out of band assets (fonts) - canvas advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-forked-kyh8zn)
+        - [Specify a font asset to load](https://codesandbox.io/p/devbox/rive-out-of-band-fonts-js-forked-kml2wd?file=%2Fsrc%2Findex.tsx)
+        - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-js-forked-23jx8m?file=%2Fsrc%2Findex.tsx)
+        - [Out of band assets (fonts) - webgl2 advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy?file=%2Fsrc%2Findex.ts)
 
         ### Using the Asset Handler API
 
@@ -189,7 +189,7 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
     ### Examples
 
-    - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77)
+    - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77?file=%2Fsrc%2FApp.tsx)
     - [Localization - Swap a font based on language (TypeScript & i18n)](https://codesandbox.io/p/sandbox/rive-react-i18n-localization-and-font-swapping-kfsqsl?file=%2Fsrc%2FRiveDemo.tsx)
     - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w)
     - [Specify an image asset to load (TypeScript)](https://codesandbox.io/p/sandbox/out-of-band-react-typescript-forked-khxxcy)

--- a/runtimes/loading-assets.mdx
+++ b/runtimes/loading-assets.mdx
@@ -191,7 +191,7 @@ See below for documentation on how to handle loading in assets at runtime for yo
 
     - [Specify a font asset to load](https://codesandbox.io/p/sandbox/peaceful-water-2chg77?file=%2Fsrc%2FApp.tsx)
     - [Localization - Swap a font based on language (TypeScript & i18n)](https://codesandbox.io/p/sandbox/rive-react-i18n-localization-and-font-swapping-kfsqsl?file=%2Fsrc%2FRiveDemo.tsx)
-    - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w)
+    - [Specify an image asset to load](https://codesandbox.io/p/sandbox/rive-out-of-band-images-react-forked-gstq2w?file=%2Fsrc%2FApp.tsx)
     - [Specify an image asset to load (TypeScript)](https://codesandbox.io/p/sandbox/out-of-band-react-typescript-forked-khxxcy)
 
     ### Using the Asset Handler API

--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -103,7 +103,7 @@ At this time, we highly recommend isolating your usage of `useRive` to its own w
 
 By isolating `useRive` to its own wrapper component, Rive will have a chance to properly clean up, and restart the animation with a new canvas. In a parent component, you can then conditionally render the wrapper component based on any state or prop-based logic.
 
-Check out this example to see this pattern in use: [https://codesandbox.io/s/userive-wrapper-pattern-zx2h3j](https://codesandbox.io/s/userive-wrapper-pattern-zx2h3j)
+Check out this example to see this pattern in use: [https://codesandbox.io/p/sandbox/rive-react-userive-wrapper-pattern-gnqpv5j](https://codesandbox.io/p/sandbox/rive-react-userive-wrapper-pattern-gnqpv5?file=%2Fsrc%2FRiveWrapper.tsx)
 
 ## Resources
 
@@ -112,7 +112,7 @@ Check out this example to see this pattern in use: [https://codesandbox.io/s/use
 **Types**: [https://github.com/rive-app/rive-react/blob/main/src/types.ts](https://github.com/rive-app/rive-react/blob/main/src/types.ts)
 
 **Examples**
-- Simple skinning example: [https://codesandbox.io/p/sandbox/rive-skins-ctcnlx](https://codesandbox.io/p/sandbox/rive-skins-ctcnlx)
+- Simple skinning example: [https://codesandbox.io/p/sandbox/rive-skins-ctcnlx](https://codesandbox.io/p/sandbox/rive-skins-ctcnlx?file=%2Fsrc%2FApp.tsx)
 - Storybook demo: [https://rive-app.github.io/rive-react/](https://rive-app.github.io/rive-react/)
 - Animated Login Form:
   - Demo: [https://rive-app.github.io/rive-use-cases/?path=/story/example-loginformcomponent--primary](https://rive-app.github.io/rive-use-cases/?path=/story/example-loginformcomponent--primary)

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -111,7 +111,7 @@ A low-level Rive API using the [CanvasRenderingContext2D](https://developer.mozi
 - Allows for rendering multiple Rive artboards to a single canvas
 - Allows deeper control and manipulation of the components in a Rive hierarchy
 
-See an example of usage here: [https://codesandbox.io/p/sandbox/canvas-advance-api-example-s6dz3m](#background)
+See an example of usage here: [https://codesandbox.io/p/sandbox/canvas-advance-api-example-s6dz3m?file=%2Fsrc%2Findex.ts](#background)
 
 <Note>
  Want an **even smaller** Rive dependency that doesn't have all the bells/whistles? Consider using `@rive-app/canvas-advanced-lite` below👇

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -139,7 +139,7 @@ A low-level Rive API using a WebGL2 context. It has the same benefits as the reg
 - Allows for rendering multiple Rive graphics to a single canvas.
 - Allows deeper control and manipulation of the components in a Rive hierarchy.
 
-See an example of usage here: [CodeSandbox](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp)
+See an example of usage here: [CodeSandbox](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp?file=%2Fsrc%2Findex.ts)
 
 ### *-single versions
 

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -139,8 +139,6 @@ A low-level Rive API using a WebGL2 context. It has the same benefits as the reg
 - Allows for rendering multiple Rive graphics to a single canvas.
 - Allows deeper control and manipulation of the components in a Rive hierarchy.
 
-See an example of usage here: [CodeSandbox](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp?file=%2Fsrc%2Findex.ts)
-
 ### *-single versions
 
 Each of the above NPM packages includes the `rive.wasm` file. In the high-level APIs (`@rive-app/canvas` and `@rive-app/webgl`) the runtime requests this for you so you don't have to, as opposed to their `-advanced` counterparts. We also have alternative versions of each of the above packages on NPM that have the WASM encoded in the JS bundle (excluding the `lite` versions). This means you won't have to make a network request for the WASM that powers the Rive animations, as it's all in one main JS file. This is a solution for if you have issues loading from the CDNs that load in the WASM in your app.

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -303,9 +303,9 @@ stateMachine.delete();
 
 See below for links to examples demonstrating the use of low-level JS APIs:
 
-- [Simple use of @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/smoosh-microservice-s6dz3m)
-- [Simple use of @rive-app/webgl2-advanced](https://codesandbox.io/p/sandbox/rive-webgl-advanced-57lczl)
-- [Out of band assets (fonts) @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy)
+- [Simple use of @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/canvas-advance-api-example-s6dz3m?file=%2Fsrc%2Findex.ts)
+- [Simple use of @rive-app/webgl2-advanced](https://codesandbox.io/p/sandbox/rive-webgl-advanced-57lczl?file=%2Fsrc%2Findex.ts)
+- [Out of band assets (fonts) @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy?file=%2Fsrc%2Findex.ts)
 - [A volume knob state machine](https://codesandbox.io/p/sandbox/rive-volume-knob-draft-j8qchy)
 - [Centaur apple game](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp)
 

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -20,19 +20,27 @@ See a simple game example [here](https://codesandbox.io/p/sandbox/rive-canvas-ad
 Here's the basic render workflow using the low-level API to render Rives:
 
 <Steps>
-  <Step title="Load the Rive Web Assembly (WASM) file, which contains the module with lower-level APIs"></Step>
-  <Step title="Load the Rive file in"></Step>
-  <Step title="Create instances for Artboards, LinearAnimations, and StateMachines"></Step>
+  <Step title="Load the Rive Web Assembly (WASM) file, which contains the module with lower-level APIs" />
+  <Step title="Load the Rive Web Assembly (WASM) file, which contains the module with lower-level APIs" />
+  <Step title="Load the Rive file in" />
+  <Step title="Create instances for Artboards, LinearAnimations, and StateMachines" />
+  <Step title="Create instances for Artboards, LinearAnimations, and StateMachines" />
   <Step title="Build the render loop function to manipulate the instances created above">
     <Steps>
-      <Step title="Advance any animation instances and apply it"></Step>
-      <Step title="Advance any state machine instances"></Step>
-      <Step title="Advance the artboard"></Step>
-      <Step title="Render the updated artboard on the canvas"></Step>
-      <Step title="Request the next animation frame"></Step>
+      <Step title="Advance any animation instances and apply it" />
+      <Step title="Advance any animation instances and apply it" />
+      <Step title="Advance any state machine instances" />
+      <Step title="Advance any state machine instances" />
+      <Step title="Advance the artboard" />
+      <Step title="Advance the artboard" />
+      <Step title="Render the updated artboard on the canvas" />
+      <Step title="Render the updated artboard on the canvas" />
+      <Step title="Request the next animation frame" />
+      <Step title="Request the next animation frame" />
     </Steps>
   </Step>
-  <Step title="Clean-up created instances when finished"></Step>
+  <Step title="Clean-up created instances when finished" />
+  <Step title="Clean-up created instances when finished" />
 </Steps>
 
 ## Getting Started

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -13,7 +13,7 @@ While the JS runtime offers a high-level API that allows for integrating Rives i
 - Smaller dependency size
 - ...and more!
 
-See a simple game example [here](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp).
+See a simple game example [here](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp?file=%2Fsrc%2Findex.ts).
 
 ## Premise
 
@@ -306,8 +306,7 @@ See below for links to examples demonstrating the use of low-level JS APIs:
 - [Simple use of @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/canvas-advance-api-example-s6dz3m?file=%2Fsrc%2Findex.ts)
 - [Simple use of @rive-app/webgl2-advanced](https://codesandbox.io/p/sandbox/rive-webgl-advanced-57lczl?file=%2Fsrc%2Findex.ts)
 - [Out of band assets (fonts) @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy?file=%2Fsrc%2Findex.ts)
-- [A volume knob state machine](https://codesandbox.io/p/sandbox/rive-volume-knob-draft-j8qchy)
-- [Centaur apple game](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp)
+- [Centaur apple game](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp?file=%2Fsrc%2Findex.ts)
 
 ## API References
 

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -13,8 +13,6 @@ While the JS runtime offers a high-level API that allows for integrating Rives i
 - Smaller dependency size
 - ...and more!
 
-See a simple game example [here](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp?file=%2Fsrc%2Findex.ts).
-
 ## Premise
 
 Here's the basic render workflow using the low-level API to render Rives:
@@ -314,7 +312,6 @@ See below for links to examples demonstrating the use of low-level JS APIs:
 - [Simple use of @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/canvas-advance-api-example-s6dz3m?file=%2Fsrc%2Findex.ts)
 - [Simple use of @rive-app/webgl2-advanced](https://codesandbox.io/p/sandbox/rive-webgl-advanced-57lczl?file=%2Fsrc%2Findex.ts)
 - [Out of band assets (fonts) @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy?file=%2Fsrc%2Findex.ts)
-- [Centaur apple game](https://codesandbox.io/p/sandbox/rive-canvas-advanced-api-centaur-example-q6snxp?file=%2Fsrc%2Findex.ts)
 
 ## API References
 

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -18,7 +18,7 @@ This guide documents how to get started using the Rive web runtime library. The 
 
 ## Quick Start
 
-See our [quick start example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6?file=%2Fsrc%2Findex.tsx).
+See our [quick start example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6?file=%2Fsrc%2Findex.ts).
 
 <Note>
   This example only demonstrates loading a .riv file resource in various ways and creating a Rive instance. The other sections detail more advanced use cases.
@@ -182,7 +182,7 @@ Bringing it all together, here's how to load a Rive graphic in a single HTML fil
 
 ### Loading Rive files
 
-[See this example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6?file=%2Fsrc%2Findex.tsx) for the different ways to load in a .riv file, the options are:
+[See this example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6?file=%2Fsrc%2Findex.ts) for the different ways to load in a .riv file, the options are:
 
 1. **Hosted URL**: Use a string representing the URL where the `.riv` file is hosted. Set this as the `src` attribute when creating a new Rive instance.
 2. **Static Assets in the bundle**: Provide a string with the path to a publicly accessible `.riv` file within your web project. Handle `.riv` files just like any other static asset (e.g., images or fonts) in your project.

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -18,7 +18,7 @@ This guide documents how to get started using the Rive web runtime library. The 
 
 ## Quick Start
 
-See our [quick start example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6).
+See our [quick start example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6?file=%2Fsrc%2Findex.tsx).
 
 <Note>
   This example only demonstrates loading a .riv file resource in various ways and creating a Rive instance. The other sections detail more advanced use cases.
@@ -43,17 +43,17 @@ Follow the steps below to integrate Rive into your web app.
       <Tab title="Script Tag">
         ```html
         // Add the following script tag to your web page to get the latest version:
-        
-        
+
+
         <script src="https://unpkg.com/@rive-app/canvas"></script>
-        
+
         // You can also pin to a specific version (See [here](https://www.npmjs.com/package/@rive-app/canvas) for the latest):
-        
-        
+
+
         <script src="https://unpkg.com/@rive-app/canvas@2.24.0"></script>
-        
+
         // This will make a global `rive` object available, allowing you to access the Rive API via the `rive` entry point:
-        
+
         new rive.Rive({});
         ```
       </Tab>
@@ -77,10 +77,10 @@ Follow the steps below to integrate Rive into your web app.
         ```javascript Importing
         // Import the entire module under the global identifier `rive`
         import * as rive from "@rive-app/canvas";
-        
+
         // Alternatively, import only the specific parts you need
         import { Rive } from "@rive-app/canvas";
-        
+
         ```
       </Tab>
     </Tabs>
@@ -182,7 +182,7 @@ Bringing it all together, here's how to load a Rive graphic in a single HTML fil
 
 ### Loading Rive files
 
-[See this example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6) for the different ways to load in a .riv file, the options are:
+[See this example](https://codesandbox.io/p/sandbox/rive-quick-start-js-xmwcm6?file=%2Fsrc%2Findex.tsx) for the different ways to load in a .riv file, the options are:
 
 1. **Hosted URL**: Use a string representing the URL where the `.riv` file is hosted. Set this as the `src` attribute when creating a new Rive instance.
 2. **Static Assets in the bundle**: Provide a string with the path to a publicly accessible `.riv` file within your web project. Handle `.riv` files just like any other static asset (e.g., images or fonts) in your project.
@@ -242,7 +242,6 @@ More in-depth Rive web documentation and advanced use cases.
 # Examples
 
 - [Basic gallery app](https://github.com/rive-app/rive-wasm/tree/master/js/examples/_frameworks/parcel_example_canvas)
-- [Tracking mouse cursor](https://codesandbox.io/p/sandbox/tracking-mouse-cursor-n38gdd)
-- [Simple skinning](https://codesandbox.io/p/sandbox/simple-skinning-example-96xnwn)
-- [Connecting to page scroll](https://codesandbox.io/p/sandbox/rive-page-scroll-h4msqw)
-- [Playing state machine only when scrolled into the user's viewport](https://codesandbox.io/p/sandbox/rive-wait-for-scroll-into-view-y9wg8d)
+- [Tracking mouse cursor](https://codesandbox.io/p/sandbox/tracking-mouse-cursor-n38gdd?file=%2Fsrc%2Findex.ts)
+- [Connecting to page scroll](https://codesandbox.io/p/sandbox/rive-page-scroll-h4msqw?file=%2Fsrc%2Findex.ts%3A27%2C45)
+- [Playing state machine only when scrolled into the user's viewport](https://codesandbox.io/p/sandbox/rive-wait-for-scroll-into-view-y9wg8d?file=%2Fsrc%2Findex.ts)


### PR DESCRIPTION
When this merges

- All Web and React examples are now using Typescript
- All Web and React examples specify which file to open (the .ts or .tsx with the Rive file)

Other stuff:
- Fix from yesterday's PR: I accidentally names some non-React files to .tsx, when they should have been .ts. 
- Remove the Centaur example

This does not include legacy examples (inputs, text, etc.), which we probably won't update. 