### PR TITLE
docs(react-native): add data binding artboards documentation

### DIFF
--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -3011,7 +3011,20 @@ Artboard properties allows you to swap out entire components at runtime. This is
   <Tab title="React Native">
     <Tabs>
       <Tab title="New Runtime (Recommended)">
-        <Note>Coming soon</Note>
+        <Info>
+          See the [React Native data binding artboards example](https://github.com/rive-app/rive-nitro-react-native/blob/main/example/src/pages/DataBindingArtboardsExample.tsx).
+        </Info>
+        Artboard properties work with the `BindableArtboard` class. Use `getBindableArtboard` on a `RiveFile` to create a bindable reference, then set it on the artboard property.
+
+        ```typescript
+        // Get artboard property from view model instance
+        const artboardProp = instance.artboardProperty('CharacterArtboard');
+
+        // Create a bindable artboard and set it
+        const bindableArtboard = riveFile.getBindableArtboard('Character 1');
+        artboardProp?.set(bindableArtboard);
+        ```
+
       </Tab>
       <Tab title="Legacy Runtime">
         <Warning>

--- a/snippets/demos.jsx
+++ b/snippets/demos.jsx
@@ -32,7 +32,8 @@ export const Demos = ({
         web: 'https://codesandbox.io/p/sandbox/rive-js-data-binding-artboards-jx3pf9?file=%2Fsrc%2Findex.mjs%3A5%2C19',
         react:
           'https://codesandbox.io/p/sandbox/rive-react-data-binding-artboards-kmvzh8?file=%2Fsrc%2FApp.tsx',
-        flutter: 'https://github.com/rive-app/rive-flutter/blob/master/example/lib/examples/databinding_artboards.dart'
+        flutter: 'https://github.com/rive-app/rive-flutter/blob/master/example/lib/examples/databinding_artboards.dart',
+        reactNative: 'https://github.com/rive-app/rive-nitro-react-native/blob/main/example/src/pages/DataBindingArtboardsExample.tsx'
       },
       source: [
         "https://rive.app/marketplace/24641-46042-data-binding-artboards/",


### PR DESCRIPTION
## Summary
- Add React Native code example for artboard data binding in the new runtime
- Add React Native link to the data binding artboards demo card

Related: https://github.com/rive-app/rive-nitro-react-native/pull/95