### PR TITLE
Update x component description in vector.mdx

### DIFF
--- a/scripting/api-reference/vector.mdx
+++ b/scripting/api-reference/vector.mdx
@@ -8,7 +8,6 @@ Represents a vector with x and y components.
 
 ### `x`
 
-Represents a vector with x and y components.
 The x component, note that this is read-only.
 
 ### `y`


### PR DESCRIPTION
Clarified the description of the x component.
the line "represents a vector with x and y components" explanation was duplicated in the x def