### PR TITLE
docs: replace intro vid with quickstart

### DIFF
--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -5,7 +5,7 @@ description: "Welcome to the Rive Docs. We've split this documentation into the 
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-<YouTube id="mMpik32gkt4" />
+<YouTube id="wnwA0izJo4E" />
 
 ## Getting Started
 


### PR DESCRIPTION
Replaces the old intro video on the Rive intro page with the new Quick Start tutorial: https://www.youtube.com/watch?v=wnwA0izJo4E&t=405s