### PR TITLE
docs(unity): link to image swapping and databinding demos

### DIFF
--- a/game-runtimes/unity/runtime-asset-swapping.mdx
+++ b/game-runtimes/unity/runtime-asset-swapping.mdx
@@ -125,3 +125,7 @@ This works for fonts, images, and audio, as long as you use the appropriate type
 byte[] imageBytes = /* fetched from a CDN or elsewhere */;
 var myImageAsset = OutOfBandAsset.Create<ImageOutOfBandAsset>(imageBytes);
 ```
+
+## Example
+
+For a demo of runtime asset swapping in Unity, see the **Image Swapping** scene in the [Rive Unity Examples repository](https://github.com/rive-app/rive-unity-examples).

--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -1833,6 +1833,8 @@ Image properties let you set and replace raster images at runtime, with each ins
         }
     }
     ```
+
+    For a demo of image data binding in Unity, see the **Image Data Binding** scene in the [Rive Unity Examples repository](https://github.com/rive-app/rive-unity-examples).
   </Tab>
   <Tab title="React Native">
     <Warning>


### PR DESCRIPTION
This PR updates the Unity docs to link to demos that showcase how to swap images at runtime.