### PR TITLE
docs(js)(react): add fallback fonts feature docs for js and react

### DIFF
--- a/runtimes/react/fonts.mdx
+++ b/runtimes/react/fonts.mdx
@@ -18,7 +18,7 @@ For more information, see [Loading Assets](/runtimes/react/loading-assets).
 
 As of `v4.28.0`, the React runtime provides an API for supplying fallback fonts. When a glyph cannot be rendered with the default font, Rive will invoke a callback you provide to retrieve a list of decoded fonts to try instead. **Importantly**, this callback must be registered before Rive begins rendering.
 
-To start, import `RiveFont` and `decodeFont` from the React package and call `RiveFont.setFallbackFontCallback()` before the Rive component begins rendering.
+To start, import `RiveFont` and `decodeFont` from the React package and call `RiveFont.setFallbackFontCallback()`, passing in the callback before the Rive component begins rendering. The callback receives the glyph that failed to render (as a Unicode code point) and the font weight, and should return a list of fallback fonts. It may be called multiple times if successive fallback fonts also lack support for the glyph.
 
 ```tsx
 import { useEffect } from "react";

--- a/runtimes/react/fonts.mdx
+++ b/runtimes/react/fonts.mdx
@@ -4,10 +4,52 @@ description: 'Loading and replacing fonts dynamically at runtime.'
 ---
 
 import SwappingFonts from "/snippets/runtimes/fonts/swapping-fonts.mdx"
-import fallbackFontsUnsupported from "/snippets/runtimes/fonts/fallback-fonts-unsupported.mdx"
+import fallbackFonts from "/snippets/runtimes/fonts/fallback-fonts.mdx"
 
 <SwappingFonts />
 
 For more information, see [Loading Assets](/runtimes/react/loading-assets).
 
-<fallbackFontsUnsupported />
+<fallbackFonts />
+
+<Note>
+  For security reasons, browsers do not allow direct access to a user's system fonts. As a result, fallback fonts must be explicitly provided for this runtime.
+</Note>
+
+As of `v4.28.0`, the React runtime provides an API for supplying fallback fonts. When a glyph cannot be rendered with the default font, Rive will invoke a callback you provide to retrieve a list of decoded fonts to try instead. **Importantly**, this callback must be registered before Rive begins rendering.
+
+To start, import `RiveFont` and `decodeFont` from the React package and call `RiveFont.setFallbackFontCallback()` before the Rive component begins rendering.
+
+```tsx
+import { useEffect } from "react";
+import { useRive, RiveFont, decodeFont } from "@rive-app/react-webgl2";
+
+const THAI_FONT_URL =
+  "https://raw.githubusercontent.com/google/fonts/main/ofl/notoserifthai/NotoSerifThai%5Bwdth%2Cwght%5D.ttf";
+
+export default function MyRiveComponent() {
+  useEffect(() => {
+    const loadFonts = async () => {
+      const notoSerifThai = await fetch(THAI_FONT_URL).then((res) => res.arrayBuffer());
+      const riveThaiDecodedFont = await decodeFont(new Uint8Array(notoSerifThai));
+
+      RiveFont.setFallbackFontCallback((codePoint: number, weight: number) => {
+        // For Thai, use Noto Serif Thai font
+        if (codePoint >= 0x0E00 && codePoint <= 0x0E7F) {
+          return [riveThaiDecodedFont];
+        }
+        return null;
+      });
+    };
+    loadFonts();
+  }, []);
+
+  const { RiveComponent } = useRive({
+    src: "my.riv",
+    autoplay: true,
+    stateMachines: "State Machine 1",
+  });
+
+  return <RiveComponent />;
+}
+```

--- a/runtimes/web/fonts.mdx
+++ b/runtimes/web/fonts.mdx
@@ -4,10 +4,52 @@ description: 'Loading and replacing fonts dynamically at runtime.'
 ---
 
 import SwappingFonts from "/snippets/runtimes/fonts/swapping-fonts.mdx"
-import fallbackFontsUnsupported from "/snippets/runtimes/fonts/fallback-fonts-unsupported.mdx"
+import fallbackFonts from "/snippets/runtimes/fonts/fallback-fonts.mdx"
 
 <SwappingFonts />
 
 For more information, see [Loading Assets](/runtimes/web/loading-assets).
+`
+<fallbackFonts />
 
-<fallbackFontsUnsupported />
+<Note>
+  For security reasons, browsers do not allow direct access to a user's system fonts. As a result, fallback fonts must be explicitly provided for this runtime.
+</Note>
+
+As of `v2.37.1`, the JS runtime provides an API for supplying fallback fonts. When a glyph cannot be rendered with the default font, Rive will invoke a callback you provide to retrieve a list of decoded fonts to try instead. Importantly, this callback must be registered before Rive begins rendering. 
+
+To start, import the `RiveFont` named export from the JS package and call its static method `setFallbackFontCallback()`, passing in your callback. The callback receives the glyph that failed to render (as a Unicode code point) and the font weight, and should return a list of fallback fonts. It may be called multiple times if successive fallback fonts also lack support for the glyph.
+
+```javascript
+import { RiveFont, decodeFont, Rive } from "@rive-app/webgl2";
+
+const THAI_FALLBACK_FONT_URL =
+  "https://raw.githubusercontent.com/google/fonts/main/ofl/notoserifthai/NotoSerifThai%5Bwdth%2Cwght%5D.ttf";
+
+const setFallbackFonts = async () => {
+  const notoSerifThai = await fetch(THAI_FALLBACK_FONT_URL).then((res) => res.arrayBuffer());
+  const riveThaiDecodedFont = await decodeFont(new Uint8Array(notoSerifThai));
+
+  RiveFont.setFallbackFontCallback((codePoint: number, weight: number) => {
+    console.log("fallback font missing glyph: ", codePoint, " + weight: ", weight);
+    // For Thai, use Noto Serif Thai font
+    if (codePoint >= 0x0E00 && codePoint <= 0x0E7F) {
+      return [riveThaiDecodedFont];
+    }
+    return null;
+  });
+};
+
+const main = async () => {
+  await setFallbackFonts();
+  const r = new Rive({ 
+    src: "my.riv",
+    autoplay: true,
+    stateMachines: "State Machine 1",
+    // ...
+  });
+};
+main();
+```
+
+

--- a/snippets/feature-support.jsx
+++ b/snippets/feature-support.jsx
@@ -252,14 +252,14 @@ export const FeatureSupportGroup = ({
         fallbackFonts: {
             title: "Fallback Fonts",
             runtimes: {
-                webCanvas: { supported: false, description: "Not yet supported" },
+                webCanvas: { supported: false, description: "2.37.1+" },
                 webCanvasLite: { supported: false, description: "Not supported" },
                 webWebGL: { supported: false, description: "Not supported" },
-                webWebGL2: { supported: false, description: "Not yet supported" },
-                reactCanvas: { supported: false, description: "Not yet supported" },
+                webWebGL2: { supported: false, description: "2.37.1+" },
+                reactCanvas: { supported: false, description: "4.28.0+" },
                 reactCanvasLite: { supported: false, description: "Not supported" },
                 reactWebGL: { supported: false, description: "Not supported" },
-                reactWebGL2: { supported: false, description: "Not yet supported" },
+                reactWebGL2: { supported: false, description: "4.28.0+" },
                 reactNative: { supported: true, version: "0.2.7+" },
                 reactNativeLegacy: { supported: false, description: "Not supported" },
                 flutter: { supported: false, description: "Not yet supported" },

--- a/snippets/feature-support.jsx
+++ b/snippets/feature-support.jsx
@@ -252,14 +252,14 @@ export const FeatureSupportGroup = ({
         fallbackFonts: {
             title: "Fallback Fonts",
             runtimes: {
-                webCanvas: { supported: false, description: "2.37.1+" },
+                webCanvas: { supported: true, version: "2.37.1+" },
                 webCanvasLite: { supported: false, description: "Not supported" },
                 webWebGL: { supported: false, description: "Not supported" },
-                webWebGL2: { supported: false, description: "2.37.1+" },
-                reactCanvas: { supported: false, description: "4.28.0+" },
+                webWebGL2: { supported: true, version: "2.37.1+" },
+                reactCanvas: { supported: true, version: "4.28.0+" },
                 reactCanvasLite: { supported: false, description: "Not supported" },
                 reactWebGL: { supported: false, description: "Not supported" },
-                reactWebGL2: { supported: false, description: "4.28.0+" },
+                reactWebGL2: { supported: true, version: "4.28.0+" },
                 reactNative: { supported: true, version: "0.2.7+" },
                 reactNativeLegacy: { supported: false, description: "Not supported" },
                 flutter: { supported: false, description: "Not yet supported" },


### PR DESCRIPTION
- Adds fallback fonts docs for Web / React `fonts` pages
- Updates feature support page to include versions where the API is exposed