### PR TITLE
docs(unity): add missing settings to rive canvas renderer options

### DIFF
--- a/game-runtimes/unity/components.mdx
+++ b/game-runtimes/unity/components.mdx
@@ -174,6 +174,8 @@ You can also create a Rive Panel that has been automatically configured to use t
 | Property | Description |
 | --- | --- |
 | Pointer Input Mode | Controls whether the renderer accepts pointer input (Enable/Disable). |
+| Custom Material | A custom UI material to use when rendering the Rive graphic. |
+| Match Canvas Resolution | Whether to match the canvas resolution to the RivePanel's resolution. This is useful for keeping the Rive graphic crisp when using a `Canvas Scaler`. By default, the RivePanel resolution is defined by its rect transform's width and height. Setting this to `true` will result in the RivePanel being rendered at a higher resolution than the panel's rect transform's size if needed. This feature is currently only supported when the RivePanel uses the `SimpleRenderTargetStrategy`, which is the default strategy used if none is provided. |
 
 #### Properties
 


### PR DESCRIPTION
This PR adds missing `Custom Material` and `Match Canvas Resolution` settings to the Rive Canvas Renderer section.

<img width="514" height="112" alt="Screenshot 2025-09-13 at 2 46 56 PM" src="https://github.com/user-attachments/assets/268a7e4a-4b9b-4971-9dfc-b94f692315d2" />
