### PR TITLE
feat(Android): Update sizes to account for scripting

### DIFF
--- a/runtimes/runtime-sizes.mdx
+++ b/runtimes/runtime-sizes.mdx
@@ -30,8 +30,8 @@ description: 'Last updated: October 2025'
   <Tab title="Android">
       | Target  | Download Size | Install Size |
       | ------- | ------------- | ------------ |
-      | ARM-v8a | 2.39MB        | 6.58MB       |
-      | ARM-v7a | 2.31MB        | 5.67MB       |
+      | ARM-v8a | 2.40MB        | 7.03MB       |
+      | ARM-v7a | 2.32MB        | 6.00MB       |
 
       ## Components
       Rive Android's binary size is comprised of a number of components:


### PR DESCRIPTION
Re-running size calculations on the new Android runtime with scripting included. The size doesn't seem to increase much, mostly because the size without scripting seems to have gone down, which I can't explain.