### PR TITLE
fix(db react native): trigger name in data binding code example

### DIFF
--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -1597,13 +1597,13 @@ You can observe changes over time to property values, either by using listeners 
 
     useEffect(() => {
         if (numberValue !== undefined) {
-        console.log('numberValue changed:', numberValue);
+            console.log('numberValue changed:', numberValue);
         }
     }, [numberValue]);
 
     const handleButtonPress = () => {
-        if (trigger) {
-            trigger();
+        if (triggerButton) {
+            triggerButton();
         }
     };
     ```


### PR DESCRIPTION

The trigger name in the example code was wrong. 

<img width="1386" height="1198" alt="CleanShot 2025-09-26 at 11 09 09@2x" src="https://github.com/user-attachments/assets/1ca679ca-3598-4127-9586-019c7b6cb43a" />
