### PR TITLE
docs: add support landing page

### DIFF
--- a/community/support.mdx
+++ b/community/support.mdx
@@ -23,11 +23,11 @@ Not sure where to start? Ask in the [community](https://community.rive.app/c/sup
 
 - [Report a Bug](https://community.rive.app/c/bug-reports?utm_source=docs&utm_medium=support_page&utm_content=bug_report) — Report issues with the editor or runtimes
 - [Request a Feature](https://community.rive.app/c/feature-requests?utm_source=docs&utm_medium=support_page) — Suggest improvements or new features
+- [Early Access](https://community.rive.app/c/early-access?utm_source=docs&utm_medium=support_page) — Discuss and give feedback on early features
 
 ### Account & Access
 
 - [Account Support](https://portal.usepylon.com/rive/forms/account-file-support-form?utm_source=docs&utm_medium=support_page) — Billing, account issues, or private inquiries
-- [Early Access](https://community.rive.app/c/early-access?utm_source=docs&utm_medium=support_page) — Discuss and give feedback on early features
 
 ---
 

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -5,9 +5,10 @@ description: 'Choose the best way to get help with Rive—from community support
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-Not sure where to start? Ask in the [community](https://community.rive.app/c/support?utm_source=docs&utm_medium=support_page&utm_content=peer_support) — you’ll usually get the fastest response.
 
 ## Quick Links
+
+Not sure where to start? Ask in the [community](https://community.rive.app/c/support?utm_source=docs&utm_medium=support_page&utm_content=peer_support) — you’ll usually get the fastest response.
 
 ### Get Help
 

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -1,0 +1,80 @@
+---
+title: 'Support'
+description: 'Choose the best way to get help with Rive—from community support to direct help from our team.'
+---
+
+import { YouTube } from '/snippets/youtube.mdx'
+
+Not sure where to start? Ask in the [community](https://community.rive.app/c/support?utm_source=docs&utm_medium=support_page&utm_content=peer_support) — you’ll usually get the fastest response.
+
+## Quick Links
+
+### Get Help
+
+- [Peer-to-peer Support](https://community.rive.app/c/support?utm_source=docs&utm_medium=support_page&utm_content=peer_support) — Best for how-to questions, learning Rive, and general debugging help from the community
+- [Voyager Support](https://community.rive.app/c/voyager-support?utm_source=docs&utm_medium=support_page&utm_content=voyager_support) — Priority support with direct help from the Rive team for production issues and blocking bugs (included with Voyager)
+- [Discord](https://discord.com/invite/FGjmaTr) — Chat with the community in real time for quick questions and discussion
+
+<Tip>
+  For faster, more accurate help, include a `.rev` file, a video, a code snippet, and a minimal example.
+</Tip>
+
+### Report & Request
+
+- [Report a Bug](https://community.rive.app/c/bug-reports?utm_source=docs&utm_medium=support_page&utm_content=bug_report) — Report issues with the editor or runtimes
+- [Request a Feature](https://community.rive.app/c/feature-requests?utm_source=docs&utm_medium=support_page) — Suggest improvements or new features
+
+### Account & Access
+
+- [Account Support](https://portal.usepylon.com/rive/forms/account-file-support-form?utm_source=docs&utm_medium=support_page) — Billing, account issues, or private inquiries
+- [Early Access](https://community.rive.app/c/early-access?utm_source=docs&utm_medium=support_page) — Discuss and give feedback on early features
+
+---
+
+## FAQs
+
+<AccordionGroup>
+	<Accordion title="Where should I ask technical questions?">
+		For most technical questions, the fastest way to get help is through the community.
+		You’ll often get answers from both the Rive team and other experienced users.
+
+		If you're working on something production-critical or need direct help from the Rive team, consider [Voyager support](/support#voyager-support).
+	</Accordion>
+
+	<Accordion title="When should I email support?">
+		Use email support for:
+		- Billing or account issues
+		- Security concerns
+		- Private or sensitive information
+
+		For general how-to questions or debugging help, the community is a better place to start.
+	</Accordion>
+
+	<Accordion title="What’s included in Voyager support?">
+		Voyager support gives you direct access to the Rive team with faster, more in-depth help.
+
+		This is best for:
+		- Production issues
+		- Blocking bugs
+		- Help debugging complex setups
+
+		[Upgrade to Voyager](https://rive.app/pricing?utm_source=docs&utm_medium=support_page).
+	</Accordion>
+
+	<Accordion title="How do I cancel my Rive subscription?">
+		See [Cancel My Account](/account-admin/account-overview/cancel-my-account).
+	</Accordion>
+
+	<Accordion title="Where can I find runtime-specific FAQs?">
+		You can browse runtime-specific FAQ pages here:
+		- [Apple Runtime FAQ](/runtimes/apple/faq)
+		- [Flutter Runtime FAQ](/runtimes/flutter/faq)
+		- [Web Runtime FAQ](/runtimes/web/faq)
+		- [Choose a Renderer FAQ](/runtimes/choose-a-renderer/faq)
+	</Accordion>
+</AccordionGroup>
+
+
+
+
+

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -3,8 +3,6 @@ title: 'Support'
 description: 'Choose the best way to get help with Rive—from community support to direct help from our team.'
 ---
 
-import { YouTube } from '/snippets/youtube.mdx'
-
 
 ## Quick Links
 
@@ -39,7 +37,7 @@ Not sure where to start? Ask in the [community](https://community.rive.app/c/sup
 		For most technical questions, the fastest way to get help is through the community.
 		You’ll often get answers from both the Rive team and other experienced users.
 
-		If you're working on something production-critical or need direct help from the Rive team, consider [Voyager support](/support#voyager-support).
+		If you're working on something production-critical or need direct help from the Rive team, consider [Voyager support](https://rive.app/pricing).
 	</Accordion>
 
 	<Accordion title="When should I email support?">

--- a/docs.json
+++ b/docs.json
@@ -652,10 +652,9 @@
       {
         "label": "Learn",
         "href": "/tutorials/learn-rive"
-      },
-      {
+      },{
         "label": "Support",
-        "href": "https://community.rive.app?utm_source=docs&utm_medium=header_nav"
+        "href": "/community/support"
       }
     ],
     "primary": {

--- a/tutorials/learn-rive.mdx
+++ b/tutorials/learn-rive.mdx
@@ -4,8 +4,6 @@ description: 'Discover tutorials, example files, videos, demos, and community re
 mode: 'wide'
 ---
 
-import { YouTube } from '/snippets/youtube.mdx'
-
 <CardGroup cols={2}>
   <Card title="Rive Community" href="https://community.rive.app/c/start-here/" img="/images/learn/community.png">
     Ask questions, share your work, find jobs, and connect with other Rive users.


### PR DESCRIPTION
The link in the top-right menu used to go directly to peer-to-peer support. Now it takes you to a landing page. 

#  Problems we're trying to solve

- There are many ways to get support, not just peer-to-peer
- Subtly nudge them to Voyager (I also added a link to upgrade on the signed out Voyager Support Circle page)
- FAQs for important questions (we get too many emails for cancelling Rive) and links to other FAQs (runtimes) 

<img width="3456" height="4078" alt="screencapture-localhost-3000-community-support-2026-04-10-11_33_04" src="https://github.com/user-attachments/assets/2d10e85a-caec-4a29-a37e-9278151bc3dd" />

