### PR TITLE
docs: revert "override Mintlify's new default iframe height"

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -9,8 +9,3 @@ ul li {
 ol li {
   font-size: 14px;
 }
-
-iframe {
-  /* TO DO: This is a temp fix becuase Mintlify added h-full to all iframes */
-  height: 400px;
-}


### PR DESCRIPTION
Reverts rive-app/rive-docs#233

I reported this to Mintlify yesterday and it looks like they've fixed it already. 