### PR TITLE
chore: docs for new scripting shortcuts

### DIFF
--- a/scripting/keyboard-shortcuts.mdx
+++ b/scripting/keyboard-shortcuts.mdx
@@ -14,6 +14,11 @@ Search & Navigation
 | **Move Caret by Subword**| <kbd>⌃</kbd> + <kbd>⌥</kbd> + <kbd>←</kbd>/<kbd>→</kbd> | — |
 | **Move Caret to Start/End** | <kbd>⌘</kbd> + <kbd>←</kbd>/<kbd>→</kbd> | <kbd>Ctrl</kbd> + <kbd>←</kbd>/<kbd>→</kbd> |
 | **Jump to Top/Bottom**   | <kbd>⌘</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>      | <kbd>Ctrl</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> |
+| **Close Tab**   | <kbd>⌘</kbd> + <kbd>W</kbd>      | <kbd>Ctrl</kbd> + <kbd>W</kbd> |
+| **Select Next Tab**   | <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>]</kbd>      | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd> |
+| **Select Previous Tab**   | <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>[</kbd>      | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd> |
+| **Show Tab Palette Next**   | <kbd>⌃</kbd> + <kbd>Tab</kbd>      | <kbd>Ctrl</kbd> + <kbd>Tab</kbd> |
+| **Show Tab Palette Previous**   | <kbd>⌃</kbd> + <kbd>↑</kbd> + <kbd>Tab</kbd>      | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> |
 
 Editing
 
@@ -23,6 +28,7 @@ Editing
 | **Toggle Comment**      | <kbd>⌘</kbd> + <kbd>/</kbd>                     | <kbd>Ctrl</kbd> + <kbd>/</kbd>       |
 | **Insert Line Below**   | <kbd>⌘</kbd> + <kbd>↩</kbd>                     | <kbd>Ctrl</kbd> + <kbd>Enter</kbd>   |
 | **Insert Line Above**   | <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>↩</kbd>      | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Enter</kbd> |
+| **Copy Line Up/Down**   | <kbd>⇧</kbd> + <kbd>⌥</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>                     | <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>   |
 | **Move Line(s) Up/Down**    | <kbd>⌥</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>          | <kbd>Alt</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> |
 | **Outdent**             | <kbd>⇧</kbd> + <kbd>Tab</kbd>                   | <kbd>Shift</kbd> + <kbd>Tab</kbd>    |
 | **Accept Autocomplete** | <kbd>↩</kbd> or <kbd>Tab</kbd>                  | <kbd>Enter</kbd> or <kbd>Tab</kbd>   |


### PR DESCRIPTION
Adds documentation for new shortcuts added in https://github.com/rive-app/rive/pull/11124