### PR TITLE
docs(flutter): add link to api reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -514,7 +514,8 @@
                     ]
                   },
                   "runtimes/flutter/migration-guide",
-                  "runtimes/flutter/faq"
+                  "runtimes/flutter/faq",
+                  "runtimes/flutter/api-reference"
                 ]
               },
               {

--- a/runtimes/flutter/api-reference.mdx
+++ b/runtimes/flutter/api-reference.mdx
@@ -1,0 +1,11 @@
+---
+title: "Flutter API Reference"
+sidebarTitle: "API Reference"
+description: "Explore the full Rive Flutter API, including widgets, controllers, and runtime classes."
+---
+
+If you're just getting started, check out the [Flutter Getting Started](/runtimes/flutter/flutter) guide instead.
+
+<Card title="View Flutter API Reference" icon="arrow-up-right" href="https://pub.dev/documentation/rive/latest/">
+  Open the full API docs on pub.dev
+</Card>

--- a/runtimes/flutter/api-reference.mdx
+++ b/runtimes/flutter/api-reference.mdx
@@ -6,6 +6,6 @@ description: "Explore the full Rive Flutter API, including widgets, controllers,
 
 If you're just getting started, check out the [Flutter Getting Started](/runtimes/flutter/flutter) guide instead.
 
-<Card title="View Flutter API Reference" icon="arrow-up-right" href="https://pub.dev/documentation/rive/latest/">
+<Card title="View Flutter API Reference" icon="arrow-up-right" href="https://pub.dev/documentation/rive/latest/rive/">
   Open the full API docs on pub.dev
 </Card>


### PR DESCRIPTION
Add a very simple landing page that describes and links to the pub.dev docs. 

<img width="2054" height="1506" alt="CleanShot 2026-04-14 at 10 30 11@2x" src="https://github.com/user-attachments/assets/8f01f09a-559f-4916-97b3-3f1ad371a78f" />
