### PR TITLE
docs: add tracking to links

### DIFF
--- a/account-admin/account-overview/account-management.mdx
+++ b/account-admin/account-overview/account-management.mdx
@@ -2,7 +2,7 @@
 title: "Account Management"
 ---
 
-Your account settings live at [rive.app/account](https://rive.app/account).
+Your account settings live at [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content).
 
 You can also get there by clicking your name (top-left corner) → Manage Account.
 

--- a/account-admin/account-overview/billing-changes.mdx
+++ b/account-admin/account-overview/billing-changes.mdx
@@ -7,7 +7,7 @@ description: "How to update your card, change your plan, or manage billing for y
 
 ## Where to Manage Billing
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find your workspace under "Workspaces"
 3. Click "Manage Workspace"
 

--- a/account-admin/account-overview/cancel-my-account.mdx
+++ b/account-admin/account-overview/cancel-my-account.mdx
@@ -2,7 +2,7 @@
 title: "Cancel My Subscription"
 ---
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find the workspace in the left sidebar
 3. Click "Manage Workspace"
 4. Click "Cancel Plan"

--- a/account-admin/account-overview/creating-an-account.mdx
+++ b/account-admin/account-overview/creating-an-account.mdx
@@ -2,7 +2,7 @@
 title: "Creating an Account"
 ---
 
-1. Go to [rive.app](http://rive.app?utm_source=docs&utm_medium=content)
+1. Go to [rive.app](https://rive.app?utm_source=docs&utm_medium=content)
 2. Click "Get Started" (top-right corner)
 3. Enter your email and a secure password
 4. Answer the role question

--- a/account-admin/account-overview/creating-an-account.mdx
+++ b/account-admin/account-overview/creating-an-account.mdx
@@ -2,7 +2,7 @@
 title: "Creating an Account"
 ---
 
-1. Go to [rive.app](http://rive.app)
+1. Go to [rive.app](http://rive.app?utm_source=docs&utm_medium=content)
 2. Click "Get Started" (top-right corner)
 3. Enter your email and a secure password
 4. Answer the role question

--- a/account-admin/account-overview/delete-my-account.mdx
+++ b/account-admin/account-overview/delete-my-account.mdx
@@ -7,7 +7,7 @@ description: "Deleting your account is permanent and removes all your data after
 
 You need to remove all workspaces from your account first:
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. For each workspace you own:
    - Click "Manage Workspace"
    - If it's a paid plan, click "Cancel Plan" first

--- a/account-admin/account-overview/downloading-my-receipt-or-invoice.mdx
+++ b/account-admin/account-overview/downloading-my-receipt-or-invoice.mdx
@@ -4,7 +4,7 @@ title: "Downloading My Receipt/Invoice"
 
 Invoice links in email expire after about a week. If your link no longer works, you can always download invoices directly from your account.
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find the workspace in the left sidebar
 3. Click "Manage Workspace"
 4. Click "Manage Billing" (opens Stripe)

--- a/account-admin/bring-your-own-bucket.mdx
+++ b/account-admin/bring-your-own-bucket.mdx
@@ -4,7 +4,7 @@ description: "Configure your own AWS S3 bucket to work with Rive"
 ---
 
 <Note>
-This feature is available exclusively to Enterprise plan customers. If you're interested in upgrading to unlock this capability, [contact us](https://rive.app/enterprise).
+This feature is available exclusively to Enterprise plan customers. If you're interested in upgrading to unlock this capability, [contact us](https://rive.app/enterprise?utm_source=docs&utm_medium=content).
 </Note>
 
 ## What is a Custom S3 Bucket?

--- a/account-admin/pricing.mdx
+++ b/account-admin/pricing.mdx
@@ -2,7 +2,7 @@
 title: "Pricing"
 ---
 
-For full details and feature comparison, see [rive.app/pricing](https://rive.app/pricing).
+For full details and feature comparison, see [rive.app/pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).
 
 ## Plans
 

--- a/account-admin/workspaces/creating-a-workspace.mdx
+++ b/account-admin/workspaces/creating-a-workspace.mdx
@@ -26,7 +26,7 @@ Invitations are emailed immediately.
 
 **From the website:**
 
-1. Go to [rive.app/pricing](https://rive.app/pricing)
+1. Go to [rive.app/pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content)
 2. Select a plan and click "Get Started"
 3. Choose your tier and billing cycle
 4. Click "Confirm & Pay"

--- a/account-admin/workspaces/inviting-workspace-members.mdx
+++ b/account-admin/workspaces/inviting-workspace-members.mdx
@@ -12,7 +12,7 @@ title: "Inviting Workspace Members"
 
 ## How to Invite
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find the workspace in the left sidebar
 3. Click "Manage Workspace"
 4. Click "Invite Members"
@@ -26,7 +26,7 @@ You can also invite directly from the editor: click "Manage Workspace" in the ri
 
 **Can't invite someone?**
 
-Check that you've verified your email address. Go to [rive.app/account](https://rive.app/account) → Profile tab → click "Resend verification email" on the right if needed.
+Check that you've verified your email address. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content) → Profile tab → click "Resend verification email" on the right if needed.
 
 ---
 

--- a/account-admin/workspaces/reactivating-a-canceled-workspace.mdx
+++ b/account-admin/workspaces/reactivating-a-canceled-workspace.mdx
@@ -3,7 +3,7 @@ title: "Reactivating a Canceled Workspace"
 description: "If your workspace was canceled but not deleted, you can reactivate it."
 ---
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find the canceled workspace in the left sidebar (status shows "Suspended")
 3. Click "Manage Workspace"
 4. Click "Reactivate Plan"

--- a/account-admin/workspaces/removing-workspace-members.mdx
+++ b/account-admin/workspaces/removing-workspace-members.mdx
@@ -4,7 +4,7 @@ title: "Removing Workspace Members"
 
 Admins can remove members from a workspace at any time.
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find the workspace in the left sidebar
 3. Click "Manage Workspace"
 4. Find the member you want to remove
@@ -14,6 +14,6 @@ You can also leave a workspace yourself from this page.
 
 **Can't remove someone?**
 
-Check that you've verified your email address. Go to [rive.app/account](https://rive.app/account) → Profile tab → click "Resend verification email" on the right if needed.
+Check that you've verified your email address. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content) → Profile tab → click "Resend verification email" on the right if needed.
 
 **Note:** The workspace owner cannot be removed. If you need to change ownership, contact [support@rive.app](mailto:support@rive.app).

--- a/community/marketplace-overview.mdx
+++ b/community/marketplace-overview.mdx
@@ -3,7 +3,7 @@ title: 'Marketplace Overview'
 description: ''
 ---
 
-The [Rive Marketplace](https://rive.app/marketplace/) is a place where creators can share their files, get feedback, and learn by opening others’ files directly in the Rive editor.
+The [Rive Marketplace](https://rive.app/marketplace?utm_source=docs&utm_medium=content) is a place where creators can share their files, get feedback, and learn by opening others’ files directly in the Rive editor.
 
 Marketplace files are all shared under a [CC BY](https://creativecommons.org/licenses/by/4.0/) license.
 

--- a/docs.json
+++ b/docs.json
@@ -639,7 +639,7 @@
   "logo": {
     "light": "/logo/rive_top_logo_black.svg",
     "dark": "/logo/rive_top_logo_white.svg",
-    "href": "https://rive.app/"
+    "href": "https://rive.app?utm_source=docs&utm_medium=header_nav"
   },
   "appearance": {
     "default": "dark"
@@ -655,13 +655,13 @@
       },
       {
         "label": "Support",
-        "href": "https://community.rive.app/"
+        "href": "https://community.rive.app?utm_source=docs&utm_medium=header_nav"
       }
     ],
     "primary": {
       "type": "button",
       "label": "Get Rive",
-      "href": "https://rive.app/downloads"
+      "href": "https://rive.app/downloads?utm_source=docs&utm_medium=header_nav"
     }
   },
   "footer": {
@@ -678,19 +678,19 @@
         "items": [
           {
             "label": "Community",
-            "href": "https://community.rive.app/"
+            "href": "https://community.rive.app?utm_source=docs&utm_medium=footer_nav"
           },
           {
             "label": "Blog",
-            "href": "https://rive.app/blog"
+            "href": "https://rive.app/blog?utm_source=docs&utm_medium=footer_nav"
           },
           {
             "label": "Case Studies",
-            "href": "https://rive.app/blog/case-studies"
+            "href": "https://rive.app/blog/case-studies?utm_source=docs&utm_medium=footer_nav"
           },
           {
             "label": "Marketplace",
-            "href": "https://rive.app/marketplace"
+            "href": "https://rive.app/marketplace?utm_source=docs&utm_medium=footer_nav"
           },
           {
             "label": "Feature Requests",
@@ -703,7 +703,7 @@
         "items": [
           {
             "label": "Careers",
-            "href": "https://rive.app/careers"
+            "href": "https://rive.app/careers?utm_source=docs&utm_medium=footer_nav"
           },
           {
             "label": "Terms of Service",

--- a/editor/ai-agent/ai-agent.mdx
+++ b/editor/ai-agent/ai-agent.mdx
@@ -3,7 +3,7 @@ title: "AI Agent"
 description: "Rive's AI agent helps you write code, design, and animate."
 ---
 
-<Note>The AI Agent is available with Cadet, Voyager, and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>The AI Agent is available with Cadet, Voyager, and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 Rive's AI agent helps you write code, design, and animate. Generate scripts, responsive layouts, data models, and even animation.
 
@@ -38,5 +38,5 @@ Use the AI Agent toolbar to manage your conversations:
 
 ## FAQ
 
-For common questions, see the [Rive AI Agent FAQ](https://rive.app/blog/rive-ai-coding-agent-faq)
+For common questions, see the [Rive AI Agent FAQ](https://rive.app/blog/rive-ai-coding-agent-faq?utm_source=docs&utm_medium=content)
  on the Rive Blog.

--- a/editor/animate-mode/animating-draw-order.mdx
+++ b/editor/animate-mode/animating-draw-order.mdx
@@ -15,7 +15,7 @@ You can change the draw order of your graphics at design time by moving items up
 To animate the draw order of a group or shape, start by selecting it. Use the Draw Order section of the Inspector to create Draw Order Rules.
 
 <Marketplace
-  href="https://rive.app/community/files/26116-48795-animating-draw-order?utm_source=docs&utm_medium=content"
+  href="https://rive.app/community/files/26116-48795-animating-draw-order"
 />
 
 ![Image](/images/editor/animate-mode/426adab7-b1d3-47bc-bc42-c5cc397fa9d6.webp)

--- a/editor/animate-mode/animating-draw-order.mdx
+++ b/editor/animate-mode/animating-draw-order.mdx
@@ -15,7 +15,7 @@ You can change the draw order of your graphics at design time by moving items up
 To animate the draw order of a group or shape, start by selecting it. Use the Draw Order section of the Inspector to create Draw Order Rules.
 
 <Marketplace
-  href="https://rive.app/community/files/26116-48795-animating-draw-order"
+  href="https://rive.app/community/files/26116-48795-animating-draw-order?utm_source=docs&utm_medium=content"
 />
 
 ![Image](/images/editor/animate-mode/426adab7-b1d3-47bc-bc42-c5cc397fa9d6.webp)

--- a/editor/embed-urls/overview.mdx
+++ b/editor/embed-urls/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: 'Overview'
 description: 'Embed URLs are a fast, no-code way to share or embed your Rive files on the web.'
 ---
 
-<Note>Generating embed URLs is available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Generating embed URLs is available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 Embed URLs let you quickly generate a public version of your file for embedding or sharing.
 
@@ -47,7 +47,7 @@ Unlike [inviting someone to collaborate](/account-admin/workspaces/inviting-work
 - **Rive Renderer** — Use the Rive Renderer (recommended) or Canvas renderer.
 - **Multi-touch** — Enable support for multi-touch interactions.
 
-<Note>Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering), are only available using the Rive Renderer. See our [Feature Support](/feature-support) page for more information.</Note>
+<Note>Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content), are only available using the Rive Renderer. See our [Feature Support](/feature-support) page for more information.</Note>
 
 
 ## Sharing on Social Media
@@ -58,4 +58,4 @@ Unlike [inviting someone to collaborate](/account-admin/workspaces/inviting-work
 
 ## Managing embed URLs
 
-Visit the [Embed URLs](https://rive.app/account/links/) section of your settings to manage the links you've generated. You can disable an embed URL by setting its Active toggle to off.
+Visit the [Embed URLs](https://rive.app/account/links?utm_source=docs&utm_medium=content) section of your settings to manage the links you've generated. You can disable an embed URL by setting its Active toggle to off.

--- a/editor/events/audio-events.mdx
+++ b/editor/events/audio-events.mdx
@@ -59,7 +59,7 @@ Like other asset formats, you can configure export options for your audio assets
 
 <Info>Assets hosted on Rive's CDN can be accessed by anyone with the link.</Info>
 
-<Note>Hosted assets are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Hosted assets are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 **Format:** choose to export your audio file as a `.wav`, `.flac`, or `.mp3`.
 

--- a/editor/exporting/exporting-for-backup.mdx
+++ b/editor/exporting/exporting-for-backup.mdx
@@ -3,7 +3,7 @@ title: 'Exporting for Backup'
 description: ''
 ---
 
-<Note>Exporting for backup is available on paid plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Exporting for backup is available on paid plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 Exporting a file for backup is useful when you want a hard copy of your file saved to your device, if you are looking to transfer a file from one user to another, or you're trying to send in a file for a support ticket. Unlike files exported for runtime (.riv), files exported for backup (.rev) contain all of the information that is typically stripped from the file.\
 \

--- a/editor/exporting/exporting-for-runtime.mdx
+++ b/editor/exporting/exporting-for-runtime.mdx
@@ -5,7 +5,7 @@ description: ''
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-<Note>Exporting for runtime is available on paid plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Exporting for runtime is available on paid plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 <YouTube id="H_px35jTqhg" />
 

--- a/editor/exporting/exporting-for-video-and-static-design.mdx
+++ b/editor/exporting/exporting-for-video-and-static-design.mdx
@@ -3,7 +3,7 @@ title: 'Exporting for Video or Static Design'
 description: ''
 ---
 
-<Note>Exporting video and images is available on paid plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Exporting video and images is available on paid plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 Rive is all about interactive animation, but sometimes you need  traditional formats such as MP4, GIF, or PNG sequence. Our Cloud Renderer turns any device into a supercomputer, allowing you to continue working while we generate your video or design file.
 

--- a/editor/fundamentals/artboards.mdx
+++ b/editor/fundamentals/artboards.mdx
@@ -101,7 +101,7 @@ If you forget to change the origin after adding animations, you can always add t
 
 ## Layout Settings
 
-Since an Artboard is the root object that all other objects are added to, Artboards allow you to add and adjust their layout properties. Read more about layouts [here](https://rive.app/docs/editor/layouts/layouts-overview).
+Since an Artboard is the root object that all other objects are added to, Artboards allow you to add and adjust their layout properties. Read more about layouts [here](/editor/layouts/layouts-overview).
 
 ![Layout](/images/layout.png)
 
@@ -113,7 +113,7 @@ Like other objects in Rive, Artboards can have one or more fills or strokes adde
 
 ![Fill and stroke](/images/fillandstroke.png)
 
-Read more about fills and strokes [here](https://rive.app/docs/editor/fundamentals/fill-and-stroke).
+Read more about fills and strokes [here](/editor/fundamentals/fill-and-stroke).
 
 ## Render Presets
 
@@ -121,7 +121,7 @@ Selecting an artboard allows you to create Render Presets that can be used to re
 
 ![Render](/images/render.png)
 
-Read more about creating render presets [here](https://rive.app/docs/editor/exporting/exporting-for-video-and-static-design).
+Read more about creating render presets [here](/editor/exporting/exporting-for-video-and-static-design).
 
 ## Selected Colors
 

--- a/editor/fundamentals/design-vs-animate-mode.mdx
+++ b/editor/fundamentals/design-vs-animate-mode.mdx
@@ -5,7 +5,7 @@ description: "The Rive Editor has two distinct modes, Design and Animate. Switch
 
 ## Design Mode
 
-Use Design Mode to prepare your graphics for animation. This is where you can design your own graphics with Rive's [tools](../interface-overview/toolbar), [import graphics from other software](./importing-assets), or rig your graphics with [bones](../manipulating-shapes/bones), [transform spaces](./transform-spaces), [layouts](https://rive.app/docs/editor/layouts/layouts-overview), [joysticks](https://rive.app/docs/editor/manipulating-shapes/joysticks), and [constraints](../constraints/).
+Use Design Mode to prepare your graphics for animation. This is where you can design your own graphics with Rive's [tools](../interface-overview/toolbar), [import graphics from other software](./importing-assets), or rig your graphics with [bones](../manipulating-shapes/bones), [transform spaces](./transform-spaces), [layouts](/editor/layouts/layouts-overview), [joysticks](/editor/manipulating-shapes/joysticks), and [constraints](../constraints/).
 
 ![Image](/images/editor/fundamentals/Design_Mode.png)
 
@@ -13,9 +13,9 @@ Design Mode is the default mode for any file that doesn't have any animations cr
 
 ## Animate Mode
 
-Use [Animate Mode](../animate-mode/) to create all of the [States](https://rive.app/docs/editor/state-machine/states) and [State Machine](../state-machine/) for your artboard.
+Use [Animate Mode](../animate-mode/) to create all of the [States](/editor/state-machine/states) and [State Machine](../state-machine/) for your artboard.
 
-When you switch to Animate Mode, the UI updates to display a list of Timelines and State Machine associated with the [active artboard](./artboards#active-artboard). The [Inspector](https://rive.app/docs/editor/interface-overview/inspector) also updates to show key buttons next to any property that can be animated.
+When you switch to Animate Mode, the UI updates to display a list of Timelines and State Machine associated with the [active artboard](./artboards#active-artboard). The [Inspector](/editor/interface-overview/inspector) also updates to show key buttons next to any property that can be animated.
 
 ![Animate Mode](/images/editor/fundamentals/Animate_Mode.png)
 

--- a/editor/fundamentals/fill-and-stroke.mdx
+++ b/editor/fundamentals/fill-and-stroke.mdx
@@ -176,8 +176,8 @@ Each Stroke has its own properties which can be edited and keyed on the timeline
 **Stroke Type** - At the bottom of the Stroke Options Panel, you'll find options to change your stroke between a solid, trim, dashed stroke.
 
 - **Solid -** Renders the stroke as a solid stroke. This is the default stroke type for each new stroke created.
-- **Trim -**  Lets you animate the start, end, and offset of a line segment. Read more [here](https://rive.app/docs/editor/manipulating-shapes/trim-path).
-- **Dashed -** Lets you create dashed strokes with animatable property like the length of the dashed segment and offset.  Read more [here.](https://rive.app/docs/editor/manipulating-shapes/trim-path)
+- **Trim -**  Lets you animate the start, end, and offset of a line segment. Read more [here](/editor/manipulating-shapes/trim-path).
+- **Dashed -** Lets you create dashed strokes with animatable property like the length of the dashed segment and offset.  Read more [here.](/editor/manipulating-shapes/trim-path)
 
 # Vector Feathering
 

--- a/editor/fundamentals/importing-assets.mdx
+++ b/editor/fundamentals/importing-assets.mdx
@@ -40,7 +40,7 @@ You can use "copy as SVG" and paste it directly into the Rive editor.
 #### Import Lottie file
 
 <Note>
-  Importing Lottie files is available on the Enterprise plan. [Learn more about our plans and pricing](https://rive.app/pricing).
+  Importing Lottie files is available on the Enterprise plan. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).
 
   This workflow can introduce risks that vary across customer setups, and implementing them without our guidance can lead to issues in performance, security, or reliability. Helping customers assess and mitigate these risks takes significant time and effort, which is why this level of support is only available on Enterprise.
 </Note>

--- a/editor/get-rive.mdx
+++ b/editor/get-rive.mdx
@@ -9,14 +9,14 @@ You can use the Rive editor as a **desktop application** or directly in your **b
 <CardGroup cols={2}>
   <Card
     title="Downloads"
-    href="https://rive.app/downloads"
+    href="https://rive.app/downloads?utm_source=docs&utm_medium=content"
   >
     Download the Rive editor for macOS or Windows.
   </Card>
 
   <Card
     title="Web Editor"
-    href="https://editor.rive.app/"
+    href="https://editor.rive.app?utm_source=docs&utm_medium=content"
   >
     Use Rive instantly in your browser.
   </Card>

--- a/editor/interface-overview/hierarchy.mdx
+++ b/editor/interface-overview/hierarchy.mdx
@@ -48,13 +48,13 @@ In addition to displaying the relationships between objects, the Hierarchy shows
 
 ![Image](https://ucarecdn.com/5aeb4f67-a7f6-4efe-83bd-975880f79618/)
 
-To change the Draw Order of objects on the stage, drag and drop the shape, or group of shapes above or below another in the list. Note that draw order also affects how objects are placed and treated in a layout. Read more about that [here](https://rive.app/docs/editor/layouts/layouts-overview).
+To change the Draw Order of objects on the stage, drag and drop the shape, or group of shapes above or below another in the list. Note that draw order also affects how objects are placed and treated in a layout. Read more about that [here](/editor/layouts/layouts-overview).
 
-The Draw Order can be animated, but the process is a bit more in-depth. Read about it on the [Animating Draw Order](https://rive.app/docs/editor/animate-mode/animating-draw-order) page.
+The Draw Order can be animated, but the process is a bit more in-depth. Read about it on the [Animating Draw Order](/editor/animate-mode/animating-draw-order) page.
 
 ## **Right Click Menu**
 
-Right clicking any object in the hierarchy will bring up a menu with different options for each object. In the menu you'll find the ability to copy and paste both objects and styles, delete objects, wrap objects in [layouts](https://rive.app/docs/editor/layouts/layouts-overview) and [solos](https://rive.app/docs/editor/manipulating-shapes/solos), show the dependency graph, add a [tag](https://rive.app/docs/editor/tagging), reverse the draw order, and[ export a name](https://rive.app/docs/editor/exporting/exporting-for-runtime).
+Right clicking any object in the hierarchy will bring up a menu with different options for each object. In the menu you'll find the ability to copy and paste both objects and styles, delete objects, wrap objects in [layouts](/editor/layouts/layouts-overview) and [solos](/editor/manipulating-shapes/solos), show the dependency graph, add a [tag](/editor/tagging), reverse the draw order, and[ export a name](/editor/exporting/exporting-for-runtime).
 
 ![Right Click](/images/right_click.png)
 
@@ -68,14 +68,14 @@ The assets panel is a list view of your Images, Lottie files, Audio, and Custom 
 ![Assets](/images/Assets.png)
 
 <CardGroup cols="3">
-  <Card title="Importing Assets" icon="page" iconType="solid" href="https://rive.app/docs/editor/fundamentals/importing-assets" />
-  <Card title="Audio Events" icon="page" iconType="solid" href="https://rive.app/docs/editor/events/audio-events" />
+  <Card title="Importing Assets" icon="page" iconType="solid" href="/editor/fundamentals/importing-assets" />
+  <Card title="Audio Events" icon="page" iconType="solid" href="/editor/events/audio-events" />
 </CardGroup>
 
 
 # Data Panel
 
-The Data Panel is where all View Models, Enums, and Converters for a file are created, organized, and viewed.  The panel is broken into three separate spaces; View Models, Enums, and Converters. Read more about Data Binding [here](https://rive.app/docs/editor/data-binding/overview).
+The Data Panel is where all View Models, Enums, and Converters for a file are created, organized, and viewed.  The panel is broken into three separate spaces; View Models, Enums, and Converters. Read more about Data Binding [here](/editor/data-binding/overview).
 
 ![Data](/images/Data.png)
 

--- a/editor/interface-overview/inspector.mdx
+++ b/editor/interface-overview/inspector.mdx
@@ -23,7 +23,7 @@ Found at the top of the Inspector, this section allows you to change the backgro
 
 **Tags**
 
-Below the background color, you can see, edit, and add new tags to your file. Learn more about tags [here](https://rive.app/docs/editor/tagging).
+Below the background color, you can see, edit, and add new tags to your file. Learn more about tags [here](/editor/tagging).
 
 ![Tags](/images/tags.png)
 
@@ -51,10 +51,10 @@ When one or more objects, such as shapes or groups, are selected, the inspector 
 ![Layout and N-Slicing](/images/LOandN.png)
 
 <CardGroup cols={2}>
-  <Card title="Layouts" icon="page" iconType="solid" href="https://rive.app/docs/editor/layouts/layouts-overview">
+  <Card title="Layouts" icon="page" iconType="solid" href="/editor/layouts/layouts-overview">
     Layouts let you build responsive designs.
   </Card>
-  <Card title="N-Slicing" icon="page" iconType="solid" href="https://rive.app/docs/editor/layouts/n-slicing">
+  <Card title="N-Slicing" icon="page" iconType="solid" href="/editor/layouts/n-slicing">
     N-slicing lets you stretch or repeat parts of raster and vector designs.
   </Card>
 </CardGroup>
@@ -98,13 +98,13 @@ This section shows customizable properties when Keys, Transitions, or States are
 ![Motion inspector](/images/motioninspector.png)
 
 <CardGroup cols={3}>
-  <Card title="Interpolation Panel" icon="page" iconType="solid" href="https://rive.app/docs/editor/animate-mode/interpolation-easing">
+  <Card title="Interpolation Panel" icon="page" iconType="solid" href="/editor/animate-mode/interpolation-easing">
     Selecting a key brings up the interpolation panel.
   </Card>
-  <Card title="Transition Properties" icon="page" iconType="solid" href="https://rive.app/docs/editor/state-machine/transitions">
+  <Card title="Transition Properties" icon="page" iconType="solid" href="/editor/state-machine/transitions">
     Selecting a transition will show customizable transition properties.
   </Card>
-  <Card title="State Properties" icon="page" iconType="solid" href="https://rive.app/docs/editor/state-machine/states">
+  <Card title="State Properties" icon="page" iconType="solid" href="/editor/state-machine/states">
     State properties are customizable by selecting a state.
   </Card>
 </CardGroup>

--- a/editor/interface-overview/toolbar.mdx
+++ b/editor/interface-overview/toolbar.mdx
@@ -25,11 +25,11 @@ The export section allows you to both export your Rive file, and export or remov
 
 ![Export Options](/images/export_Options.png)
 
-Read more about exporting a Rive file and its contents [here](https://rive.app/docs/editor/exporting/exporting-for-runtime).
+Read more about exporting a Rive file and its contents [here](/editor/exporting/exporting-for-runtime).
 
 **Generate Embed URL**
 
-<Note>Generating embed URLs is available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Generating embed URLs is available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 Embed URLs are a fast no-code way to get your Rive files running on a website or to present your graphics to a client.
 
@@ -37,7 +37,7 @@ Embed URLs are a fast no-code way to get your Rive files running on a website or
 
 Share the current version of the file you’re working with embed URLs. Note that this is not the same as giving someone access to the live file with all its revision history. This link will be a frozen version of the file in its current state. If you make changes to the file, you’ll need to generate a new embed URL.
 
-Learn more about embed URLs [here](https://rive.app/docs/editor/embed-urls/overview).
+Learn more about embed URLs [here](/editor/embed-urls/overview).
 
 **Publish to Marketplace**
 
@@ -53,7 +53,7 @@ The file menu give you a way to both view and add new animation or presets to th
 
 ![Render](/images/render.png)
 
-Learn more about using our Cloud renderer [here](https://rive.app/docs/editor/exporting/exporting-for-video-and-static-design).
+Learn more about using our Cloud renderer [here](/editor/exporting/exporting-for-video-and-static-design).
 
 **Browse Sounds**
 
@@ -61,7 +61,7 @@ Rive allows you to add and play different sound effects in your file through Eve
 
 ![Sounds](/images/sounds.png)
 
-Read more about adding sound to your Rive file [here](https://rive.app/docs/editor/events/audio-events).
+Read more about adding sound to your Rive file [here](/editor/events/audio-events).
 
 **Show Shortcuts**
 
@@ -114,7 +114,7 @@ The Scale tool allows you to click on the gizmo or in an empty space to modify t
 
 Freeze mode allows you to modify the position of origins, groups, and bones without affecting the underlying objects associated with them.
 
-Learn more about Origin and Freeze mode [here](https://rive.app/docs/editor/fundamentals/freeze-and-origin).
+Learn more about Origin and Freeze mode [here](/editor/fundamentals/freeze-and-origin).
 
 ## Artboard, Layout, and Groups menu
 
@@ -132,7 +132,7 @@ Learn about Artboards, Components, Layouts and Groups.
   <Card title="Groups" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="../fundamentals/groups">
     Use groups to organize your graphics or to add extra transform spaces.
   </Card>
-  <Card title="Layouts" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="https://rive.app/docs/editor/layouts/layouts-overview">
+  <Card title="Layouts" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="/editor/layouts/layouts-overview">
     Layouts let you make responsive designs.
   </Card>
 </CardGroup>
@@ -159,10 +159,10 @@ The Events and Joysticks menu lets you add new Events and Joysticks to your File
 ![Events](/images/events.png)
 
 <CardGroup cols="2">
-  <Card title="Events" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="https://rive.app/docs/editor/events/overview">
+  <Card title="Events" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="/editor/events/overview">
     Events let you provide additional information to both the runtimes and in the editor.
   </Card>
-  <Card title="Joysticks" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="https://rive.app/docs/editor/manipulating-shapes/joysticks">
+  <Card title="Joysticks" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8.036 1v4.178c0 1.034.839 1.873 1.873 1.873h4.003v6.178a1.77 1.77 0 0 1-1.77 1.77H3.858a1.77 1.77 0 0 1-1.771-1.77V2.771A1.77 1.77 0 0 1 3.857 1zm1.25.145v4.033c0 .345.279.624.623.624h3.889a1.8 1.8 0 0 0-.377-.597L11.618 3.32 9.842 1.525a1.8 1.8 0 0 0-.557-.38" clip-rule="evenodd"></path></svg>} iconType="solid" href="/editor/manipulating-shapes/joysticks">
     Joysticks are a rigging tool that gives you stage controls that allow you to pan through connected timelines.
   </Card>
 </CardGroup>

--- a/editor/interface-overview/toolbar.mdx
+++ b/editor/interface-overview/toolbar.mdx
@@ -17,7 +17,7 @@ Rive automatically saves your revision history. You can view your view or reinst
 
 Additionally, you can create a new, custom revision using the Create Revision option.
 
-Read more about revision history [here](http://rive.app/docs/editor/fundamentals/revision-history).
+Read more about revision history [here](https://rive.app/docs/editor/fundamentals/revision-history).
 
 **Export**
 

--- a/editor/libraries.mdx
+++ b/editor/libraries.mdx
@@ -6,7 +6,7 @@ description: "Publish your components with dynamic data once, and reuse them eve
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-<Note>Libraries are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Libraries are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 <YouTube id="g6AXyqp4Ow0" />
 
@@ -19,7 +19,7 @@ With Libraries:
 - Updates flow downstream with version history and change notifications.
 - Teams can collaborate without worrying about mismatched assets.
 
-<Note>Libraries are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).</Note>
+<Note>Libraries are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
 ## Creating a Library
 Any file can be made into a library. First, you'll need to create a [component](editor/fundamentals/components) and/or a view model before you can publish the file as a library. Select an artboard on the stage and use the component icon in the inspector or `Shift` + `N` to toggle its status as a component.

--- a/editor/manipulating-shapes/meshes.mdx
+++ b/editor/manipulating-shapes/meshes.mdx
@@ -23,6 +23,6 @@ You can edit a mesh at any time by using the Edit Mesh button in the Inspector o
 
 ## Mesh Deform
 
-In both Design and Edit modes, you can deform your mesh by entering edit mesh mode, and moving a vertex with the select tool. For a more natural experience, consider using [bones](https://rive.app/docs/editor/manipulating-shapes/bones).
+In both Design and Edit modes, you can deform your mesh by entering edit mesh mode, and moving a vertex with the select tool. For a more natural experience, consider using [bones](/editor/manipulating-shapes/bones).
 
 ![Mesh Deform](/images/editor/manipulating-shapes/MeshDeform.gif)

--- a/editor/text/fonts.mdx
+++ b/editor/text/fonts.mdx
@@ -59,7 +59,7 @@ Select the font in the **Assets** panel and change the **Type** option to define
 </Info>
 
 <Note>
-  Hosted fonts are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing).
+  Hosted fonts are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).
 </Note>
 
 ---

--- a/feature-support.mdx
+++ b/feature-support.mdx
@@ -14,7 +14,7 @@ Use the table below to verify whether a feature used in your `.riv` file is supp
   documentation on [choosing a renderer](/runtimes/choose-a-renderer/).
 
   Currently, the only feature that requires the Rive Renderer is **[Vector
-  Feathering](https://rive.app/blog/introducing-vector-feathering)**.
+  Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content)**.
 </Warning>
 
 When a feature requires API changes, migration notes will be included below.

--- a/game-runtimes/unity/tutorials/health-bar.mdx
+++ b/game-runtimes/unity/tutorials/health-bar.mdx
@@ -4,7 +4,7 @@ description: "Learn how to connect Unity gameplay data to a Rive health bar usin
 ---
 <Badge color="green">Beginner</Badge>
 
-This tutorial walks through connecting a Rive health bar file to Unity using [Data Binding](https://rive.app/docs/editor/data-binding/overview). In this setup, your Unity code updates a single number (`health`) while the Rive file handles the visuals in response (e.g. color changes, and low-health warnings).
+This tutorial walks through connecting a Rive health bar file to Unity using [Data Binding](/editor/data-binding/overview). In this setup, your Unity code updates a single number (`health`) while the Rive file handles the visuals in response (e.g. color changes, and low-health warnings).
 
 ![GIF of the Health Bar Demo with the value changing from 100 to 0](/images/runtimes/quick-start.gif)
 

--- a/home/account-admin/account-overview/add-vat-tax-id-to-your-invoice.mdx
+++ b/home/account-admin/account-overview/add-vat-tax-id-to-your-invoice.mdx
@@ -20,7 +20,7 @@ Your tax invoice will be emailed to you immediately.
 
 To have your tax info included automatically on all future receipts, update your billing details in Stripe:
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Click "Manage Billing" to open the Stripe Customer Portal
 3. Update your customer information with your Tax ID
 4. Save changes

--- a/home/account-admin/account-overview/change-your-email-or-password.mdx
+++ b/home/account-admin/account-overview/change-your-email-or-password.mdx
@@ -2,7 +2,7 @@
 title: "Change Your Email or Password"
 ---
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Make sure you're on the **Account** tab
 
 **To change your email:**

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -53,7 +53,7 @@ To remove members before deletion: [Removing Workspace Members](/account-admin/w
 
 ### Step 3: Delete the Workspace
 
-1. Go to [rive.app/account](https://rive.app/account)
+1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Scroll to "Workspaces"
 3. Find the workspace you want to delete
 4. Click "Manage Workspace"

--- a/legal/privacy-policy.mdx
+++ b/legal/privacy-policy.mdx
@@ -2,21 +2,21 @@
 title: 'Privacy Policy'
 description: ''
 ---
-Last Updated: January 28, 2021 
+Last Updated: January 28, 2021
 
-## Overview 
+## Overview
 
-This Privacy Policy explains how information is collected, used, and disclosed by Rive Inc. (**“Rive”**) and applies to information collected when you use or access Rive’s website at [rive.app](https://rive.app/) (the **“Website”**) or when you use the services we offer (our **“Product”**) (together with the Website, the **“Service”**). We respect the privacy rights of users and recognize the importance of protecting information collected about you.
+This Privacy Policy explains how information is collected, used, and disclosed by Rive Inc. (**“Rive”**) and applies to information collected when you use or access Rive’s website at [rive.app](https://rive.app/=?utm_source=docs&utm_medium=content) (the **“Website”**) or when you use the services we offer (our **“Product”**) (together with the Website, the **“Service”**). We respect the privacy rights of users and recognize the importance of protecting information collected about you.
 
 Please read the following carefully to understand how we will collect, use, and maintain your personal information. It also describes your choices regarding the use, access, and correction of your personal information. By accessing and using our Services, you signify acceptance to the terms of this Privacy Policy.
 
-### Changing our Policy 
+### Changing our Policy
 
 We may change this Privacy Policy from time to time. If we make any changes, we will revise the "Last Updated" date at the beginning of this Privacy Policy and, in some cases, we may provide you with additional notice (such as adding a statement to our homepage or sending you an email notification). If there are material changes to this Privacy Policy, we will notify you more directly by email or means of a notice on the home page prior to the change becoming effective. We encourage you to review our Privacy Policy whenever you access the Service to stay informed about our information practices and the ways you can help protect your privacy.
 
 If you disagree with any changes to this Privacy Policy and do not wish your information to be subject to the revised Privacy Policy, you will need to deactivate your account with us and stop using the Service. Your use of the Service after the posting of such changes shall constitute your consent to such changes.
 
-## Information Collected 
+## Information Collected
 
 We may collect certain user information (including personal information and/or sensitive personal information) in the following ways:
 
@@ -34,7 +34,7 @@ We may collect certain user information (including personal information and/or s
 - Usage, Log, and Device Information: We collect information from your use of the Service such as system activity, hardware settings, browser type, browser language, the date and time of your visit, and the referral URL. We monitor user activity in connection with the Service and may collect information about the features you use, the content you upload, download, share, or access while using the Service, the content you access, and any actions taken in connection with the access and use of your content in the Service.
 - Information Collected by Cookies and Other Tracking Technologies: A cookie is a small file containing a string of characters that is sent to your computer when you visit a website. When you visit the website again, the cookie allows that site to recognize your browser. Cookies may store user preferences and other information. You can set your browser to refuse all cookies or to indicate when a cookie is being sent. However, some website features or services may not function properly without cookies. We use cookies to understand and save your preferences for future visits and compile aggregate data about site traffic and site interaction so that we can offer better site experiences and tools in the future. We may contract with third-party service providers to assist us in better understanding our site visitors. These service providers are not permitted to use the information collected on our behalf except to help us conduct and improve our business.
 
-## Use of Information 
+## Use of Information
 
 We may use the information collected through the Service for the limited purpose of providing the Service and related functionality and services for which Rive has been engaged. The information may be used for a variety of purposes, including:
 
@@ -55,7 +55,7 @@ Additionally we may disclose personal data in special cases when we have a good 
 
 **Do Not Track.** Some browsers offer a “do not track” (**“DNT”**) option. Because no common industry or legal standard for DNT has been adopted by industry groups, technology companies, or regulators, we do not respond to DNT signals. We will make efforts to continue to monitor developments around DNT browser technology and the implementation of a standard.
 
-### Sharing and Disclosure of Information 
+### Sharing and Disclosure of Information
 
 We will not share personal information about you or any Content with any third parties except as described in this Privacy Policy, or as defined in an agreement with us, in connection with the Service. For example, we may share personal information about you:
 
@@ -64,7 +64,7 @@ We will not share personal information about you or any Content with any third p
 - **For Business Transfers:** We may share or transfer your information in connection with, or during negotiations of, any merger, sale of company assets, financing, or acquisition of all or a portion of our business to another company. You may be notified thereafter via email of any such change in ownership or control of your personal information.
 - **As Aggregated and/or Anonymized Data:** We may also share aggregated and/or anonymized information with third parties that does not directly identify you.
 
-## International Data Transfers 
+## International Data Transfers
 
 Rive is headquartered in the United States and has employees and service providers who operate around the globe. Therefore, as a global business, Rive processes, hosts and transfers personal information in different countries, including in the United States. These countries may have data protection laws that are different to the laws of your country.
 
@@ -100,14 +100,14 @@ If you are a California resident, you may designate an authorized agent to make 
 
 In accordance with California Civil Code Section 1789.3, California resident users are entitled to know that they may file grievances and complaints with the California Department of Consumer Affairs, 400 R Street, STE 1080, Sacramento, CA 95814; or by phone at (916) 445-1254 or (800) 952-5210; or by email to [dca@dca.ca.gov](mailto:dca@dca.ca.gov).
 
-## Links to Third-Party Websites 
+## Links to Third-Party Websites
 
 We may place links on the Service. When you click on a link to a third-party website from our Website, your activity and use on the linked website is governed by that website’s policies, not by those of Rive. We encourage you to review their privacy and user policies.
 
-## Our Policy Toward Children 
+## Our Policy Toward Children
 
 The Service is not directed to individuals under 13. We do not knowingly collect personal information from children under 13. If you become aware that a child has provided us with personal information, please contact us at [support@rive.app](mailto:support@rive.app). If we become aware that a child under 13 has provided us with personal information, we will take steps to delete such information. If you are under the age of 13, you may not use our website, products, or services.
 
-## Contacting Us 
+## Contacting Us
 
 Any questions about this Privacy Policy should be addressed to [support@rive.app](mailto:support@rive.app).

--- a/legal/privacy-policy.mdx
+++ b/legal/privacy-policy.mdx
@@ -6,7 +6,7 @@ Last Updated: January 28, 2021
 
 ## Overview
 
-This Privacy Policy explains how information is collected, used, and disclosed by Rive Inc. (**“Rive”**) and applies to information collected when you use or access Rive’s website at [rive.app](https://rive.app/=?utm_source=docs&utm_medium=content) (the **“Website”**) or when you use the services we offer (our **“Product”**) (together with the Website, the **“Service”**). We respect the privacy rights of users and recognize the importance of protecting information collected about you.
+This Privacy Policy explains how information is collected, used, and disclosed by Rive Inc. (**“Rive”**) and applies to information collected when you use or access Rive’s website at [rive.app](https://rive.app?utm_source=docs&utm_medium=content) (the **“Website”**) or when you use the services we offer (our **“Product”**) (together with the Website, the **“Service”**). We respect the privacy rights of users and recognize the importance of protecting information collected about you.
 
 Please read the following carefully to understand how we will collect, use, and maintain your personal information. It also describes your choices regarding the use, access, and correction of your personal information. By accessing and using our Services, you signify acceptance to the terms of this Privacy Policy.
 

--- a/legal/terms-of-service.mdx
+++ b/legal/terms-of-service.mdx
@@ -170,7 +170,7 @@ You may, from time to time, provide us with ideas, suggestions, feedback, recomm
 
 Your use of the Service must not violate any applicable laws, including, without limitation, copyright or trademark laws, export control or sanctions laws. You are responsible for making sure that your use of the Service is in compliance with laws and any applicable regulations.
 
-You agree that You will not under any circumstances violate our [Acceptable Use Policy](https://rive.app/docs/legal/acceptable-use-policy).
+You agree that You will not under any circumstances violate our [Acceptable Use Policy](/legal/acceptable-use-policy).
 
 ## G. Copyright Infringement and the Digital Millennium Copyright Act
 

--- a/runtimes/choose-a-renderer/faq.mdx
+++ b/runtimes/choose-a-renderer/faq.mdx
@@ -9,8 +9,8 @@ See [Choose a Renderer](/runtimes/choose-a-renderer/overview) for all supported 
 
 ## Why should I enable the Rive Renderer?
 
-For vector-heavy graphics, the Rive Renderer will offer the ability to draw onto surfaces/textures/canvases with incredible speed and quality while keeping runtime bundle sizes low. Future features developed in Rive, such as blurs and glows, will be possible with the Rive renderer. To learn more about the Rive Renderer, visit our [product page](https://rive.app/renderer).
+For vector-heavy graphics, the Rive Renderer will offer the ability to draw onto surfaces/textures/canvases with incredible speed and quality while keeping runtime bundle sizes low. Future features developed in Rive, such as blurs and glows, will be possible with the Rive renderer. To learn more about the Rive Renderer, visit our [product page](https://rive.app/renderer?utm_source=docs&utm_medium=content).
 
 ## Am I restricted in using the Rive Renderer with one of the open-source runtimes?
 
-Nope! You can integrate the Rive Renderer into your custom platform/engine. For custom integrations, [contact us](https://rive.app/contact).
+Nope! You can integrate the Rive Renderer into your custom platform/engine. For custom integrations, [contact us](https://rive.app/contact?utm_source=docs&utm_medium=content).

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -6,11 +6,11 @@ description: "Specify a renderer to use at runtime."
 
 import { Apple } from "/snippets/constants.mdx";
 
-Rive makes use of various different renderers depending on platform and runtime. We're working towards unifying the default renderer used across all platforms/runtimes with the [Rive Renderer](https://rive.app/renderer).
+Rive makes use of various different renderers depending on platform and runtime. We're working towards unifying the default renderer used across all platforms/runtimes with the [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content).
 
 <Warning>
   Certain features, such as [Vector
-  Feathering](https://rive.app/blog/introducing-vector-feathering), are only
+  Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content), are only
   supported through the Rive Renderer. See our [Feature
   Support](/feature-support) page for more information.
 </Warning>
@@ -32,9 +32,9 @@ The table below outlines the available, and default, renderers for Rive's runtim
 
 ## Rive Renderer
 
-The [Rive Renderer](https://rive.app/renderer) is a new rendering engine designed to provide better performance and visual fidelity across all platforms. It leverages modern graphics APIs and techniques to deliver high-quality rendering for Rive graphics.
+The [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content) is a new rendering engine designed to provide better performance and visual fidelity across all platforms. It leverages modern graphics APIs and techniques to deliver high-quality rendering for Rive graphics.
 
-It also allows Rive to innovate with new features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering), which are only supported through the Rive Renderer. See our [Feature Support](/feature-support) page for more information.
+It also allows Rive to innovate with new features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content), which are only supported through the Rive Renderer. See our [Feature Support](/feature-support) page for more information.
 
 <Tabs>
 

--- a/runtimes/demos.mdx
+++ b/runtimes/demos.mdx
@@ -32,7 +32,7 @@ import { ExampleEyeFollow } from '/snippets/example-eye-follow.jsx'
     links={{
       web: "https://codesandbox.io/p/sandbox/rive-web-track-your-mouse-n38gdd"
     }}
-    source={["https://rive.app/marketplace/24639-46040-cat-follow-cursor-demo/"]}
+    source={["https://rive.app/marketplace/24639-46040-cat-follow-cursor-demo?utm_source=docs&utm_medium=docs_card_demo"]}
   >
     <ExampleEyeFollow />
   </RiveCard>

--- a/runtimes/flutter/migration-guide.mdx
+++ b/runtimes/flutter/migration-guide.mdx
@@ -13,12 +13,12 @@ This has resulted in a number of changes to the underlying API, and a large port
 
 This release of Rive Flutter adds support for:
 
-- [Rive Renderer](https://rive.app/renderer)
+- [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content)
 - [Data Binding](/editor/data-binding/)
 - [Layouts](/editor/layouts/layouts-overview)
 - [Scrolling](/editor/layouts/scrolling)
 - [N-Slicing](/editor/layouts/n-slicing)
-- [Vector Feathering](https://rive.app/blog/introducing-vector-feathering)
+- [Vector Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content)
 - All other features added to Rive that did not make it to the previous versions of Rive Flutter
 - Includes the latest fixes and improvements for the Rive C++ runtime
 - Adds prebuilt libraries, with the ability to build manually. See the [rive_native](https://pub.dev/packages/rive_native) package for more information
@@ -91,7 +91,7 @@ The following classes have been completely removed:
 
 <Tabs>
   <Tab title="New API">
-    ```dart 
+    ```dart
     final file = await File.decode(bytes, factory: Factory.rive);
     final artboard = file.defaultArtboard();
     final artboard = file.artboard('MyArtboard');
@@ -623,7 +623,7 @@ All of the "runtime" Dart code has been removed from these paths:
 
 If you encounter issues during migration:
 
-1. Check the [Rive Flutter documentation](https://rive.app/docs/flutter)
+1. Check the [Rive Flutter documentation](/flutter)
 2. Review the [Data Binding guide](/editor/data-binding/overview)
 3. Visit the [Rive community forums](https://community.rive.app)
 4. Report issues on the [GitHub repository](https://github.com/rive-app/rive-flutter)

--- a/runtimes/flutter/migration-guide.mdx
+++ b/runtimes/flutter/migration-guide.mdx
@@ -623,7 +623,7 @@ All of the "runtime" Dart code has been removed from these paths:
 
 If you encounter issues during migration:
 
-1. Check the [Rive Flutter documentation](/flutter)
+1. Check the [Rive Flutter documentation](/runtimes/flutter/flutter)
 2. Review the [Data Binding guide](/editor/data-binding/overview)
 3. Visit the [Rive community forums](https://community.rive.app)
 4. Report issues on the [GitHub repository](https://github.com/rive-app/rive-flutter)

--- a/runtimes/flutter/rive-native.mdx
+++ b/runtimes/flutter/rive-native.mdx
@@ -21,7 +21,7 @@ The [Rive Flutter runtime](https://pub.dev/packages/rive) (`rive`) is built on t
 
 Rive Native acts as the bridge between Flutter and the Rive C++ runtime, allowing you to use Rive graphics in your Flutter applications.
 
-- **C++ Runtime Integration**:  
+- **C++ Runtime Integration**:
   `rive_native` is built on Rive's [C++ runtime](https://github.com/rive-app/rive-runtime) via FFI. This ensures a consistent experience across platforms and the Rive Editor, while unlocking performance improvements and new features exclusive to the C++ runtime, such as:
 
   - [Data Binding](/editor/data-binding/)
@@ -30,8 +30,8 @@ Rive Native acts as the bridge between Flutter and the Rive C++ runtime, allowin
   - [N-Slicing](/editor/layouts/n-slicing)
   - [Vector Feathering](https://rive.app/blog/introducing-vector-feathering)
 
-- **Rive Renderer Support**:  
-  `rive_native` bring the [Rive Renderer](https://rive.app/renderer) to Flutter. While you can still use the Flutter-based renderer (Dart/Impeller), the Rive Renderer is recommended for performance-critical use cases. For more information see [Choosing a Renderer](/runtimes/choose-a-renderer/overview).
+- **Rive Renderer Support**:
+  `rive_native` bring the [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content) to Flutter. While you can still use the Flutter-based renderer (Dart/Impeller), the Rive Renderer is recommended for performance-critical use cases. For more information see [Choosing a Renderer](/runtimes/choose-a-renderer/overview).
 
   Some features, like Vector Feathering, are only supported with the Rive Renderer. See the [Feature Support page](/feature-support) for more details.
 

--- a/runtimes/react-native/react-native.mdx
+++ b/runtimes/react-native/react-native.mdx
@@ -50,7 +50,7 @@ This guide documents how to get started using the Rive React Native runtime. The
     <CardGroup cols={2}>
       <Card
         title="Rive File"
-        href="https://rive.app/marketplace/24637-46037-health-bar-data-binding-quick-start/"
+        href="https://rive.app/marketplace/24637-46037-health-bar-data-binding-quick-start?utm_source=docs&utm_medium=content"
       >
         Remix/download the Rive file used in this quick start guide
       </Card>

--- a/runtimes/react-native/state-machines.mdx
+++ b/runtimes/react-native/state-machines.mdx
@@ -15,7 +15,7 @@ import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-stat
 
 <Tabs>
   <Tab title="New Runtime (Recommended)">
-    By default, `RiveView` automatically uses the default artboard and state machine [configured in the Editor](https://rive.app/docs/editor/fundamentals/artboards#default-state-machine). In most cases, you only need to provide the `file` prop.
+    By default, `RiveView` automatically uses the default artboard and state machine [configured in the Editor](/editor/fundamentals/artboards#default-state-machine). In most cases, you only need to provide the `file` prop.
 
     For programmatic control, you can optionally specify `artboardName` and `stateMachineName` props to use a different artboard or state machine.
 

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -20,7 +20,7 @@ Use `@rive-app/webgl2` if you want the best rendering quality and performance in
 npm install @rive-app/webgl2
 ```
 
-- Uses the [Rive Renderer](https://rive.app/renderer) for the best rendering performance
+- Uses the [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content) for the best rendering performance
 - Supports Rive Renderer-only features (for example, vector feathering)
 
 <Note>

--- a/scripting/api-reference/image/image-sampler.mdx
+++ b/scripting/api-reference/image/image-sampler.mdx
@@ -6,7 +6,7 @@ Represents sampling parameters applied when drawing an image, including
 wrapping and filtering behaviour.
 See also [ImageSampler](/scripting/api-reference/image/image-sampler), [ImageWrap](/scripting/api-reference/image/image-wrap), and [ImageFilter](/scripting/api-reference/image/image-filter).
 
-Check out [Scripting demos](https://rive.app/docs/scripting/demos) to see a working example.
+Check out [Scripting demos](/scripting/demos) to see a working example.
 
 ```lua highlight={3,8,15}
 type DrawImage = {

--- a/scripting/api-reference/interfaces/context.mdx
+++ b/scripting/api-reference/interfaces/context.mdx
@@ -126,7 +126,7 @@ The returned [Image](/scripting/api-reference/image/image) can be drawn via `dra
 
 See also [ImageSampler](/scripting/api-reference/image/image-sampler).
 
-Check out [Scripting demos](https://rive.app/docs/scripting/demos) to see a working example.
+Check out [Scripting demos](/scripting/demos) to see a working example.
 
 ```lua highlight={7,15}
 type DrawImage = {

--- a/scripting/api-reference/renderer/renderer.mdx
+++ b/scripting/api-reference/renderer/renderer.mdx
@@ -38,7 +38,7 @@ drawImage(image: Image, sampler: ImageSampler, blendMode: BlendMode, opacity: nu
 
 Draws an [Image](/scripting/api-reference/image/image) using the [ImageSampler](/scripting/api-reference/image/image-sampler), [BlendMode](/scripting/api-reference/paint/blend-mode), and opacity.
 
-Check out [Scripting demos](https://rive.app/docs/scripting/demos) to see a working example.
+Check out [Scripting demos](/scripting/demos) to see a working example.
 
 ```lua highlight={15}
 type DrawImage = {

--- a/scripting/getting-started.mdx
+++ b/scripting/getting-started.mdx
@@ -16,7 +16,7 @@ This video introduces the basics of writing and using scripts in Rive. You’ll 
 
 ## Fundamentals
 
-- [Why Luau](https://rive.app/blog/why-scripting-runs-on-luau) - Why Scripting runs on Luau
+- [Why Luau](https://rive.app/blog/why-scripting-runs-on-luau?utm_source=docs&utm_medium=content) - Why Scripting runs on Luau
 - [Creating Scripts](/scripting/creating-scripts) - Creating a new script
 - [Protocols](/scripting/protocols) - The type of scripts you can create
 - [Inputs](/scripting/script-inputs) - Connecting scripts to inputs and data

--- a/scripting/protocols/node-scripts.mdx
+++ b/scripting/protocols/node-scripts.mdx
@@ -108,7 +108,7 @@ type Enemy = {
 
 export type MyGame = {
   -- This is the component that we will dynamically add to our scene
-  -- See: https://rive.app/docs/scripting/script-inputs
+  -- See: /scripting/script-inputs
   enemy: Input<Artboard<Data.Enemy>>,
   enemies: { Enemy },
 }

--- a/snippets/demos.jsx
+++ b/snippets/demos.jsx
@@ -237,7 +237,7 @@ export const Demos = ({
       image: "https://static.rive.app/docs/render-image-with-scripting.jpg",
       description: "Draw an image, give it transforms, control its mesh, and add clipping all through scripting.",
       links: {
-        editor: "https://rive.app/community/files/26406-49444-draw-an-image-with-scripting/"
+        editor: "https://rive.app/community/files/26406-draw-an-image-with-scripting"
       }
     },
     scriptingSlotMachine: {
@@ -369,7 +369,7 @@ export const Demos = ({
     if (!link) return null
 
     if (runtime === 'editor') {
-      link = `${link}?utm_source=docs&utm_medium=docs_demo_card&utm_campaign=docs_to_marketplace_links`
+      link = `${link}?utm_source=docs&utm_medium=docs_demo_card`
     }
 
     return (

--- a/snippets/early-access-feature.mdx
+++ b/snippets/early-access-feature.mdx
@@ -1,7 +1,7 @@
 export const EarlyAccessFeature = ({ featureName, children }) => {
   return (
     <Warning>
-      {featureName} is in <a href="https://rive.app/blog/early-access-to-unreleased-features" target="_blank" rel="noopener noreferrer">Early Access</a> and is not yet available for production. Runtime support may be limited or unavailable. See <a href="/feature-support">Feature Support</a> for updates.
+      {featureName} is in <a href="https://rive.app/blog/early-access-to-unreleased-features?utm_source=docs&utm_medium=content" target="_blank" rel="noopener noreferrer">Early Access</a> and is not yet available for production. Runtime support may be limited or unavailable. See <a href="/feature-support">Feature Support</a> for updates.
 
       {children && (
         <>

--- a/snippets/early-access.mdx
+++ b/snippets/early-access.mdx
@@ -1,7 +1,7 @@
 export const EarlyAccess = ({ featureName, children }) => {
   return (
     <Warning>
-      {featureName} is in <a href="https://rive.app/blog/early-access-to-unreleased-features" target="_blank" rel="noopener noreferrer">Early Access</a> and is not yet available for production.
+      {featureName} is in <a href="https://rive.app/blog/early-access-to-unreleased-features?utm_source=docs&utm_medium=content" target="_blank" rel="noopener noreferrer">Early Access</a> and is not yet available for production.
 
       {children && (
         <>
@@ -11,4 +11,4 @@ export const EarlyAccess = ({ featureName, children }) => {
       )}
     </Warning>
   );
-}; 
+};

--- a/snippets/runtimes/loading-assets/loading-via-cdn.mdx
+++ b/snippets/runtimes/loading-assets/loading-via-cdn.mdx
@@ -6,5 +6,5 @@ In the Rive editor, you can mark an imported asset as a _"Hosted"_ export type, 
 
 <Note>
   Hosted assets are available on Voyager and Enterprise plans. [Learn more about
-  our plans and pricing](https://rive.app/pricing).
+  our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).
 </Note>

--- a/snippets/runtimes/text/resources.mdx
+++ b/snippets/runtimes/text/resources.mdx
@@ -1,3 +1,3 @@
 ### Additional Resources:
 
-- [Accessible web animations: ARIA live regions](https://rive.app/blog/accesible-web-animations-aria-live-regions)
+- [Accessible web animations: ARIA live regions](https://rive.app/blog/accesible-web-animations-aria-live-regions?utm_source=docs&utm_medium=content)


### PR DESCRIPTION
- Add tracking to all links that go from the docs to marketplace and the website (`https://community.rive.app?utm_source=docs&utm_medium=footer_nav`)
- Switch any direct internal links to relative (`https://rive.app/docs/editor/` -> `/editor/`)
- Update relative links (`./some-page`)

Side note: Added tracking from links in Circle to other sources. 