### PR TITLE
docs(ai): deprecate mcp

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -232,13 +232,7 @@
                   "editor/share-links/framer-and-rive"
                 ]
               },
-              {
-                "group": "AI",
-                "pages": [
-                  "editor/ai-agent/ai-agent",
-                  "editor/mcp/integration"
-                ]
-              },
+              "editor/ai-agent/ai-agent",
               "editor/tagging"
             ]
           }

--- a/editor/mcp/integration.mdx
+++ b/editor/mcp/integration.mdx
@@ -5,9 +5,9 @@ sidebarTitle: "MCP Integration"
 
 import { EarlyAccess } from '/snippets/early-access.mdx'
 
-<EarlyAccess featureName="MCP">
-   MCP Integration is initially available in the Early Access version of the Mac Desktop app. Windows support is coming.
-</EarlyAccess>
+<Warning>
+   MCP Integration was an experimental feature and is deprecated. Please use the [AI Agent](/editor/ai-agent/) instead.
+</Warning>
 
 ## Getting started
 
@@ -83,7 +83,7 @@ Once Cursor is installed and everything is set up correctly, it's time to start 
   </Step>
   <Step title="Enter your prompt">
     Type your prompt into the chat UI and hit enter. The AI will take a moment to process the request.
-    
+
     Example prompt:
     ```
     Create a State Machine about birds with 20 states and 2 layers


### PR DESCRIPTION
<img width="1628" height="402" alt="CleanShot 2026-01-20 at 21 12 11@2x" src="https://github.com/user-attachments/assets/ae68036b-6d8b-4727-81fe-455e936555c0" />

This cleans up the sidebar so it says "AI Agent", rather than "AI"

<img width="570" height="466" alt="CleanShot 2026-01-20 at 21 12 23@2x" src="https://github.com/user-attachments/assets/ff1adb42-cda7-4133-9fe0-fe6cf38d0b31" />
