### PR TITLE
docs(editor): data binding migration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -182,7 +182,8 @@
                 "group": "Data Binding",
                 "pages": [
                   "editor/data-binding/overview",
-                  "editor/data-binding/lists"
+                  "editor/data-binding/lists",
+                  "editor/data-binding/migration-guide"
                 ]
               },
               {

--- a/editor/data-binding/migration-guide.mdx
+++ b/editor/data-binding/migration-guide.mdx
@@ -5,7 +5,20 @@ description: "Migrate from State Machine Inputs and Listening to Events at runti
 
 Data binding replaces both **state machine inputs** and **runtime event listeners**, and also removes the need to directly modify elements like text runs from code.
 
-It provides a more flexible, consistent system for both sending data into Rive and reacting to changes from Rive.
+It provides more data types in a more flexible, consistent system for both sending data into Rive and reacting to changes from Rive.
+
+|                        | Inputs | Events | View Model Properties |
+| ---------------------- | :----- | :----- | :-------------------- |
+| Floating point numbers | ✅      | ✅      | ✅                   |
+| Booleans               | ✅      | ✅      | ✅                   |
+| Triggers               | ✅      | ❌      | ✅                   |
+| Strings                | ❌      | ✅      | ✅                   |
+| Enumerations (Enums)   | ❌      | ❌      | ✅                   |
+| Colors                 | ❌      | ❌      | ✅                   |
+| View Model Nesting     | ❌      | ❌      | ✅                   |
+| Lists                  | ❌      | ❌      | ✅                   |
+| Images                 | ❌      | ❌      | ✅                   |
+| Artboards              | ❌      | ❌      | ✅                   |
 
 <Note>
   You do **not** need to update existing files. Inputs and events will continue to work as expected. Data binding is recommended for new work and future updates.

--- a/editor/data-binding/migration-guide.mdx
+++ b/editor/data-binding/migration-guide.mdx
@@ -1,0 +1,126 @@
+---
+title: "Migration Guide"
+description: "Migrate from State Machine Inputs and Listening to Events at runtime to Data Binding"
+---
+
+Data binding replaces both **state machine inputs** and **runtime event listeners**, and also removes the need to directly modify elements like text runs from code.
+
+It provides a more flexible, consistent system for both sending data into Rive and reacting to changes from Rive.
+
+<Note>
+  You do **not** need to update existing files. Inputs and events will continue to work as expected. Data binding is recommended for new work and future updates.
+</Note>
+
+
+## Migrating from Deprecated Features
+
+### State Machine Inputs
+
+State machine inputs were previously the main way to control animations from code.
+
+With data binding, you instead expose **view model properties** that can drive State machine transitions, Blend states, and Any bindable property in the editor
+
+<Steps>
+  <Step>Open the **hamburger menu** in the editor</Step>
+  <Step>Select **Convert Inputs to View Models**</Step>
+  <Step>Update your runtime code to set values on the view model instead of inputs</Step>
+</Steps>
+
+<Note>
+  **Why are State Machine Inputs deprecated?**
+
+  Inputs are limited to driving state machine transitions and must be used as-is.
+
+  View model properties:
+  - Can drive more than just transitions
+  - Can be transformed using converters
+  - Can be shared across multiple parts of a file
+  - Provide a more flexible and scalable data model
+</Note>
+
+#### How to migrate
+
+
+### Communicating with Code via Events
+
+Events were previously used to send information from a Rive file back to runtime code.
+
+With data binding, you instead **listen to changes on view model properties**, including trigger and lists.
+
+<Note>
+  **Why is listening for Events at runtime deprecated?**
+
+  Events had several limitations:
+
+  - Difficult to pass dynamic or changing data
+  - Required manual handling to work across nested artboards
+  - Represented a one-time signal rather than a persistent value
+
+  View model properties always reflect the latest value and can be observed directly.
+</Note>
+
+#### How to migrate
+
+Instead of listening for an event:
+
+- Create a **view model property**
+- Update it from your Rive file (via animation, listener, or script)
+- Subscribe to that property in your runtime
+
+For more info, see [Data Binding](/runtimes/data-binding)
+
+---
+
+### Updating Text Runs at Runtime
+
+Previously, updating text required:
+- Knowing the exact **name**
+- Knowing the **hierarchy/path**
+- Accessing the text run directly from code
+
+This approach was brittle and easy to break when files changed.
+
+With data binding:
+- Bind a **string property** to a text run
+- Update the value through the view model
+
+This keeps your runtime code stable even if the structure of your file changes.
+
+
+
+## When to Use Data Binding vs Other Features
+
+### Constraints
+
+Constraints are still fully supported and remain the best option for many use cases.
+
+#### When to use constraints
+
+Use constraints when:
+- You are linking one object directly to another
+- The relationship is purely visual or spatial
+- You want a simple, editor-only solution
+
+#### When to use data binding instead
+
+Use data binding when:
+- The value needs to come from **runtime code**
+- Multiple elements depend on the same value
+- You want to introduce **logic or transformation** (via converters)
+- The relationship isn’t strictly object-to-object
+
+<Tip>
+
+**Example:**
+
+You could:
+- Use a **constraint** to link the rotation of multiple wheels together
+
+Or:
+- Use a **data-bound `rotation` property** that:
+  - Is controlled at runtime
+  - Drives all wheels
+  - Can be reused elsewhere (speed, effects, UI, etc.)
+</Tip>
+
+Data binding is more flexible, while constraints are more direct.

--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -54,13 +54,13 @@ These exported instances can then be assigned to an artboard at runtime by devel
 
 ### Binding
 
-A binding is an association between a view model property and an editor element. For instance, you might have a string property called "name" bound to a text run. Once bound, the text run will take the value from the view model property. See [Bind Direction](#bind-direction) for additional options. 
+A binding is an association between a view model property and an editor element. For instance, you might have a string property called "name" bound to a text run. Once bound, the text run will take the value from the view model property. See [Bind Direction](#bind-direction) for additional options.
 
 #### Absolute & Relative Binding
 By default, new data binding connections are created as absolute binds.
 
-- Absolute Binding: the bind points the value at a specific property location within the view model tree. For example, "the second property of the first view model". 
-- Relative Binding: the bind finds the value of property with a specific name, regardless of where it falls within the view model tree. For example, a relative binding to "myNumber" will look for a property of that name within the view model available. 
+- Absolute Binding: the bind points the value at a specific property location within the view model tree. For example, "the second property of the first view model".
+- Relative Binding: the bind finds the value of property with a specific name, regardless of where it falls within the view model tree. For example, a relative binding to "myNumber" will look for a property of that name within the view model available.
 
 <YouTube id="4LOXhXesG74" />
 
@@ -97,63 +97,6 @@ Enum properties can be either a "system" enum, in which case they represent a fi
 A converter is a general purpose way of transforming a binding's value when it is applied. These transformations might involve changing its type. For instance, the "Convert to String" converter can be used to convert a numerical binding to text, so that an object's X position could be applied to a text run.
 
 To apply a converter on a value that already has a binding, right click on the bound property, click Update Bind, and select your converter from the Convert dropdown.
-
-# Comparing to Existing Features
-
-Data binding fills some of the same roles as existing features in Rive. In general, it is considered a more powerful alternative to both inputs and events, and we recommend you adopt it for most use cases going forward. However, this does not mean that you need to retrofit existing files as they will continue to work as expected.
-
-### Type Support
-
-View model properties can represent more types of data compared to inputs and events. See below for a comparison.
-
-|                        | Inputs | Events | View Model Properties |
-| ---------------------- | :----- | :----- | :-------------------- |
-| Floating point numbers | ✅      | ✅      | ✅                     |
-| Booleans               | ✅      | ✅      | ✅                     |
-| Triggers               | ✅      | ❌      | ✅                     |
-| Strings                | ❌      | ✅      | ✅                     |
-| Enumerations (Enums)   | ❌      | ❌      | ✅                     |
-| Colors                 | ❌      | ❌      | ✅                     |
-| View Model Nesting     | ❌      | ❌      | ✅                     |
-| Lists                  | ❌      | ❌      | ✅                     |
-| Images                 | ❌      | ❌      | ✅                     |
-| Artboards              | ❌      | ❌      | ✅                     |
-
-### State Machine Inputs
-
-Before data binding, state machine inputs were the primary way for developers to affect designs. They formed the "input" side of the contract with design. View model properties are a more flexible system.
-
-Inputs can only be used to drive state machine transitions, whereas data binding can be used to drive most editor elements in Rive and state machine transitions.
-
-Inputs must be used as-is where data-bound properties can be converted, either before being used by developers or before being applied to editor elements.
-
-View model properties also support both polling and listening APIs for developers, whereas inputs only support polling. This means that developers can more naturally react to changes in data.
-
-View model properties can also be used in two features currently used by inputs, that being blended states (both Blend 1D and Blend Additive) as the mix parameter and as the receiver for listeners, e.g. setting a value on a mouse click or tap.
-
-### Events
-
-The counterpart to inputs, events were the primary way for developers to receive "outputs" from designs. Data binding is a much richer channel for developers to observe values from the Rive design. Additionally, events were used internally in Rive files to add reactivity using listeners. Both of these use cases are addressed by properties. For developers, the runtime APIs allow you to subscribe to changes to their values. For designers, you can bind reacting elements directly to the property.
-
-Events can only be triggered by timelines, state machine transitions, or listeners. By comparison, data bound properties can be changed from any number of sources.
-
-Events can have keyable properties with values that are passed when triggered. This is limited to being updated by animation keys and can be tricky to "bubble" when the animation exists on a component. By comparison, view model properties carry the most recent data each time they change, from any level of the hierarchy, triggering a developer's listener with the new value.
-
-One use case which events offer functionality not yet supported by data binding is in their ability to play audio.
-
-### Constraints
-
-Constraints allow for a specific kind of binding between two objects, such as Translation for position. This constraint is optimized for that use case, with built in options for local/world space conversion, a strength parameter, minimum and maximum values, etc. For use cases where this is all you need, this is likely to be the more concise option. By comparison, for example, data binding the X and Y positions can be used for a broader range of output behavior, though it may require some setup with converters to achieve.
-
-### Nesting
-
-There are a few use cases related to nesting where you may want to consider updating to use data binding, as it offers a much more straightforward approach:
-
-- Setting nested inputs
-- Setting nested text runs
-- "Bubbling" nested events
-
-These three use cases are unified by view model instances, where components can pull from top-level viewmodels. This simplifies the developer interop, as the structure, naming, and nesting of the file's artboards can change without breaking the code's reference to the data.
 
 # Runtime APIs
 


### PR DESCRIPTION
_This is part of a larger project focused on improving the data binding docs_ 

Right now the Overview has a bunch of info about why we switched from Inputs and Events. This PR  moves that info to its own page and rewrites it to read more like a migration guide. 

It's a little longer, but there is less text overall. And I put a lot of it in lists and <Info> callouts to make it more scannable. 

This also includes instructions for automatic conversion, which didn't exist when these docs were first written. 