### PR TITLE
chore: add mintignore for github directory

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,1 +1,1 @@
-.github/
+.github


### PR DESCRIPTION
All PRs are failing because of "link rot" in the .github directory. This adds a mintignore file to ignore that directory. 