### PR TITLE
docs(unity): change change low-level API to legacy API

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -372,11 +372,17 @@
                   "game-runtimes/unity/listeners",
                   "game-runtimes/unity/state-machines",
                   "game-runtimes/unity/data-binding",
-                  "game-runtimes/unity/rive-events",
-                  "game-runtimes/unity/text",
                   "game-runtimes/unity/loading-assets",
                   "game-runtimes/unity/procedural-rendering",
-                  "game-runtimes/unity/runtime-asset-swapping"
+                  "game-runtimes/unity/runtime-asset-swapping",
+                  {
+                    "group": "Legacy",
+                    "pages": [
+                      "game-runtimes/unity/inputs",
+                      "game-runtimes/unity/text",
+                      "game-runtimes/unity/rive-events"
+                    ]
+                  }
                 ]
               },
               "game-runtimes/defold"

--- a/game-runtimes/unity/data-binding.mdx
+++ b/game-runtimes/unity/data-binding.mdx
@@ -3,6 +3,8 @@ title: 'Data Binding'
 description: 'Binding Rive Data to Unity and vice versa'
 ---
 
+import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
 # Quick Start
 
 Data binding allows you to establish connections between your Unity code and your Rive graphics. This creates a two-way reactive system where changes in your code affect the Rive design, and changes in the design can trigger responses in your code.
@@ -161,7 +163,10 @@ public class DataBindingExample : MonoBehaviour
 Explore the **RewardsDataBinding** scene in the [getting-started example project](https://github.com/rive-app/rive-unity-examples) for a practical implementation in Unity.
 
 </Tab>
-<Tab title="Low-level API">
+<Tab title="Legacy API">
+
+<LegacyApiNotice />
+
  If you choose to use the low-level API to control the render loop, you'll need to manually set up data binding in your scripts. 
  
  For reference, check this [RiveScreen example](https://github.com/rive-app/rive-unity/blob/main/examples/basic/Assets/GameRuntime/RiveScreen.cs) that demonstrates one way to implement auto binding in a custom render loop.  

--- a/game-runtimes/unity/fundamentals.mdx
+++ b/game-runtimes/unity/fundamentals.mdx
@@ -9,7 +9,7 @@ import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
 
 To add a `.riv` file to a Unity project, simply drag it into the Project Window. Once dropped, a **Rive Asset** will be automatically created.
 
-Now you can display the Rive Asset within a **Rive Panel** and **Rive Widget** or create a custom script using the low-level API to display the graphic.
+Now you can display the Rive Asset within a **Rive Panel** and **Rive Widget**.
 
 ## File
 
@@ -117,7 +117,7 @@ private void Start()
 
 ## State Machines
 
-A StateMachine contains Inputs and Events, for more information see Unity [State Machines](/editor/state-machine/state-machine) and [Rive Events](/runtimes/rive-events/).
+For more information, see [State Machines](/game-runtimes/unity/state-machines).
 
 <Tabs>
     <Tab title="Components">

--- a/game-runtimes/unity/fundamentals.mdx
+++ b/game-runtimes/unity/fundamentals.mdx
@@ -3,6 +3,8 @@ title: 'Fundamentals'
 description: ''
 ---
 
+import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
 ## Adding Rive Assets
 
 To add a `.riv` file to a Unity project, simply drag it into the Project Window. Once dropped, a **Rive Asset** will be automatically created.
@@ -95,7 +97,9 @@ private void Start()
 
     </Tab>
 
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+
+        <LegacyApiNotice />
 
         Artboards are instantiated from a `Rive.File` instance:
 
@@ -124,7 +128,9 @@ A StateMachine contains Inputs and Events, for more information see Unity [State
 
     </Tab>
 
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+
+        <LegacyApiNotice />
 
         State Machines are instantiated from an Artboard instance:
 
@@ -167,7 +173,9 @@ In Unity, Rive renders to a [RenderTexture](https://docs.unity3d.com/ScriptRefer
         To display a **Rive Panel** on a GameObject's mesh, use the **Rive Texture Renderer.**
     </Tab>
 
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+
+        <LegacyApiNotice />
 
         Layout and draw commands are managed through the `Rive.Renderer`.
 

--- a/game-runtimes/unity/inputs.mdx
+++ b/game-runtimes/unity/inputs.mdx
@@ -1,0 +1,101 @@
+---
+title: "Inputs"
+description: ""
+noindex: true
+---
+
+import LegacyDataBindingNotice from '/snippets/unity/legacy-databinding-notice.mdx';
+
+<LegacyDataBindingNotice subject="Inputs" />
+
+## Accessing Inputs
+
+There are three input types, each extends `SMIInput` (State Machine Input):
+
+- `SMIBool` contains a `.Value` property, a boolean that can be set to true or false.
+- `SMITrigger` is a boolean that is set to true for one frame by calling the `.Fire()` method.
+- `SMINumber` contains a `.Value` property, a float that can be set to any value.
+
+State machine inputs can be accessed in a number of different ways.
+
+#### Access by name
+
+Retrieve a state machine input by name and type.
+
+**Trigger:**
+
+```csharp
+SMITrigger someTrigger = m_stateMachine.GetTrigger("icon_02_press_trig");
+if (someTrigger != null)
+{
+    someTrigger.Fire();
+}
+```
+
+**Bool:**
+
+```csharp
+SMIBool someBool = m_stateMachine.GetBool("centerHover");
+if (someBool == null) return;
+Debug.Log(someBool.Value);
+someBool.Value = !someBool.Value;
+Debug.Log(someBool.Value);
+```
+
+**Number:**
+
+```csharp
+SMINumber someNumber = m_stateMachine.GetNumber("rating");
+if (someNumber == null) return;
+Debug.Log(someNumber.Value);
+someNumber.Value = 4;
+Debug.Log(someNumber.Value);
+```
+
+#### Access by index
+
+Get the input count (length) and retrieve by index:
+
+```csharp
+Debug.Log(m_stateMachine.InputCount());
+SMIInput input = m_stateMachine.Input(1);
+```
+
+#### Access all inputs
+
+Retrieve a list of all `SMIInputs`:
+
+```csharp
+var inputs = m_riveStateMachine.Inputs();
+foreach (var input in inputs)
+{
+    switch (input)
+    {
+        case SMITrigger smiTrigger:
+        {
+            // Do something
+            break;
+        }
+        case SMIBool smiBool:
+        {
+            // Do something
+            break;
+        }
+        case SMINumber smiNumber:
+        {
+            // Do something
+            break;
+        }
+    }
+}
+```
+
+## Accessing Nested Inputs
+
+For more information about accessing inputs in components, check out this [example](/runtimes/inputs#nested-inputs).
+
+### Additional Resources
+
+For a complete example see the **getting-started** project in the [examples repository](https://github.com/rive-app/rive-unity-examples) and open the **StateMachineInputScene** scene. Enter **Play** mode and in the inspector on the **Main Camera** component, you can interact with all available state machine inputs for the provided animation.
+
+

--- a/game-runtimes/unity/layouts.mdx
+++ b/game-runtimes/unity/layouts.mdx
@@ -3,6 +3,8 @@ title: 'Layouts'
 description: 'Control the layout of your Rive animation in Unity'
 ---
 
+import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
 For more information on Rive Layout see the [runtime documentation](/runtimes/layout).
 
 <CardGroup col="auto">
@@ -19,7 +21,9 @@ For more information on Rive Layout see the [runtime documentation](/runtimes/la
         ![The Fit and Alignment dropdowns in the Unity inspector](/images/game-runtimes/unity/03086bad-8cd9-4cfc-8d23-03579ff93a00.webp)
 
     </Tab>
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+
+        <LegacyApiNotice />
 
         The **fit** and **alignment** can be controlled on the **Rive.Renderer** `.Align()` method:
 
@@ -98,7 +102,9 @@ The `Layout` **Fit** mode lets you display resizable artboards with built-in res
         In practice, you might use this factor to give yourself flexibility in adjusting the artboard size, even after choosing a particular scaling mode. For example, you might find that everything is slightly too large on mobile and set the Layout Scale Factor to 0.9 (90% of the scaled size).
     </Tab>
 
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+        <LegacyApiNotice />
+
         **Implementing Layout in Custom Scripts** 
 
         When implementing `Fit.Layout` in your custom scripts, consider the following aspects:

--- a/game-runtimes/unity/listeners.mdx
+++ b/game-runtimes/unity/listeners.mdx
@@ -3,6 +3,8 @@ title: 'Listeners'
 description: 'Enable listeners on your Rive animation in Unity'
 ---
 
+import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
 For more information on Rive Listeners see the [editor documentation](/editor/state-machine/listeners).
 
 <CardGroup col="auto">
@@ -43,7 +45,9 @@ For more information on Rive Listeners see the [editor documentation](/editor/st
 
     </Tab>
 
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+
+        <LegacyApiNotice />
 
         ## Pointer Positions
 

--- a/game-runtimes/unity/rive-events.mdx
+++ b/game-runtimes/unity/rive-events.mdx
@@ -1,9 +1,13 @@
 ---
 title: 'Rive Events'
 description: 'Access Rive Events in Unity.'
+noindex: true
 ---
 
+import LegacyDataBindingNotice from '/snippets/unity/legacy-databinding-notice.mdx';
 import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
+<LegacyDataBindingNotice subject="Events" />
 
 For more information on Rive Events see the respective runtime and editor documentation.
 

--- a/game-runtimes/unity/rive-events.mdx
+++ b/game-runtimes/unity/rive-events.mdx
@@ -3,6 +3,8 @@ title: 'Rive Events'
 description: 'Access Rive Events in Unity.'
 ---
 
+import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
 For more information on Rive Events see the respective runtime and editor documentation.
 
 <CardGroup col="2">
@@ -36,7 +38,9 @@ The following code demonstrates accessing all Rive events reported from an activ
         ```
     </Tab>
 
-    <Tab title="Low-level API">
+    <Tab title="Legacy API">
+
+        <LegacyApiNotice />
 
         ```csharp
         ...

--- a/game-runtimes/unity/state-machines.mdx
+++ b/game-runtimes/unity/state-machines.mdx
@@ -19,11 +19,11 @@ For more information on Rive State Machines see the respective [runtime](/runtim
 
 ## Overview
 
-A StateMachine contains [Inputs](/editor/state-machine/inputs) and [Events](/runtimes/rive-events) and advances (plays) an animation.
+A StateMachine advances (plays) animations in an Artboard.
 
 <Tabs>
   <Tab title="Components">
-    A **Rive Widget** automatically loads and advances the state machine from [your artboard configuration settings](/game-runtimes/unity/fundamentals#artboards). Here's how you can access the loaded state machine in your scripts:\*\*
+    A **Rive Widget** automatically loads and advances the state machine from [your artboard configuration settings](/game-runtimes/unity/fundamentals#artboards). Here's how you can access the loaded state machine in your scripts:
 
     ```csharp
     [SerializeField] private RiveWidget m_riveWidget;
@@ -76,93 +76,3 @@ A StateMachine contains [Inputs](/editor/state-machine/inputs) and [Events](/run
     ```
   </Tab>
 </Tabs>
-
-## Accessing Inputs
-
-There are three input types, each extends `SMIInput` (State Machine Input):
-
-- `SMIBool` contains a `.Value` property, a boolean that can be set to true or false.
-- `SMITrigger` is a boolean that is set to true for one frame by calling the `.Fire()` method.
-- `SMINumber` contains a `.Value` property, a float that can be set to any value.
-
-State machine inputs can be accessed in a number of different ways.
-
-#### Access by name
-
-Retrieve a state machine input by name and type.
-
-**Trigger:**
-
-```csharp
-SMITrigger someTrigger = m_stateMachine.GetTrigger("icon_02_press_trig");
-if (someTrigger != null)
-{
-    someTrigger.Fire();
-}
-```
-
-**Bool:**
-
-```csharp
-SMIBool someBool = m_stateMachine.GetBool("centerHover");
-if (someBool == null) return;
-Debug.Log(someBool.Value);
-someBool.Value = !someBool.Value;
-Debug.Log(someBool.Value);
-```
-
-**Number:**
-
-```csharp
-SMINumber someNumber = m_stateMachine.GetNumber("rating");
-if (someNumber == null) return;
-Debug.Log(someNumber.Value);
-someNumber.Value = 4;
-Debug.Log(someNumber.Value);
-```
-
-#### Access by index
-
-Get the input count (length) and retrieve by index:
-
-```csharp
-Debug.Log(m_stateMachine.InputCount());
-SMIInput input = m_stateMachine.Input(1);
-```
-
-#### Access all inputs
-
-Retrieve a list of all `SMIInputs`:
-
-```csharp
-var inputs = m_riveStateMachine.Inputs();
-foreach (var input in inputs)
-{
-    switch (input)
-    {
-        case SMITrigger smiTrigger:
-        {
-            // Do something
-            break;
-        }
-        case SMIBool smiBool:
-        {
-            // Do something
-            break;
-        }
-        case SMINumber smiNumber:
-        {
-            // Do something
-            break;
-        }
-    }
-}
-```
-
-## Accessing Nested Inputs
-
-For more information about accessing inputs in components, check out this [example](/runtimes/inputs#nested-inputs).
-
-### Additional Resources
-
-For a complete example see the **getting-started** project in the [examples repository](https://github.com/rive-app/rive-unity-examples) and open the **StateMachineInputScene** scene. Enter **Play** mode and in the inspector on the **Main Camera** component, you can interact with all available state machine inputs for the provided animation.

--- a/game-runtimes/unity/state-machines.mdx
+++ b/game-runtimes/unity/state-machines.mdx
@@ -2,6 +2,8 @@
 title: "State Machines"
 ---
 
+import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
+
 Interact with the Rive State Machine in Unity.
 
 For more information on Rive State Machines see the respective [runtime](/runtimes/state-machines) and [editor](/editor/state-machine) documentation.
@@ -49,7 +51,9 @@ A StateMachine contains [Inputs](/editor/state-machine/inputs) and [Events](/run
     }
     ```
   </Tab>
-  <Tab title="Low-level API">
+  <Tab title="Legacy API">
+    <LegacyApiNotice />
+    
     State Machines are instantiated from an Arboard instance:
 
     ```csharp

--- a/game-runtimes/unity/text.mdx
+++ b/game-runtimes/unity/text.mdx
@@ -1,7 +1,12 @@
 ---
 title: 'Text'
 description: ''
+noindex: true
 ---
+
+import LegacyDataBindingNotice from '/snippets/unity/legacy-databinding-notice.mdx';
+
+<LegacyDataBindingNotice subject="Text" />
 
 For more information on Rive Text see the respective runtime and editor documentation.
 

--- a/snippets/unity/legacy-api-notice.mdx
+++ b/snippets/unity/legacy-api-notice.mdx
@@ -1,3 +1,3 @@
 <Warning>
-Using the low-level API is no longer recommended. Please use the [Component API](/game-runtimes/unity/components) instead for ease of use and maintainability.
+Using the low-level API is no longer recommended. Please use the [Component API](/game-runtimes/unity/components) instead for ease of use and maintainability. This content is provided for legacy support only.
 </Warning>

--- a/snippets/unity/legacy-api-notice.mdx
+++ b/snippets/unity/legacy-api-notice.mdx
@@ -1,0 +1,3 @@
+<Warning>
+Using the low-level API is no longer recommended. Please use the [Component API](/game-runtimes/unity/components) instead for ease of use and maintainability.
+</Warning>

--- a/snippets/unity/legacy-databinding-notice.mdx
+++ b/snippets/unity/legacy-databinding-notice.mdx
@@ -1,0 +1,8 @@
+<Warning>
+  **DEPRECATION NOTICE:** This entire page documents the legacy {subject} system.
+  **For new projects:** Use [Data Binding](/game-runtimes/unity/data-binding) instead.
+  **For existing projects:** Plan to migrate from {subject} to Data Binding as soon
+  as possible. **This content is provided for legacy support only.**
+</Warning>
+
+


### PR DESCRIPTION
This PR updates mentions of the 'low-level API' in the Unity docs to say 'legacy API' instead. It also moves features like inputs and events to a 'Legacy' section in the Unity docs.