### PR TITLE
docs(unity): fix unity image databinding API reference

### DIFF
--- a/game-runtimes/unity/data-binding.mdx
+++ b/game-runtimes/unity/data-binding.mdx
@@ -26,7 +26,10 @@ The simplest way to use data binding is through the Unity Inspector. The **Rive 
 
 ## Usage Example
 
-Once your **Rive Widget** is bound to a view model instance, you can access and modify its properties from your Unity scripts. The following example shows how to get, set, and observe different types of properties:
+Once your **Rive Widget** is bound to a view model instance, you can access and modify its properties from your Unity scripts. The following example shows how to get, set, and observe different types of primitive properties.
+
+For a deeper understanding of data binding concepts and more advanced usage (e.g. databinding [lists](/runtimes/data-binding#lists) or [artboards](/runtimes/data-binding#artboards)), see the [Data Binding documentation](/runtimes/data-binding).
+
 
 ```csharp
 using UnityEngine;
@@ -176,6 +179,3 @@ Using the low-level API requires additional implementation effort and understand
 </Note>
 </Tab>
 </Tabs>
-
-For a deeper understanding of data binding concepts and more advanced usage, see the [Data Binding documentation](/runtimes/data-binding).
-

--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -1789,11 +1789,11 @@ Image properties let you set and replace raster images at runtime, with each ins
             // or alternatively:
             // imageProperty = viewModelInstance.GetProperty<ViewModelInstanceImageProperty>("profileImage");
 
-        // Set up change callback
-        imageProperty.OnValueChanged += OnImageChanged;
+            // Set up change callback
+            imageProperty.OnValueChanged += OnImageChanged;
 
-        // Set initial image (light mode)
-        imageProperty.Value = m_lightImageAsset;
+            // Set initial image (light mode)
+            imageProperty.Value = m_lightImageAsset;
         }
     }
 

--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -1789,11 +1789,11 @@ Image properties let you set and replace raster images at runtime, with each ins
             // or alternatively:
             // imageProperty = viewModelInstance.GetProperty<ViewModelInstanceImageProperty>("profileImage");
 
-            // Set up change callback
-            imageProperty.OnValueChanged += OnImageChanged;
+        // Set up change callback
+        imageProperty.OnValueChanged += OnImageChanged;
 
-            // Set initial image (light mode)
-            imageProperty.SetImage(m_lightImageAsset);
+        // Set initial image (light mode)
+        imageProperty.Value = m_lightImageAsset;
         }
     }
 
@@ -1802,22 +1802,22 @@ Image properties let you set and replace raster images at runtime, with each ins
         Debug.Log("Image updated!");
     }
 
-    // Example method to toggle between light and dark mode images
-    public void ToggleTheme()
+// Example method to toggle between light and dark mode images
+public void ToggleTheme()
+{
+    if (imageProperty != null)
     {
-        if (imageProperty != null)
-        {
-            isDarkMode = !isDarkMode;
-            imageProperty.SetImage(isDarkMode ? m_darkImageAsset : m_lightImageAsset);
-        }
+        isDarkMode = !isDarkMode;
+        imageProperty.Value = isDarkMode ? m_darkImageAsset : m_lightImageAsset;
     }
+}
 
     // Example method to clear the image
     public void ClearImage()
     {
         if (imageProperty != null)
         {
-            imageProperty.SetImage(null);
+            imageProperty.Value = null;
         }
     }
 


### PR DESCRIPTION
This PR updates the Unity docs to use the correct `Value` setter for image properties, replacing the older/temporary `SetImage()` method.

It also adds links to the main runtime docs for data binding with lists and artboards, since those aren’t currently referenced in the Unity example (which only covers simpler property types like strings and numbers).
