### PR TITLE
fix: use string URL directly with useRiveFile

### DIFF
--- a/runtimes/react-native/react-native.mdx
+++ b/runtimes/react-native/react-native.mdx
@@ -346,11 +346,11 @@ This guide documents how to get started using the Rive React Native runtime. The
     Hook for loading Rive files from a URL or local source:
 
     ```javascript
-    const { riveFile } = useRiveFile({
-      url: 'https://cdn.rive.app/animations/vehicles.riv',
-      // or
-      // source: require('./assets/graphic.riv'),
-    });
+    const { riveFile } = useRiveFile(
+      'https://cdn.rive.app/animations/vehicles.riv'
+    );
+    // or
+    // const { riveFile } = useRiveFile(require('./assets/graphic.riv'));
     ```
 
     See [loading Rive files](/runtimes/react-native/loading-rive-files) and [caching Rive files](/runtimes/caching-a-rive-file) for more information.

--- a/runtimes/state-machines.mdx
+++ b/runtimes/state-machines.mdx
@@ -117,9 +117,9 @@ Rive's state machines provide a way to combine a set of animation states and man
 
         ```ts
         export default function PlaybackExample() {
-          const { riveFile } = useRiveFile({
-            uri: 'https://cdn.rive.app/animations/vehicles.riv',
-          });
+          const { riveFile } = useRiveFile(
+            'https://cdn.rive.app/animations/vehicles.riv'
+          );
 
           return (
             <View style={styles.container}>
@@ -156,9 +156,9 @@ Rive's state machines provide a way to combine a set of animation states and man
 
         export default function PlaybackExample() {
           const { riveViewRef, setHybridRef } = useRive();
-          const { riveFile } = useRiveFile({
-            uri: 'https://cdn.rive.app/animations/vehicles.riv',
-          });
+          const { riveFile } = useRiveFile(
+            'https://cdn.rive.app/animations/vehicles.riv'
+          );
 
           const play = () => {
             riveViewRef?.play();


### PR DESCRIPTION
Update React Native examples to pass URL strings directly to `useRiveFile` instead of using object syntax.

Passing an inline object like `useRiveFile({ uri: '...' })` creates a new object reference on each render, which can cause infinite re-renders due to useEffect dependency changes.

The correct usage is:
```js
const { riveFile } = useRiveFile('https://cdn.rive.app/animations/vehicles.riv');
```

Instead of:
```js
const { riveFile } = useRiveFile({ uri: 'https://cdn.rive.app/animations/vehicles.riv' });
```

alternatives: 
- enabling react compiler
- using useMemo


Fixes: 
- See #https://github.com/rive-app/rive-nitro-react-native/issues/99
- https://rive.app/docs/runtimes/react-native/react-native#userivefile
- https://rive.app/docs/runtimes/state-machines#react-native