### PR TITLE
docs(android): Add legacy bindable artboards with VMI example

### DIFF
--- a/runtimes/android/data-binding.mdx
+++ b/runtimes/android/data-binding.mdx
@@ -508,8 +508,7 @@ import { Demos } from "/snippets/demos.jsx";
     externalFile.dispose()
     ```
 
-    Bindable artboards can also be provided a view model instance to control the state of it.
-
+    You can also create a bindable artboard with a view model instance to control its state.
 
     ```kotlin
     // Create the view model instance for the child artboard.

--- a/runtimes/android/data-binding.mdx
+++ b/runtimes/android/data-binding.mdx
@@ -507,6 +507,28 @@ import { Demos } from "/snippets/demos.jsx";
     // Clean up external file when done
     externalFile.dispose()
     ```
+
+    Bindable artboards can also be provided a view model instance to control the state of it.
+
+
+    ```kotlin
+    // Create the view model instance for the child artboard.
+    val childVmi = childFile.getViewModelByName("ChildVM").createBlankInstance()
+    val bindableArtboard = childFile.createBindableArtboardByName("Child", childVmi)
+
+    // Get the artboard property from the main artboard.
+    val vmi = rive.file!!.firstArtboard.viewModelInstance!!
+    val artboardProperty = vmi.getArtboardProperty("Artboard property")
+
+    // Set the bound artboard VMIs state.
+    childVmi.getNumberProperty("rotation").value = 90f
+
+    // Set the bound artboard on the main artboard.
+    artboardProperty.set(bindableArtboard)
+    
+    // Release the reference we hold from creation.
+    bindableArtboard.release() 
+    ```
     </Tab>
 </Tabs>
 


### PR DESCRIPTION
Adds documentation for bindable artboards with an attached view model instance.

Note:
Please do not merge until the other runtime contributions have been added.

- [ ] Web
- [ ] React
- [ ] React Native
- [ ] Flutter
- [ ] Apple
- [x] Android
- [ ] Unity
- [ ] Unreal