### PR TITLE
Override Mintlify's new default iframe height

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -9,3 +9,8 @@ ul li {
 ol li {
   font-size: 14px;
 }
+
+iframe {
+  /* TO DO: This is a temp fix becuase Mintlify added h-full to all iframes */
+  height: 400px;
+}


### PR DESCRIPTION
Mintlify added `height: 100%` to all `iframe`'s. This overrides YouTube's default height. This makes some of our videos look squished (left), others disappear: 

<img width="4916" height="1496" alt="CleanShot 2025-09-29 at 13 00 33@2x" src="https://github.com/user-attachments/assets/f1111715-fad5-4881-ab2d-4609c2cc6a1c" />

This'll fix it while we're waiting for Mintlify to undo what they did. 