### PR TITLE
docs(editor): update audio events page to reference scripting API

### DIFF
--- a/editor/events/audio-events.mdx
+++ b/editor/events/audio-events.mdx
@@ -13,7 +13,7 @@ Audio events represent the first phase of audio features in Rive — they provid
 
 Previously, triggering audio with events would require some work with one of the Rive runtimes and your application or game. The introduction of audio events directly inside the Rive editor streamlines the process of adding sound to your animations — further empowering designers, whilst simplifying the implementation for developers.
 
-<Info>Audio events are ideal for triggering shorter sounds in response to user interactions or to compliment character animations. Whilst longer form audio — such as background music and voice overs — can also be triggered with audio events, they lack a level of control to manipulate volume, panning, and more over time. Stay tuned for additional audio features coming soon that provide preferred solutions for other audio use cases.</Info>
+<Info>Audio events are ideal for triggering shorter sounds in response to user interactions or to compliment character animations. Whilst longer form audio — such as background music and voice overs — can also be triggered with audio events, they lack a level of control to manipulate volume, panning, and more over time. For use cases requiring greater control over playback, consider using [Scripting](/scripting/getting-started). Check out [AudioSound](/scripting/api-reference/interfaces/audio-sound) and [AudioSource](/scripting/api-reference/interfaces/audio-source) for more information.</Info>
 
 ---
 
@@ -82,11 +82,3 @@ Like regular events, audio events can be triggered in a selection of different w
 ### Monitoring audio
 
 Audio levels can be monitored via the VU meter at the base of the inspector. Use the VU meter to check for clipping. This may occur if multiple audio events are playing at once, causing the overall output to clip. If you notice peak levels turning red, consider lowering the volume of your audio asset to provide more headroom.
-
----
-
-## Triggering audio with the Scripting API
-
-Audio can also be triggered directly from the [Scripting API](/scripting/getting-started), without relying on audio events. This gives you programmatic control over playback — including pausing, resuming, seeking, and adjusting volume at runtime.
-
-For the full list of available controls, see the [`AudioSource`](/scripting/api-reference/interfaces/audio-source) and [`AudioSound`](/scripting/api-reference/interfaces/audio-sound) API reference pages.

--- a/editor/events/audio-events.mdx
+++ b/editor/events/audio-events.mdx
@@ -82,3 +82,11 @@ Like regular events, audio events can be triggered in a selection of different w
 ### Monitoring audio
 
 Audio levels can be monitored via the VU meter at the base of the inspector. Use the VU meter to check for clipping. This may occur if multiple audio events are playing at once, causing the overall output to clip. If you notice peak levels turning red, consider lowering the volume of your audio asset to provide more headroom.
+
+---
+
+## Triggering audio with the Scripting API
+
+Audio can also be triggered directly from the [Scripting API](/scripting/getting-started), without relying on audio events. This gives you programmatic control over playback — including pausing, resuming, seeking, and adjusting volume at runtime.
+
+For the full list of available controls, see the [`AudioSource`](/scripting/api-reference/interfaces/audio-source) and [`AudioSound`](/scripting/api-reference/interfaces/audio-sound) API reference pages.

--- a/editor/events/audio-events.mdx
+++ b/editor/events/audio-events.mdx
@@ -13,7 +13,11 @@ Audio events represent the first phase of audio features in Rive — they provid
 
 Previously, triggering audio with events would require some work with one of the Rive runtimes and your application or game. The introduction of audio events directly inside the Rive editor streamlines the process of adding sound to your animations — further empowering designers, whilst simplifying the implementation for developers.
 
-<Info>Audio events are ideal for triggering shorter sounds in response to user interactions or to compliment character animations. Whilst longer form audio — such as background music and voice overs — can also be triggered with audio events, they lack a level of control to manipulate volume, panning, and more over time. For use cases requiring greater control over playback, consider using [Scripting](/scripting/getting-started). Check out [AudioSound](/scripting/api-reference/interfaces/audio-sound) and [AudioSource](/scripting/api-reference/interfaces/audio-source) for more information.</Info>
+<Info>
+Audio events are ideal for triggering shorter sounds in response to user interactions or to compliment character animations. Whilst longer form audio — such as background music and voice overs — can also be triggered with audio events, they lack a level of control to manipulate volume, panning, and more over time. 
+
+For use cases requiring greater control over volume and playback, consider using [Scripting](/scripting/getting-started). Check out [AudioSound](/scripting/api-reference/interfaces/audio-sound) and [AudioSource](/scripting/api-reference/interfaces/audio-source) for more information.
+</Info>
 
 ---
 


### PR DESCRIPTION
Updates the info block on the Audio Events page to replace the placeholder "Stay tuned" message with direct links to the Scripting API for users who need greater control over audio playback. References the AudioSound and AudioSource interfaces as the recommended path for advanced use cases.