### PR TITLE
docs(unity): include vulkan support

### DIFF
--- a/game-runtimes/unity/unity.mdx
+++ b/game-runtimes/unity/unity.mdx
@@ -26,11 +26,13 @@ The rive-unity runtime uses the [Rive Renderer](https://rive.app/renderer) and i
 - D3D11 on Windows
 - OpenGL on Windows
 - OpenGL on Android
+- Vulkan on Windows
+- Vulkan on Android
+- Vulkan on Ubuntu 24.04+ (x86_64)
 
 Planned support for:
 
 - D3D12
-- Vulkan
 
 ### Bug Reports
 


### PR DESCRIPTION
This PR updates the Unity docs to mention Vulkan support on Windows, Linux, and Android.