### PR TITLE
docs (scripting api): move api to its own sidebar group

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -277,120 +277,120 @@
                   "scripting/debugging/unit-testing"
                 ]
               },
-              "scripting/keyboard-shortcuts",
+              "scripting/keyboard-shortcuts"
+            ]
+          },
+          {
+            "group": "Scripting API",
+            "pages": [
               {
-                "group": "Scripting API",
+                "group": "Artboards",
                 "pages": [
-                  {
-                    "group": "Artboards",
-                    "pages": [
-                      "scripting/api-reference/artboards/animation",
-                      "scripting/api-reference/artboards/artboard",
-                      "scripting/api-reference/artboards/node-data",
-                      "scripting/api-reference/artboards/node-read-data",
-                      "scripting/api-reference/artboards/pointer-event",
-                      "scripting/api-reference/artboards/view-model"
-                    ]
-                  },
-                  {
-                    "group": "Color",
-                    "pages": [
-                      "scripting/api-reference/color/color"
-                    ]
-                  },
-                  {
-                    "group": "DataValue",
-                    "pages": [
-                      "scripting/api-reference/data-value/data-value",
-                      "scripting/api-reference/data-value/data-value-boolean",
-                      "scripting/api-reference/data-value/data-value-color",
-                      "scripting/api-reference/data-value/data-value-number",
-                      "scripting/api-reference/data-value/data-value-string",
-                      "scripting/api-reference/data-value/listener",
-                      "scripting/api-reference/data-value/property",
-                      "scripting/api-reference/data-value/property-trigger"
-                    ]
-                  },
-                  {
-                    "group": "Gradient",
-                    "pages": [
-                      "scripting/api-reference/gradient/gradient",
-                      "scripting/api-reference/gradient/gradient-stop"
-                    ]
-                  },
-                  {
-                    "group": "Image",
-                    "pages": [
-                      "scripting/api-reference/image/image",
-                      "scripting/api-reference/image/image-filter",
-                      "scripting/api-reference/image/image-sampler",
-                      "scripting/api-reference/image/image-wrap"
-                    ]
-                  },
-                  {
-                    "group": "Interfaces",
-                    "pages": [
-                      "scripting/api-reference/interfaces/audio-sound",
-                      "scripting/api-reference/interfaces/audio-source",
-                      "scripting/api-reference/interfaces/blob",
-                      "scripting/api-reference/interfaces/context",
-                      "scripting/api-reference/interfaces/converter",
-                      "scripting/api-reference/interfaces/data-context",
-                      "scripting/api-reference/interfaces/enum-values",
-                      "scripting/api-reference/interfaces/input",
-                      "scripting/api-reference/interfaces/layout",
-                      "scripting/api-reference/interfaces/listener-action",
-                      "scripting/api-reference/interfaces/node",
-                      "scripting/api-reference/interfaces/output",
-                      "scripting/api-reference/interfaces/path-effect",
-                      "scripting/api-reference/interfaces/property-enum",
-                      "scripting/api-reference/interfaces/property-list",
-                      "scripting/api-reference/interfaces/property-view-model",
-                      "scripting/api-reference/interfaces/transition-condition",
-                      "scripting/api-reference/interfaces/trigger",
-                      "scripting/api-reference/interfaces/view-model"
-                    ]
-                  },
-                  {
-                    "group": "Mat2d",
-                    "pages": [
-                      "scripting/api-reference/mat2d/mat2d"
-                    ]
-                  },
-                  {
-                    "group": "Paint",
-                    "pages": [
-                      "scripting/api-reference/paint/paint",
-                      "scripting/api-reference/paint/blend-mode",
-                      "scripting/api-reference/paint/paint-definition",
-                      "scripting/api-reference/paint/paint-style",
-                      "scripting/api-reference/paint/stroke-cap",
-                      "scripting/api-reference/paint/stroke-join"
-                    ]
-                  },
-                  {
-                    "group": "Path",
-                    "pages": [
-                      "scripting/api-reference/path/path",
-                      "scripting/api-reference/path/command-type",
-                      "scripting/api-reference/path/contour-measure",
-                      "scripting/api-reference/path/path-command",
-                      "scripting/api-reference/path/path-data",
-                      "scripting/api-reference/path/path-measure"
-                    ]
-                  },
-                  {
-                    "group": "Renderer",
-                    "pages": [
-                      "scripting/api-reference/renderer/renderer"
-                    ]
-                  },
-                  {
-                    "group": "Vec2d",
-                    "pages": [
-                      "scripting/api-reference/vec2d/vector"
-                    ]
-                  }
+                  "scripting/api-reference/artboards/animation",
+                  "scripting/api-reference/artboards/artboard",
+                  "scripting/api-reference/artboards/node-data",
+                  "scripting/api-reference/artboards/node-read-data",
+                  "scripting/api-reference/artboards/pointer-event",
+                  "scripting/api-reference/artboards/view-model"
+                ]
+              },
+              {
+                "group": "Color",
+                "pages": [
+                  "scripting/api-reference/color/color"
+                ]
+              },
+              {
+                "group": "DataValue",
+                "pages": [
+                  "scripting/api-reference/data-value/data-value",
+                  "scripting/api-reference/data-value/data-value-boolean",
+                  "scripting/api-reference/data-value/data-value-color",
+                  "scripting/api-reference/data-value/data-value-number",
+                  "scripting/api-reference/data-value/data-value-string",
+                  "scripting/api-reference/data-value/listener",
+                  "scripting/api-reference/data-value/property",
+                  "scripting/api-reference/data-value/property-trigger"
+                ]
+              },
+              {
+                "group": "Gradient",
+                "pages": [
+                  "scripting/api-reference/gradient/gradient",
+                  "scripting/api-reference/gradient/gradient-stop"
+                ]
+              },
+              {
+                "group": "Image",
+                "pages": [
+                  "scripting/api-reference/image/image",
+                  "scripting/api-reference/image/image-filter",
+                  "scripting/api-reference/image/image-sampler",
+                  "scripting/api-reference/image/image-wrap"
+                ]
+              },
+              {
+                "group": "Interfaces",
+                "pages": [
+                  "scripting/api-reference/interfaces/audio-sound",
+                  "scripting/api-reference/interfaces/audio-source",
+                  "scripting/api-reference/interfaces/blob",
+                  "scripting/api-reference/interfaces/context",
+                  "scripting/api-reference/interfaces/converter",
+                  "scripting/api-reference/interfaces/data-context",
+                  "scripting/api-reference/interfaces/enum-values",
+                  "scripting/api-reference/interfaces/input",
+                  "scripting/api-reference/interfaces/layout",
+                  "scripting/api-reference/interfaces/listener-action",
+                  "scripting/api-reference/interfaces/node",
+                  "scripting/api-reference/interfaces/output",
+                  "scripting/api-reference/interfaces/path-effect",
+                  "scripting/api-reference/interfaces/property-enum",
+                  "scripting/api-reference/interfaces/property-list",
+                  "scripting/api-reference/interfaces/property-view-model",
+                  "scripting/api-reference/interfaces/transition-condition",
+                  "scripting/api-reference/interfaces/trigger",
+                  "scripting/api-reference/interfaces/view-model"
+                ]
+              },
+              {
+                "group": "Mat2d",
+                "pages": [
+                  "scripting/api-reference/mat2d/mat2d"
+                ]
+              },
+              {
+                "group": "Paint",
+                "pages": [
+                  "scripting/api-reference/paint/paint",
+                  "scripting/api-reference/paint/blend-mode",
+                  "scripting/api-reference/paint/paint-definition",
+                  "scripting/api-reference/paint/paint-style",
+                  "scripting/api-reference/paint/stroke-cap",
+                  "scripting/api-reference/paint/stroke-join"
+                ]
+              },
+              {
+                "group": "Path",
+                "pages": [
+                  "scripting/api-reference/path/path",
+                  "scripting/api-reference/path/command-type",
+                  "scripting/api-reference/path/contour-measure",
+                  "scripting/api-reference/path/path-command",
+                  "scripting/api-reference/path/path-data",
+                  "scripting/api-reference/path/path-measure"
+                ]
+              },
+              {
+                "group": "Renderer",
+                "pages": [
+                  "scripting/api-reference/renderer/renderer"
+                ]
+              },
+              {
+                "group": "Vec2d",
+                "pages": [
+                  "scripting/api-reference/vec2d/vector"
                 ]
               }
             ]


### PR DESCRIPTION
This PR only changes the organization of the sidebar by moving Scripting API to its own group - it doesn't add, move or remove content. All page urls stay the same. 

This makes it easier to see what section you're in. Before it was too easy to accidentally go into or out of the scripting docs without realizing it. 

This should not affect the auto-documentation generator in the `rive` repo. 

## Before/After:

<img width="783" height="1332" alt="CleanShot 2026-02-17 at 11 00 58 2" src="https://github.com/user-attachments/assets/34558176-6fc5-410d-9844-259dd733b0a2" />

