### PR TITLE
fix(docs): Replace relative paths with absolute paths

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -651,11 +651,11 @@
     "links": [
       {
         "label": "Learn",
-        "href": "/tutorials/learn-rive"
+        "href": "https://rive.app/docs/tutorials/learn-rive"
       },
       {
         "label": "Support",
-        "href": "/community/support"
+        "href": "https://rive.app/docs/community/support"
       }
     ],
     "primary": {
@@ -707,15 +707,15 @@
           },
           {
             "label": "Terms of Service",
-            "href": "/legal/terms-of-service"
+            "href": "https://rive.app/docs/legal/terms-of-service"
           },
           {
             "label": "Acceptable Use Policy",
-            "href": "/legal/acceptable-use-policy"
+            "href": "https://rive.app/docs/legal/acceptable-use-policy"
           },
           {
             "label": "Privacy Policy",
-            "href": "/legal/privacy-policy"
+            "href": "https://rive.app/docs/legal/privacy-policy"
           }
         ]
       }


### PR DESCRIPTION
Replaces the relative paths in `docs.json` with absolute paths to satisfy Mintlify's CLI.