### PR TITLE
docs: add overview to editor artboards pages

### DIFF
--- a/runtimes/android/artboards.mdx
+++ b/runtimes/android/artboards.mdx
@@ -3,7 +3,7 @@ title: 'Artboards'
 description: 'Selecting which artboard to render at runtime'
 ---
 
-import Header from "/snippets/runtimes/artboards/header.mdx"
+import Header from "/snippets/runtimes/artboards/overview.mdx"
 import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboard.mdx"
 
 <Header />

--- a/runtimes/apple/artboards.mdx
+++ b/runtimes/apple/artboards.mdx
@@ -3,7 +3,7 @@ title: 'Artboards'
 description: 'Selecting which artboard to render at runtime'
 ---
 
-import Header from "/snippets/runtimes/artboards/header.mdx"
+import Header from "/snippets/runtimes/artboards/overview.mdx"
 import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboard.mdx"
 
 import { Apple } from "/snippets/constants.mdx"

--- a/runtimes/flutter/artboards.mdx
+++ b/runtimes/flutter/artboards.mdx
@@ -3,7 +3,7 @@ title: 'Artboards'
 description: 'Selecting which artboard to render at runtime'
 ---
 
-import Header from "/snippets/runtimes/artboards/header.mdx"
+import Header from "/snippets/runtimes/artboards/overview.mdx"
 import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboard.mdx"
 
 <Header />

--- a/runtimes/react-native/artboards.mdx
+++ b/runtimes/react-native/artboards.mdx
@@ -3,7 +3,7 @@ title: 'Artboards'
 description: 'Selecting which artboard to render at runtime'
 ---
 
-import Header from "/snippets/runtimes/artboards/header.mdx"
+import Header from "/snippets/runtimes/artboards/overview.mdx"
 import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboard.mdx"
 
 <Header />

--- a/runtimes/react/artboards.mdx
+++ b/runtimes/react/artboards.mdx
@@ -3,7 +3,7 @@ title: 'Artboards'
 description: 'Selecting which artboard to render at runtime'
 ---
 
-import Header from "/snippets/runtimes/artboards/header.mdx"
+import Header from "/snippets/runtimes/artboards/overview.mdx"
 import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboard.mdx"
 
 <Header />

--- a/snippets/example-eye-follow.jsx
+++ b/snippets/example-eye-follow.jsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-
 export const ExampleEyeFollow = () => {
   const [riveReady, setRiveReady] = useState(false);
 
@@ -50,13 +48,13 @@ export const ExampleEyeFollow = () => {
         }),
          onLoad: () => {
           r.resizeDrawingSurfaceToCanvas();
-      
+
           const vmi = r.viewModelInstance;
           if (!vmi) return;
-      
+
           const xProperty = vmi.number("xPos");
           const yProperty = vmi.number("yPos");
-      
+
           // Set the x and y values to 50 initially so the character is looking forward
           if (xProperty) {
             xProperty.value = 50;
@@ -64,21 +62,21 @@ export const ExampleEyeFollow = () => {
           if (yProperty) {
             yProperty.value = 50;
           }
-      
+
           // Unified handler for both mouse and touch position updates
           const updatePosition = (clientX, clientY) => {
             // Get canvas position and dimensions
             const rect = riveCanvas.getBoundingClientRect();
-      
+
             // Calculate position relative to canvas
             const canvasX = clientX - rect.left;
             const canvasY = clientY - rect.top;
-      
+
             // Map position to 0-100 range based on canvas dimensions
             // This accounts for canvas position in the window
             const xValue = mapCursorToRange(canvasX, rect.width);
             const yValue = mapCursorToRange(canvasY, rect.height);
-      
+
             // Update the view model properties
             if (xProperty) {
               xProperty.value = xValue;
@@ -86,16 +84,16 @@ export const ExampleEyeFollow = () => {
             if (yProperty) {
               yProperty.value = yValue;
             }
-      
+
             // Optional: Log values for debugging
             // console.log(`X: ${xValue.toFixed(2)}, Y: ${yValue.toFixed(2)}`);
           };
-      
+
           // Mouse move event handler
           const handleMouseMove = (event) => {
             updatePosition(event.clientX, event.clientY);
           };
-      
+
           // Touch move event handler
           const handleTouchMove = (event) => {
             // Use the first touch point
@@ -104,20 +102,20 @@ export const ExampleEyeFollow = () => {
               updatePosition(touch.clientX, touch.clientY);
             }
           };
-      
+
           // Touch end event handler - reset to center when touch ends
           const handleTouchEnd = () => {
             if (xProperty) xProperty.value = 50;
             if (yProperty) yProperty.value = 50;
           };
-      
+
           // Add mouse move listener to the entire window
           window.addEventListener("mousemove", handleMouseMove);
-      
+
           // Add touch event listeners to the entire window (passive to allow scrolling)
           window.addEventListener("touchmove", handleTouchMove, { passive: true });
           window.addEventListener("touchend", handleTouchEnd);
-      
+
           // Set x and y values back to 50 when the cursor leaves the window
           document.addEventListener("mouseleave", () => {
             if (xProperty) xProperty.value = 50;


### PR DESCRIPTION
This file got misnamed at some point so it was missing from the various runtime artboards pages. Here's what's being added: 

<img width="806" height="77" alt="CleanShot 2026-04-14 at 11 44 55" src="https://github.com/user-attachments/assets/709d40c9-86cd-4b64-9eed-57e53d5c85de" />
