### PR TITLE
docs(unity): specify minimum version for scripting support

### DIFF
--- a/snippets/features-support.mdx
+++ b/snippets/features-support.mdx
@@ -26,7 +26,7 @@ We may include notes on migrating to newer versions if a new feature warrants re
         | Apple | ✅ `v6.13.0+` |
         | Android | ✅ `v11.1.0+` |
         | C++ | ✅ Supported |
-        | Unity | Not yet supported |
+        | Unity |  ✅ `v0.4.1-canary.33+` |
         | Unreal | ✅ `v0.4.20+` |
     </Accordion>
     <Accordion title="Data Binding - Lists, Images, and Artboards">


### PR DESCRIPTION
This PR updates the Feature Support page to include the minimum version of the package that supports scripting.