### PR TITLE
feat(Android): Update Android size numbers and guidance

### DIFF
--- a/runtimes/runtime-sizes.mdx
+++ b/runtimes/runtime-sizes.mdx
@@ -50,7 +50,7 @@ description: 'Last updated: October 2025'
           | Volley                                     | Network loading                |
 
       ## Amortization and R8
-      The sizes listed above reflect adding Rive to an otherwise empty application. Some of the above dependencies may already be present in your application, and so do not contribute to the size increase when adding Rive. For example, if your app already uses Jetpack Compose, the Compose dependencies will likely already be included in your app's binary.
+      The sizes listed above reflect adding Rive to an otherwise empty application. Some of the above dependencies may already be present in your application, and as a result do not contribute to the size increase when adding Rive. For example, if your app already uses Jetpack Compose, the Compose dependencies will likely already be included in your app's binary.
 
       The same is true for the C++ standard library, which will be shared across all dependencies with native code.
 


### PR DESCRIPTION
The new numbers reflect a real world use more closely, by doing Android App Bundle (.aab) difference for networked and APK difference for install size.

Includes:
- Reordered tabs to match other areas of the documentation
- Capitalized size suffixes