### PR TITLE
fix footer legal links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -719,15 +719,15 @@
           },
           {
             "label": "Terms of Service",
-            "href": "/legal/terms-of-service"
+            "href": "/docs/legal/terms-of-service"
           },
           {
             "label": "Acceptable Use Policy",
-            "href": "/legal/acceptable-use-policy"
+            "href": "/docs/legal/acceptable-use-policy"
           },
           {
             "label": "Privacy Policy",
-            "href": "/legal/privacy-policy"
+            "href": "/docs/legal/privacy-policy"
           }
         ]
       }


### PR DESCRIPTION
We were directing to /legal/terms-of-service instead of /docs/legal/terms-of-service