### PR TITLE
Link to s3 .rivs

### DIFF
--- a/snippets/demos.jsx
+++ b/snippets/demos.jsx
@@ -5,7 +5,7 @@ export const Demos = ({
     cachingARiveFile: {
       title: 'Demo: Caching a Rive File',
       description: 'Load the .riv into memory once, use it multiple times.',
-      riv: 'https://rive-static-content.s3.us-west-1.amazonaws.com/rivs/rives_animated_emojis.riv',
+      riv: 'https://static.rive.app/rivs/rives_animated_emojis.riv',
       stateMachines: "State Machine 1",
       artboard: "Emoji_package",
       links: {
@@ -46,7 +46,7 @@ export const Demos = ({
     layouts: {
       title: "Responsive Layouts",
       description: "Create responsive layouts that adapt to different screen sizes.",
-      riv: "https://rive-static-content.s3.us-west-1.amazonaws.com/rivs/layouts_demo.riv",
+      riv: "https://static.rive.app/rivs/layouts_demo.riv",
       stateMachines: "State Machine 1",
       artboard: "Demo",
       links: {

--- a/snippets/demos.jsx
+++ b/snippets/demos.jsx
@@ -5,7 +5,7 @@ export const Demos = ({
     cachingARiveFile: {
       title: 'Demo: Caching a Rive File',
       description: 'Load the .riv into memory once, use it multiple times.',
-      riv: 'https://rive.app/docs/assets/rivs/rives_animated_emojis.riv',
+      riv: 'https://rive-static-content.s3.us-west-1.amazonaws.com/rivs/rives_animated_emojis.riv',
       stateMachines: "State Machine 1",
       artboard: "Emoji_package",
       links: {
@@ -46,7 +46,7 @@ export const Demos = ({
     layouts: {
       title: "Responsive Layouts",
       description: "Create responsive layouts that adapt to different screen sizes.",
-      riv: "https://rive.app/docs/assets/rivs/layouts_demo.riv",
+      riv: "https://rive-static-content.s3.us-west-1.amazonaws.com/rivs/layouts_demo.riv",
       stateMachines: "State Machine 1",
       artboard: "Demo",
       links: {


### PR DESCRIPTION
Mintlify won't let you upload .riv files to their s3. This PR switches to ours. 

Previews: 

- Demos: https://rive-replace-rivs.mintlify.app/runtimes/caching-a-rive-file
- https://rive-replace-rivs.mintlify.app/runtimes/layout

<img width="1145" height="1010" alt="CleanShot 2025-09-25 at 13 37 46" src="https://github.com/user-attachments/assets/9587dc0e-0ab7-4b45-a008-3a55fe2970ff" />
