### PR TITLE
docs: add RiveCMP community runtime

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -632,7 +632,8 @@
                 "group": "Community Runtimes",
                 "pages": [
                   "runtimes/community-runtimes/c-sharp",
-                  "runtimes/community-runtimes/qt-quick"
+                  "runtimes/community-runtimes/qt-quick",
+                  "runtimes/community-runtimes/rive-cmp"
                 ]
               }
             ]

--- a/runtimes/community-runtimes/rive-cmp.mdx
+++ b/runtimes/community-runtimes/rive-cmp.mdx
@@ -1,0 +1,10 @@
+---
+title: 'RiveCMP'
+description: 'A Compose Multiplatform wrapper library for integrating Rive animations'
+---
+
+<Note>This is not a Rive owned or maintained project.</Note>
+
+This library provides a unified API to use rive-android, rive-ios, and @rive-app/canvas seamlessly across Android, iOS, and Web platforms in Compose Multiplatform.
+
+See the [GitHub repository](https://github.com/muazkadan/Rive-CMP) for additional information.

--- a/runtimes/getting-started.mdx
+++ b/runtimes/getting-started.mdx
@@ -148,6 +148,7 @@ Check out the runtime subpages for steps on how to get started!
 | --- | --- | --- |
 | QtQuick | [basysKom](https://github.com/basysKom) | [Github](https://github.com/basysKom/RiveQtQuickPlugin) |
 | UWP (C#) | Windows Community Toolkit | [Github](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/RivePlayer/samples/RivePlayer.md) |
+| RiveCMP | [muazkadan](https://github.com/muazkadan) | [Github](https://github.com/muazkadan/Rive-CMP/blob/main/README.md) |
 
 
 ## Handling .riv files


### PR DESCRIPTION
Adds RiveCMP, a Compose Multiplatform wrapper library, to the community runtimes documentation and navigation.