### PR TITLE
docs(unity): add bindable artboard vmi example

### DIFF
--- a/runtimes/data-binding.mdx
+++ b/runtimes/data-binding.mdx
@@ -3619,7 +3619,7 @@ Artboard properties allows you to swap out entire components at runtime. This is
     }
     ```
 
-    ### Using Custom ViewModelInstances with Bindable Artboards
+    ### Using Custom View Model Instances with Bindable Artboards
 
     You can link a custom `ViewModelInstance` to a bindable artboard, giving you control over the data being used by that artboard.
 


### PR DESCRIPTION
Updates Unity data binding documentation to cover the new `File.BindableArtboard(name, viewModelInstance)` overload. Also adds a **Featured Content Slot** example demonstrating how to populate UI slots with different artboards, each using unique data structures.