### PR TITLE
docs(unity): update image and artboard databinding event handlers

### DIFF
--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -2215,15 +2215,15 @@ Image properties let you set and replace raster images at runtime, with each ins
         Debug.Log("Image updated!");
     }
 
-// Example method to toggle between light and dark mode images
-public void ToggleTheme()
-{
-    if (imageProperty != null)
+    // Example method to toggle between light and dark mode images
+    public void ToggleTheme()
     {
-        isDarkMode = !isDarkMode;
-        imageProperty.Value = isDarkMode ? m_darkImageAsset : m_lightImageAsset;
+        if (imageProperty != null)
+        {
+            isDarkMode = !isDarkMode;
+            imageProperty.Value = isDarkMode ? m_darkImageAsset : m_lightImageAsset;
+        }
     }
-}
 
     // Example method to clear the image
     public void ClearImage()


### PR DESCRIPTION
This PR updates the unity data binding docs to use the correct event handlers when subscribing to artboard or image property changes. The event handlers in the recent Unity package releases no longer include the updated property values, so this PR updates the docs to reflect that.