### PR TITLE
docs(react): recommend webgl2

### DIFF
--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'React'
-description: 'React runtime for Rive. '
+description: 'React runtime for Rive.'
 ---
 
 import NoteOnFeatureSupport from "/snippets/runtimes/rendering-feature-support.mdx"
@@ -14,7 +14,7 @@ import { Demos } from '/snippets/demos.jsx'
 
 This guide documents how to get started using the React runtime library. Rive runtime libraries are open-source. The source is available in its [GitHub repository](https://github.com/rive-app/rive-react).
 
-This library contains a React component, as well as custom hooks to help integrate Rive into your web application (types included). Under the hood, this runtime is a React-friendly wrapper around the `@rive-app/canvas` runtime, exposing types, and Rive instance functionality.
+This library contains a React component, as well as custom hooks to help integrate Rive into your web application (types included). Under the hood, this runtime is a React-friendly wrapper around the `@rive-app/webgl2` runtime, exposing types, and Rive instance functionality.
 
 ## Getting Started
 
@@ -24,24 +24,27 @@ Follow the steps below for a quick start on integrating Rive into your React app
   <Step title="Install the dependency">
     The Rive React runtime allows for two main options based on which backing renderer you need.
 
-    - **(Recommended)** `@rive-app/react-canvas` - Wraps the `@rive-app/canvas` dependency. Unless you specifically need a `WebGL` backing renderer, we recommend you use this dependency when using Rive in your apps for quick and fast usage.
-    - `@rive-app/react-canvas-lite` - Similar to `@rive-app/react-canvas`, but [smaller](/runtimes/web/canvas-vs-webgl). This is recommended if the Rive graphic does not use [Rive Text](/editor/text/)
-    - `@rive-app/react-webgl` - Wraps the `@rive-app/webgl` dependency. In the future, we may have advanced rendering features that are only supported by using `WebGL`. At the moment, however, due to the size of the dependency (with Skia), we do not recommend it unless you have specific needs here. We are currently working on improving the performance and size with the [Rive Renderer](https://rive.app/renderer).
-    - `@rive-app/react-webgl2` - Wraps the `@rive-app/webgl2` dependency. It uses the Rive Renderer with a WebGL2 context and has a much smaller build size than `rive-app/react-webgl`. In a future major release, this package may be deprecated, and `@rive-app/react-webgl` will make use of the Rive Renderer completely, without an added Skia dependency.
+    - **(Recommended)** `@rive-app/react-webgl2` - Wraps the `@rive-app/webgl2` dependency, which uses the Rive Renderer.
+    - `@rive-app/react-canvas` - Wraps the `@rive-app/canvas` dependency. This does not utilize the Rive Renderer and doesn't support advanced features, like Vector Feathering.
+    - `@rive-app/react-canvas-lite` - Similar to `@rive-app/react-canvas`, but [smaller](/runtimes/web/canvas-vs-webgl). This is not recommended if the Rive file uses [Rive Text](/editor/text/) or other advanced features.
 
     <Note>
-    To take advantage of trying out the Rive Renderer with react-webgl2 , you should [enable the draft](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome) `WEBGL_shader_pixel_local_storage` Chrome Extension (by adding WebGL Draft Extensions), otherwise, Rive will fall back to an MSAA solution (also with WebGL2) on browsers without the extension support. Current work is underway with major browsers to support this extension by default in consumer's browsers.
+    To take advantage of the full performance benefits of the Rive Renderer with `react-webgl2`, [enable the draft](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome) `WEBGL_shader_pixel_local_storage` Chrome Extension (by adding WebGL Draft Extensions).
+
+    If the draft extension is disabled on a user's device, Rive will fall back to an MSAA solution (also with WebGL2) on browsers without the extension support.
+
+    Current work is underway with major browsers to support this extension by default in consumer's browsers.
     </Note>
 
     ```bash
-    npm i --save @rive-app/react-canvas
+    npm i --save @rive-app/react-webgl2
     ```
   </Step>
   <Step title="Render the Rive component">
     Rive React provides a basic component as its default import for displaying simple animations with a few props you can set such as artboard and layout. Include the code below in your React project to test out an example Rive animation.
 
     ```javascript
-    import Rive from '@rive-app/react-canvas';
+    import Rive from '@rive-app/react-webgl2';
 
     export const Simple = () => (
       <Rive
@@ -64,7 +67,7 @@ Follow the steps below for a quick start on integrating Rive into your React app
     The `useRive` hook returns both this `rive` instance, as well as the React component that mounts the underlying `<canvas>` element that Rive will draw onto.
 
     ```javascript
-    import { useRive } from '@rive-app/react-canvas';
+    import { useRive } from '@rive-app/react-webgl2';
 
     export default function Simple() {
       const { rive, RiveComponent } = useRive({


### PR DESCRIPTION
Recommend using webgl2 over canvas. Rework the section on the draft extension to make it clear that this is for better performance, not required to run webgl2. 