### PR TITLE
docs(js): update available public APIs and parameters when using the high-level JS runtime

### DIFF
--- a/runtimes/web/data-binding.mdx
+++ b/runtimes/web/data-binding.mdx
@@ -366,6 +366,9 @@ const assetsFile = new RiveFile({
 assetsFile.init();
 ```
 
+In the example above, we load from a separate `swap_character_assets.riv` file to get the `Character 1` bindable artboard. We can then use this value in the main `swap_character_main.riv` file by setting the value of the `artboardProperty` to the loaded `characterArtboard`. This allows us to swap out the artboard being used in the main file at runtime.
+Additionally, you can set an external `ViewModelInstance` to that bindable artboard via the `.viewModel` setter.
+
 <Enums />
 
 ```typescript

--- a/runtimes/web/data-binding.mdx
+++ b/runtimes/web/data-binding.mdx
@@ -53,12 +53,18 @@ for (let i = 0; i < r.viewModelCount; i++) {
 const defaultVM = r.defaultViewModel();
 ```
 
-Alternatively, if you have access to the underlying Rive File object you can access the above methods on the file.
+Alternatively, if you have access to the underlying `RiveFile` object you can access the above methods on the file.
 
 ```typescript
-const namedVM = file.viewModelByName("My View Model");
-const indexedVM = file.viewModelByIndex(0);
-const defaultVM = file.defaultArtboardViewModel(artboard);
+const file = new RiveFile(/** ... */);
+await file.init();
+const vmFromFile = file.viewModelByName("My View Model");
+
+// Or grab the ViewModel via other means from the RiveFile underlying instance
+const fileInstance = file.getInstance();
+const namedVM = fileInstance.viewModelByName("My View Model");
+const indexedVM = fileInstance.viewModelByIndex(0);
+const defaultVM = fileInstance.defaultArtboardViewModel(artboard);
 ```
 
 <ViewModelInstances />
@@ -171,8 +177,8 @@ const r = new rive.Rive({
 
         // Other ways to set color
         colorProperty.rgb(255, 0, 0); // Set RGB to red
-        colorProperty.rbga(255, 0, 0, 128); // Set RGBA to red with 50% opacity
-        colorProperty.argba(128, 255, 0, 0); // Set RGBA to red with 50% opacity
+        colorProperty.rgba(255, 0, 0, 128); // Set RGBA to red with 50% opacity
+        colorProperty.argb(128, 255, 0, 0); // Set ARGB to red with 50% opacity
         colorProperty.opacity(0.5); // Set opacity to 50%
 
         // Triggers

--- a/runtimes/web/layouts.mdx
+++ b/runtimes/web/layouts.mdx
@@ -92,3 +92,31 @@ riveInstance.layout = new rive.Layout({ fit: rive.Fit.Fill });
     .matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
     .addEventListener("change", computeSize);
 ```
+
+## TypeScript API surface
+
+These types are exported from `@rive-app/canvas` (or your bundled `rive` global):
+
+```typescript
+export interface LayoutParameters {
+  fit?: Fit;
+  alignment?: Alignment;
+  layoutScaleFactor?: number;
+  minX?: number;
+  minY?: number;
+  maxX?: number;
+  maxY?: number;
+}
+
+export class Layout {
+  constructor(params?: LayoutParameters);
+  readonly fit: Fit;
+  readonly alignment: Alignment;
+  readonly layoutScaleFactor: number;
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+  copyWith(partial: LayoutParameters): Layout;
+}
+```

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -322,5 +322,3 @@ When using Rive’s advanced JS APIs to customize how you use Rive, you will hav
 ## Integrating Rive into Existing rAF Loop
 
 If you're looking to add Rive to your existing render loop (the JS API `requestAniationFrame()`) and do not want to use the Rive-wrapped `requestAnimationFrame()` API, you can do so with an extra API call at the end of your render loop. Call the `rive.resolveAnimationFrame()` API at the end of the render loop before calling `requestAnimationFrame()` again.
-
-See more on usage in the [Rive Parameters](/runtimes/web/rive-parameters) doc.

--- a/runtimes/web/playing-audio.mdx
+++ b/runtimes/web/playing-audio.mdx
@@ -17,3 +17,14 @@ import ReferencedAssets from "/snippets/runtimes/playing-audio/referenced-assets
 <ReferencedAssets />
 
 For more information, see [Loading Assets](/runtimes/web/loading-assets).
+
+## Volume control
+
+To control volume on the artboard, set the `.volume` property on the Rive instance. The value is a multiplier applied to the default volume level of each audio event on the artboard, allowing you to adjust the overall audio level up or down as needed. The default value is `1.0`, which means the audio plays at its default level.
+To mute the audio, set `.volume` to `0`.
+
+The example below adjusts the volume to be 50% softer than the default level.
+```javascript
+const r = new Rive ({ ... });
+r.volume = 0.5;
+```

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -7,17 +7,14 @@ This page is a **reference** for constructor options, types, and instance method
 
 **Related guides**
 
-- [Getting started](/runtimes/web/web-js) — install, `src` / public paths, basic `onLoad` + `resizeDrawingSurfaceToCanvas`
-- [Artboards](/runtimes/web/artboards) — choosing artboards in the `.riv` file (pairs with `artboard` / `reset` / `load`)
-- [Layout](/runtimes/web/layouts) — fit, alignment, bounds, responsive `Fit.Layout`, DPR / resize patterns
-- [State machine playback](/runtimes/web/state-machines) — `play` / `pause` / `stop`, **`reset()`** example
-- [Loading assets](/runtimes/web/loading-assets) — **`assetLoader`**, referenced/hosted assets, `decodeFont` / `decodeImage`
+- [Getting started](/runtimes/web/web-js) — start here for a walkthrough of loading Rive into your web applications
+- [Artboards](/runtimes/web/artboards) — choosing artboards to load from the `.riv` file
+- [Layout](/runtimes/web/layouts) — see how to layout your Rive graphic within the canvas and make it responsive to size changes
+- [State machine playback](/runtimes/web/state-machines) — handle playback controls for the Rive state machine
+- [Loading assets](/runtimes/web/loading-assets) — handle asset loading for your Rive file
 - [Caching a Rive file](/runtimes/web/caching-a-rive-file) — **`RiveFile`** + **`riveFile`** for multiple instances
 - [Data binding](/runtimes/web/data-binding) — **`autoBind`**, view models, `bindViewModelInstance`
-- [Rive Events](/runtimes/web/rive-events) — subscribing to **`EventType.RiveEvent`** (legacy events; prefer data binding where possible)
-- [Low-level API](/runtimes/web/low-level-api-usage) — custom render loops, **`resolveAnimationFrame()`** on the WASM runtime
-- [Text](/runtimes/web/text) — text runs vs data binding; nested paths pair with APIs below
-- [Playing audio](/runtimes/web/playing-audio) — artboard **`volume`** and audio behavior in the browser
+- [Playing audio](/runtimes/web/playing-audio) — handling audio assets and controlling volume levels
 
 ## `Rive` constructor parameters
 
@@ -30,7 +27,7 @@ export interface RiveParameters {
   buffer?: ArrayBuffer; // one of src, buffer, or riveFile is required
   riveFile?: RiveFile; // one of src, buffer, or riveFile is required
   artboard?: string;
-  stateMachines?: string | string[];
+  stateMachines?: string | string[]; // strongly recommended setting this property
   layout?: Layout;
   autoplay?: boolean;
   autoBind?: boolean;
@@ -60,9 +57,9 @@ export interface RiveParameters {
 
 - `canvas` - *(required)* Provide a `<canvas>` element to draw Rive animations onto.
 - To load a `.riv` file, one of the following is required:
-  - `src` - *(optional)* Hosted URL or app-relative public path to the `.riv` file. One of `src`, `buffer`, or `riveFile` must be provided. URL vs bundled path, bundler/data-URI setup, and a minimal example are on [Getting started](/runtimes/web/web-js#loading-rive-files).
-  - `buffer` - *(optional)* `ArrayBuffer` of `.riv` bytes. One of `src`, `buffer`, or `riveFile` must be provided.
-  - `riveFile` - *(optional)* Provide a loaded **`RiveFile`** (parsed file + assets) across instances. See [Caching a Rive file](/runtimes/web/caching-a-rive-file).
+  - `src` - *(optional)* Hosted URL or app-relative public path to the `.riv` file. See a minimal example on the [Getting started](/runtimes/web/web-js#loading-rive-files) guide.
+  - `buffer` - *(optional)* `ArrayBuffer` of `.riv` bytes.
+  - `riveFile` - *(optional)* Provide a loaded **`RiveFile`** across instances. See [Caching a Rive file](/runtimes/web/caching-a-rive-file) for more details.
 - `artboard` - *(optional)* Name of the artboard to use. If not provided, it will pull the default artboard from the exported `.riv` file.
 - `stateMachines` - *(strongly recommended)* Name of a state machine to load (i.e. `"State Machine 1"`) from the `.riv` file. If not provided, currently Rive will pull the first linear animation it finds (deprecated behavior). In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
 
@@ -70,15 +67,15 @@ export interface RiveParameters {
  Note: You should only provide a single state machine string for `stateMachines`. Running multiple state machines of the same artboard at the same time may cause unintended consequences.
 </Note>
 
-- `layout` - *(optional)* Provide a [`new Layout()`](/runtimes/web/layouts) instance. See that page for fit modes, alignment, bounds, and responsive layout.
+- `layout` - *(optional)* Provide a [`new Layout()`](/runtimes/web/layouts) instance. See that guide for fit modes, alignment, bounds, and responsive layout.
 - `autoplay` - *(optional)* If true, the animation will automatically start playing when loaded. Defaults to false.
-- `useOffscreenRenderer` - *(optional)* Boolean flag to determine whether to use a shared offscreen WebGL2 context rather than create its own WebGL2 context for this instance of Rive. This is only relevant for WebGL-based runtimes such as `@rive-app/webgl2`. If you are displaying multiple Rive animations, it is highly encouraged to set this flag to `true`. Defaults to `false`.
-- `enableRiveAssetCDN` - *(optional)* Allow the runtime to automatically load assets (i.e. fonts) hosted in Rive's CDN. Enabled true by default.
+- `autoBind` - *(optional)* When set to `true`, Rive will automatically look for a default view model and view model instance to bind to the artboard. Defaults to false.
+- `useOffscreenRenderer` - *(optional)* Boolean flag to determine whether to use a shared offscreen WebGL2 context rather than create its own WebGL2 context for this instance of Rive. This is only relevant for WebGL-based runtimes such as `@rive-app/webgl2`. If you are displaying multiple Rive instances on a page, it is highly encouraged to set this flag to `true`. Defaults to `false`.
+- `enableRiveAssetCDN` - *(optional)* Allow the runtime to automatically load assets (i.e. fonts) hosted in Rive's CDN. Defaults to true.
 - `shouldDisableRiveListeners` - *(optional)* Boolean flag to disable setting up Rive Listeners on the `<canvas>` element, thus preventing any event listeners from being set up on the element.
   - **Note:** Rive Listeners by default are not set up on a `<canvas>` element if there is no playing state machine, or a state machine without any Rive Listeners set up on the state machine
 - `isTouchScrollEnabled` - *(optional)* For Rive Listeners, allows scrolling behavior to still occur on canvas elements when a touch/drag action is performed on touch-enabled devices. Otherwise, scroll behavior may be prevented on touch/drag actions on the canvas by default.
 - `automaticallyHandleEvents` - *(optional)* Enable Rive Events to be handled by the runtime. This means any special Rive Event may have a side effect that takes place implicitly. For example, if during the render loop an `OpenUrlEvent` is detected, the browser may try to open the specified URL in the payload. This flag is `false` by default to prevent any unwanted behaviors from taking place. This means any special Rive Event will have to be handled manually by subscribing to `EventType.RiveEvent`
-- `autoBind` - *(optional)* When set to `true`, Rive will automatically look for a default view model and view model instance to bind to the artboard.
 - `dispatchPointerExit` - *(optional)* For Rive Listeners, dispatches a pointer exit event when the pointer exits the canvas. This can be useful for ensuring hover states are properly reset when the user's cursor leaves the canvas area. Defaults to true.
 - `enableMultiTouch` - *(optional)* Enables multi-touch support for Rive Listeners. When enabled, the runtime will track and respond to multiple simultaneous touch points on touch-enabled devices. Defaults to false.
 - `drawingOptions` - *(optional)* An enum (`DrawOptimizationOptions`) that provides drawing optimization options. This can be used to configure rendering performance optimizations. The default is `DrawOptimizationOptions.DrawOnChanged`, which will only submit a draw command if the artboard has visually updated.
@@ -92,7 +89,7 @@ export interface RiveParameters {
 - `onLoop` - *(optional)* Callback that gets fired when the animation completes a loop.
 - `onStateChange` - *(optional)* Callback that gets fired when a state change occurs.
 - `onAdvance` - *(optional)* Callback that gets fired every frame when the Artboard has advanced.
-- `assetLoader` - *(optional)* Per-asset load hook (**`FileAsset`**, **`bytes`**, return boolean). Full patterns and examples: [Loading assets](/runtimes/web/loading-assets).
+- `assetLoader` - *(optional)* Callback to load assets. Full patterns and examples in the [loading assets](/runtimes/web/loading-assets) guide.
 - `enablePerfMarks` - *(optional)* Emits `performance.mark` / `performance.measure` entries for key Rive startup and render events for performance profiling purposes. False by default. Also available on `RuntimeLoader` and `RiveFile`.
 
 ### Deprecated parameters
@@ -107,9 +104,9 @@ The following APIs are available on a `Rive` instance after construction.
 
 ### Data binding (View Models)
 
-View model APIs on `Rive` are documented in depth on [Data binding](/runtimes/web/data-binding). For a quick reference on available APIs on the `Rive` instance, see below:
+View model APIs on `Rive` are documented in depth on the [data binding](/runtimes/web/data-binding) guide. For a quick reference on available APIs on the `Rive` instance, see below:
 
-- `viewModelInstance` (getter) — currently bound instance, if any. From an instance, you can get a reference to view model properties based on type:
+- `viewModelInstance` (getter) — currently bound instance, if any. This is available if `autoBind` is `true` and there is a default View Model instance to reference. From an instance, you can get a reference to view model properties based on type:
   - `.number(path: string): ViewModelInstanceNumber`
   - `.boolean(path: string): ViewModelInstanceBoolean`
   - `.string(path: string): ViewModelInstanceString`
@@ -127,7 +124,7 @@ View model APIs on `Rive` are documented in depth on [Data binding](/runtimes/we
 - `viewModelByName(name: string): ViewModel | null` - returns a `ViewModel` specified by name, or null if it doesn't exist or the file isn't loaded yet
 - `defaultViewModel(): ViewModel | null` - returns the default `ViewModel` for the file, or null if it doesn't exist or the file isn't loaded yet
 - `bindViewModelInstance(instance: ViewModelInstance | null): void` - Binds a `ViewModelInstance` to the state machine. Note that this is taken care of automatically if `autoBind` is `true`.
-- `enums(): DataEnum[]`
+- `enums(): DataEnum[]` - List of enums defined in the file
 - `getBindableArtboard(name: string): BindableArtboard | null` - Returns a named artboard as a `BindableArtboard`, which exposes data-binding APIs. Once you have a bindable artboard, you can set the `.viewModel` property on that artboard to bind a `ViewModelInstance`. Bindable artboards can be set as a value to an artboard property on a different ViewModel. Returns `null` if the artboard doesn't exist or the file isn't loaded.
 - `getDefaultBindableArtboard(): BindableArtboard | null` - Returns the file's default artboard as a `BindableArtboard`, or `null` if not available.
 
@@ -175,7 +172,7 @@ Resets the artboard, timeline animations, and/or state machines from the start (
 
 ### Canvas size and layout
 
-Use these APIs to respond to canvas or window resize changes to ensure Rive content continues to render crisply.
+Use these APIs to respond to canvas or window resize changes to ensure Rive content scales and renders clearly.
 
 #### resizeDrawingSurfaceToCanvas()
 
@@ -187,7 +184,7 @@ Sets the canvas element’s `width` and `height` from its CSS layout size and de
 In a future major version of this runtime, this API may be called internally on initialization by default, with an option to opt-out if you have specific `width` and `height` properties you want to set on the canvas.
 </Note>
 
-Typical usage (e.g. call from `onLoad` once layout is known): [Getting started](/runtimes/web/web-js), [Layout](/runtimes/web/layouts).
+See the [layout](/runtimes/web/layouts) guide for examples on usage.
 
 #### resizeToCanvas()
 
@@ -195,16 +192,15 @@ Typical usage (e.g. call from `onLoad` once layout is known): [Getting started](
 
 Sets layout bounds (`minX`, `minY`, `maxX`, `maxY`) from the current canvas pixel width and height. Call when the canvas backing store size changes.
 
-
-#### devicePixelRatioUsed
-
-Getter/setter for the DPR value applied when sizing the drawing surface (updated by `resizeDrawingSurfaceToCanvas()`).
-
 #### resetArtboardSize()
 
 `resetArtboardSize(): void`
 
 Restores artboard dimensions to the file's original values.
+
+#### devicePixelRatioUsed
+
+Getter/setter for the device pixel ratio (DPR) value applied when sizing the drawing surface (updated by `resizeDrawingSurfaceToCanvas()`).
 
 #### bounds
 
@@ -226,9 +222,9 @@ Avoid setting these manually when using [`resizeDrawingSurfaceToCanvas()`](#resi
 
 #### volume
 
-Getter/setter for artboard audio volume (combined with system audio when applicable). The default value is `1.0`, which means the volume is set by the default level for that artboard.
+Getter/setter for artboard audio volume. The default value is `1.0`, which means the volume is set by the default level for that artboard.
 
-See the [playing audio](/runtimes/web/playing-audio) guide for more details.
+See the [playing audio](/runtimes/web/playing-audio) guide for more details on controlling volume levels.
 
 ---
 
@@ -254,7 +250,7 @@ Unsubscribe using the same `EventType` and callback reference passed to `on()`.
 
 Removes all listeners for a given `EventType`, or all types if `type` is omitted.
 
-#### EventType
+#### Event types and payload
 
 ```typescript
 export enum EventType {
@@ -270,23 +266,17 @@ export enum EventType {
 }
 ```
 
-- **`Draw`** — Fired when a draw pass occurs (useful for advanced instrumentation).
-
-#### Event payload (`event.data`)
-
 The `Event` type is `{ type: EventType; data?: ... }`. The shape of `data` depends on `type`:
 
 - **Load** — `RiveFile`  (the loaded file handle) or the string "buffer" indicating a load from an ArrayBuffer
 - **LoadError** — `string` (error message)
 - **Play**, **Pause**, **Stop** — `string[]` (names of the animations or state machines affected)
-- **Loop** — `LoopEvent` (`{ animation: string; type: LoopType }`)
+- **Loop** — `LoopEvent` (`{ animation: string; type: LoopType }`). `LoopType` is `OneShot`, `Loop`, or `PingPong`.
 - **Advance** — `number` (elapsed seconds for that frame)
 - **StateChange** — `string[]` (state names that changed)
 - **RiveEvent** — custom or built-in Rive event payload (for example open-URL events)
 
-`LoopType` is `OneShot`, `Loop`, or `PingPong`.
-
-For **`EventType.RiveEvent`** listener examples (including `automaticallyHandleEvents`), see [Rive Events](/runtimes/web/rive-events). Prefer [Data binding](/runtimes/web/data-binding) for new work where it applies.
+For **`EventType.RiveEvent`** listener examples, see [Rive Events](/runtimes/web/rive-events). Prefer [Data binding](/runtimes/web/data-binding) for new work where it applies.
 
 ---
 
@@ -313,7 +303,7 @@ interface RiveLoadParameters {
 load(params: RiveLoadParameters): void
 ```
 
-Replaces the current `.riv` source and reinitializes the instance. Stops current playback and clears the previous file reference. One of `src`, `buffer`, or `riveFile` must be provided (same rule as the constructor). WASM is typically already loaded, so you usually only pay network cost if you point at a new URL.
+Replaces the current `.riv` source and reinitializes the instance. This also stops current playback and clears the previous file reference. One of `src`, `buffer`, or `riveFile` must be provided (same rule as the constructor) when resetting. WASM is typically already loaded, so you usually only pay network cost if you point at a new `.riv` hosted location.
 
 #### cleanup()
 
@@ -363,7 +353,8 @@ Not a method on the high-level **`Rive`** class, but available for using the low
 
 ### Rive Listeners
 
-Editor-side setup: [Listeners](/editor/state-machine/listeners) in the state machine. In most cases, this is automatically handled by the runtime.
+In most cases, listeners are automatically set up and handled during instantiation. See the guide on Rive [listeners](/editor/state-machine/listeners) for more details.
+The following APIs are available if you need specific control over Rive intercepting input events on the canvas.
 
 #### setupRiveListeners()
 
@@ -446,8 +437,6 @@ Once Rive is instantiated, you can inspect various properties of the playing ins
 
 When the file has finished loading, `contents` describes artboards, animations, state machines, and each state machine’s inputs. If not loaded, `undefined`.
 
-Shape (conceptual):
-
 ```typescript
 // Documented shape; types may not be exported from the package
 interface RiveFileContents {
@@ -464,6 +453,8 @@ interface RiveFileContents {
 
 ### `enableFPSCounter()` / `disableFPSCounter()`
 
+Enable FPS readouts for the current instance.
+
 ```typescript
 type FPSCallback = (fps: number) => void;
 
@@ -471,7 +462,7 @@ enableFPSCounter(fpsCallback?: FPSCallback): void;
 disableFPSCounter(): void;
 ```
 
-Without a callback, a fixed-position FPS readout may be injected (runtime-dependent).
+Without a callback, a fixed-position FPS readout may be injected in the corner of the viewport.
 
 ### Performance profiling marks
 
@@ -518,7 +509,7 @@ The following below are named exports from the same package.
 ### `RiveFile`
 
 `RiveFile` lets you parse a `.riv` file once and share the result across multiple `Rive` instances — avoiding redundant network fetches and parse overhead. See the full usage guide at [Caching a Rive file](/runtimes/web/caching-a-rive-file).
-In many cases, you may want to load a `RiveFile` before actually rendering the graphic on a canvas, if you want to preload Rive WASM and the `.riv` file ahead of rendering, or to get certain `.riv` file data.
+In many cases, you may want to load a `RiveFile` before actually rendering the graphic on a canvas. This is useful if you want to preload Rive WASM and the `.riv` file ahead of rendering, or to get certain `.riv` file data.
 
 #### `RiveFile` constructor parameters
 

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -39,7 +39,6 @@ export interface RiveParameters {
   shouldDisableRiveListeners?: boolean;
   isTouchScrollEnabled?: boolean;
   automaticallyHandleEvents?: boolean;
-  animations?: string | string[];
   dispatchPointerExit?: boolean;
   enableMultiTouch?: boolean;
   drawingOptions?: DrawOptimizationOptions;
@@ -65,7 +64,7 @@ export interface RiveParameters {
   - `buffer` - *(optional)* `ArrayBuffer` of `.riv` bytes. One of `src`, `buffer`, or `riveFile` must be provided.
   - `riveFile` - *(optional)* Provide a loaded **`RiveFile`** (parsed file + assets) across instances. See [Caching a Rive file](/runtimes/web/caching-a-rive-file).
 - `artboard` - *(optional)* Name of the artboard to use. If not provided, it will pull the default artboard from the exported `.riv` file.
-- `stateMachines` - *(required)* Name of a state machine to load (i.e. `"State Machine 1"`) from the `.riv` file. If not provided, currently Rive will pull the first linear animation it finds (deprecated behavior). In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
+- `stateMachines` - *(strongly recommended)* Name of a state machine to load (i.e. `"State Machine 1"`) from the `.riv` file. If not provided, currently Rive will pull the first linear animation it finds (deprecated behavior). In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
 
 <Note>
  Note: You should only provide a single state machine string for `stateMachines`. Running multiple state machines of the same artboard at the same time may cause unintended consequences.

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -3,166 +3,160 @@ title: 'Rive Parameters'
 description: 'API docs for the Rive instance.'
 ---
 
-## Parameters
+This page is a **reference** for constructor options, types, and instance methods on the high-level **`Rive`** class, as well as a number of other exported classes. For walkthroughs and samples, use the guides below and link back here when you need exact signatures.
+
+**Related guides**
+
+- [Getting started](/runtimes/web/web-js) — install, `src` / public paths, basic `onLoad` + `resizeDrawingSurfaceToCanvas`
+- [Artboards](/runtimes/web/artboards) — choosing artboards in the `.riv` file (pairs with `artboard` / `reset` / `load`)
+- [Layout](/runtimes/web/layouts) — fit, alignment, bounds, responsive `Fit.Layout`, DPR / resize patterns
+- [State machine playback](/runtimes/web/state-machines) — `play` / `pause` / `stop`, **`reset()`** example
+- [Loading assets](/runtimes/web/loading-assets) — **`assetLoader`**, referenced/hosted assets, `decodeFont` / `decodeImage`
+- [Caching a Rive file](/runtimes/web/caching-a-rive-file) — **`RiveFile`** + **`riveFile`** for multiple instances
+- [Data binding](/runtimes/web/data-binding) — **`autoBind`**, view models, `bindViewModelInstance`
+- [Rive Events](/runtimes/web/rive-events) — subscribing to **`EventType.RiveEvent`** (legacy events; prefer data binding where possible)
+- [Low-level API](/runtimes/web/low-level-api-usage) — custom render loops, **`resolveAnimationFrame()`** on the WASM runtime
+- [Text](/runtimes/web/text) — text runs vs data binding; nested paths pair with APIs below
+- [Playing audio](/runtimes/web/playing-audio) — artboard **`volume`** and audio behavior in the browser
+
+## `Rive` constructor parameters
 
 You can set any of the following parameters on the Rive object when instantiating:
 
-``` typescript
+```typescript
 export interface RiveParameters {
-  canvas: HTMLCanvasElement | OffscreenCanvas, // required
-  src?: string, // one of src or buffer or riveFile is required
-  buffer?: ArrayBuffer, // one of src or buffer or riveFile is required
-  riveFile?: RiveFile, // one of src or buffer or riveFile is required
-  artboard?: string,
-  animations?: string | string[],
-  stateMachines?: string | string[],
-  layout?: Layout,
-  autoplay?: boolean,
-  useOffscreenRenderer?: boolean,
-  enableRiveAssetCDN?: boolean,
-  shouldDisableRiveListeners?: boolean,
-  isTouchScrollEnabled?: boolean,
-  automaticallyHandleEvents?: boolean,
-  autoBind?: boolean,
-  dispatchPointerExit?: boolean,
-  enableMultiTouch?: boolean,
-  drawingOptions?: DrawOptimizationOptions,
-  onLoad?: EventCallback,
-  onLoadError?: EventCallback,
-  onPlay?: EventCallback,
-  onPause?: EventCallback,
-  onStop?: EventCallback,
-  onLoop?: EventCallback,
-  onStateChange?: EventCallback,
-  onAdvance?: EventCallback,
-  assetLoader?: AssetLoadCallback,
-  enablePerfMarks?: boolean,
+  canvas: HTMLCanvasElement | OffscreenCanvas; // required
+  src?: string; // one of src, buffer, or riveFile is required
+  buffer?: ArrayBuffer; // one of src, buffer, or riveFile is required
+  riveFile?: RiveFile; // one of src, buffer, or riveFile is required
+  artboard?: string;
+  stateMachines?: string | string[];
+  layout?: Layout;
+  autoplay?: boolean;
+  autoBind?: boolean;
+  useOffscreenRenderer?: boolean;
+  enableRiveAssetCDN?: boolean;
+  shouldDisableRiveListeners?: boolean;
+  isTouchScrollEnabled?: boolean;
+  automaticallyHandleEvents?: boolean;
+  animations?: string | string[];
+  dispatchPointerExit?: boolean;
+  enableMultiTouch?: boolean;
+  drawingOptions?: DrawOptimizationOptions;
+  onLoad?: EventCallback;
+  onLoadError?: EventCallback;
+  onPlay?: EventCallback;
+  onPause?: EventCallback;
+  onStop?: EventCallback;
+  onLoop?: EventCallback;
+  onStateChange?: EventCallback;
+  onAdvance?: EventCallback;
+  assetLoader?: AssetLoadCallback;
+  enablePerfMarks?: boolean;
+
+  // Deprecated parameters
+  animations?: string | string[]; // deprecated in favor of stateMachines
 }
 ```
 
-- `canvas` - *(required)* Canvas element to draw Rive animations onto.
-- `src?` - *(optional)* There are two optional ways to use `src`: either via URL to the `.riv` file, or a path to the public `.riv` asset to use. One of `src`, `buffer`, or `riveFile` must be provided.
-  - URL - If you are hosting your `.riv` on some publicly accessible bucket/CDN (i.e. AWS, GCS, etc.), you can pass in the URL here.
-    - Alternatively, with ES6, you may import the `.riv` file as a data URI. Depending on your bundle loader, you may need to use a plugin (i.e `url-loader` for Webpack) to properly parse and load in `.riv` files as a data URI string. See [this project](https://github.com/zplata/rive-nextjs/blob/main/next.config.js#L8) as a basic example on how to set this up
-  - Path to public asset - This is a string path to the`.riv` public asset if bundled in your application. Note that this is **not** a relative path to the asset from wherever the current JS file is in. Treat the `.riv` as any other asset bundled in your application, such as an image or font. If your JS is compiled and run at the root of your web application, you must specify the path from the root to the location of the asset. For example, if your asset is in `/public/foo.riv`, and your JS is run from the root at `/`, you would specify: `src: '/public/foo.riv'` in this property.
-- `buffer?` - *(optional)* ArrayBuffer containing the raw bytes from a .riv file. One of `src`, `buffer`, or `riveFile` must be provided.
-- `riveFile?` - *(optional)* Lets you reuse a previously loaded Rive runtime file object without needing to fetch it again from the `src` URL or reload it from the `buffer`. This can improve performance by eliminating redundant network requests and loading times, especially when creating multiple Rive instances from the same source. Unlike the `buffer` and `src` parameters, which still require parsing under the hood to create a runtime file object, the file parameter uses an already parsed object, including any loaded assets.
-- `artboard?` - *(optional)* Name of the artboard to use.
-- `animations?` - *(optional)* Name or list of names of animations to play.
-
-<Note>
- Currently, Rive will play the first timeline animation it finds if no `stateMachines` or `animations` parameter is provided, however, in a future major version of `rive-wasm`, the default will be to play the first state machine it finds.
-</Note>
-
-- `stateMachines?` - *(optional)* Name or list of names of state machines to load.
+- `canvas` - *(required)* Provide a `<canvas>` element to draw Rive animations onto.
+- To load a `.riv` file, one of the following is required:
+  - `src` - *(optional)* Hosted URL or app-relative public path to the `.riv` file. One of `src`, `buffer`, or `riveFile` must be provided. URL vs bundled path, bundler/data-URI setup, and a minimal example are on [Getting started](/runtimes/web/web-js#loading-rive-files).
+  - `buffer` - *(optional)* `ArrayBuffer` of `.riv` bytes. One of `src`, `buffer`, or `riveFile` must be provided.
+  - `riveFile` - *(optional)* Provide a loaded **`RiveFile`** (parsed file + assets) across instances. See [Caching a Rive file](/runtimes/web/caching-a-rive-file).
+- `artboard` - *(optional)* Name of the artboard to use. If not provided, it will pull the default artboard from the exported `.riv` file.
+- `stateMachines` - *(required)* Name of a state machine to load (i.e. `"State Machine 1"`) from the `.riv` file. If not provided, currently Rive will pull the first linear animation it finds (deprecated behavior). In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
 
 <Note>
  Note: You should only provide a single state machine string for `stateMachines`. Running multiple state machines of the same artboard at the same time may cause unintended consequences.
-<br/>
- In a future major version of `rive-wasm`, `stateMachines` will be a singular string you pass in.
 </Note>
 
-
-- `layout?` - *(optional)* Layout object to define how animations are displayed on the canvas.
-- `autoplay?` - *(optional)* If true, the animation will automatically start playing when loaded. Defaults to false.
-- `useOffscreenRenderer?` - *(optional)* Boolean flag to determine whether to use a shared offscreen WebGL context rather than create its own WebGL context for this instance of Rive. This is relevant for WebGL-based runtimes such as `@rive-app/webgl2`. If you are displaying multiple Rive animations, it is highly encouraged to set this flag to `true`. Defaults to `false`.
-- `enableRiveAssetCDN?` - *(optional)* Allow the runtime to automatically load assets hosted in Rive's CDN. Enabled by default.
-- `shouldDisableRiveListeners?` - *(optional)* Boolean flag to disable setting up Rive Listeners on the `<canvas>` element, thus preventing any event listeners from being set up on the element.
+- `layout` - *(optional)* Provide a [`new Layout()`](/runtimes/web/layouts) instance. See that page for fit modes, alignment, bounds, and responsive layout.
+- `autoplay` - *(optional)* If true, the animation will automatically start playing when loaded. Defaults to false.
+- `useOffscreenRenderer` - *(optional)* Boolean flag to determine whether to use a shared offscreen WebGL2 context rather than create its own WebGL2 context for this instance of Rive. This is only relevant for WebGL-based runtimes such as `@rive-app/webgl2`. If you are displaying multiple Rive animations, it is highly encouraged to set this flag to `true`. Defaults to `false`.
+- `enableRiveAssetCDN` - *(optional)* Allow the runtime to automatically load assets (i.e. fonts) hosted in Rive's CDN. Enabled true by default.
+- `shouldDisableRiveListeners` - *(optional)* Boolean flag to disable setting up Rive Listeners on the `<canvas>` element, thus preventing any event listeners from being set up on the element.
   - **Note:** Rive Listeners by default are not set up on a `<canvas>` element if there is no playing state machine, or a state machine without any Rive Listeners set up on the state machine
-- `isTouchScrollEnabled?` - *(optional)* For Rive Listeners, allows scrolling behavior to still occur on canvas elements when a touch/drag action is performed on touch-enabled devices. Otherwise, scroll behavior may be prevented on touch/drag actions on the canvas by default.
-- `automaticallyHandleEvents?` - *(optional)* Enable Rive Events to be handled by the runtime. This means any special Rive Event may have a side effect that takes place implicitly. For example, if during the render loop an `OpenUrlEvent` is detected, the browser may try to open the specified URL in the payload. This flag is `false` by default to prevent any unwanted behaviors from taking place. This means any special Rive Event will have to be handled manually by subscribing to `EventType.RiveEvent`
-- `autoBind?` - *(optional)* When set to `true`, Rive will automatically look for a default view model and view model instance to bind to the artboard.
-- `dispatchPointerExit?` - *(optional)* For Rive Listeners, dispatches a pointer exit event when the pointer exits the canvas. This can be useful for ensuring hover states are properly reset when the user's cursor leaves the canvas area.
-- `enableMultiTouch?` - *(optional)* Enables multi-touch support for Rive Listeners. When enabled, the runtime will track and respond to multiple simultaneous touch points on touch-enabled devices.
-- `drawingOptions?` - *(optional)* An enum (`DrawOptimizationOptions`) that provides drawing optimization options. This can be used to configure rendering performance optimizations. The default is `DrawOptimizationOptions.DrawOnChanged`, which will only submit a draw command if the artboard has visually updated.
-- `onLoad?` - *(optional)* Callback that gets fired when the .riv file loads.
-- `onLoadError?` - *(optional)* Callback that gets fired when an error occurs loading the .riv file.
-- `onPlay?` - *(optional)* Callback that gets fired when the animation starts playing.
-- `onPause?` - *(optional)* Callback that gets fired when the animation pauses.
-- `onStop?` - *(optional)* Callback that gets fired when the animation stops playing.
-- `onLoop?` - *(optional)* Callback that gets fired when the animation completes a loop.
-- `onStateChange?` - *(optional)* Callback that gets fired when a state change occurs.
-- `onAdvance?` - *(optional)* Callback that gets fired every frame when the Artboard has advanced.
-- `assetLoader?` - *(optional)* Callback that gets invoked for every asset detected in a Rive file (whether included or excluded). The callback is passed a reference to a Rive **FileAsset** and associated **bytes** for the file (if the asset is embedded in the file). In this callback, you'll determine whether or not to load the asset in your app yourself, or have Rive do it for you. For more details and examples, see the [Loading Assets](/runtimes/web/loading-assets) page.
-- `enablePerfMarks?` - *(optional)* Emits `performance.mark` / `performance.measure` entries for key Rive startup events. False by default. Also available on `RuntimeLoader` and `RiveFile`.
+- `isTouchScrollEnabled` - *(optional)* For Rive Listeners, allows scrolling behavior to still occur on canvas elements when a touch/drag action is performed on touch-enabled devices. Otherwise, scroll behavior may be prevented on touch/drag actions on the canvas by default.
+- `automaticallyHandleEvents` - *(optional)* Enable Rive Events to be handled by the runtime. This means any special Rive Event may have a side effect that takes place implicitly. For example, if during the render loop an `OpenUrlEvent` is detected, the browser may try to open the specified URL in the payload. This flag is `false` by default to prevent any unwanted behaviors from taking place. This means any special Rive Event will have to be handled manually by subscribing to `EventType.RiveEvent`
+- `autoBind` - *(optional)* When set to `true`, Rive will automatically look for a default view model and view model instance to bind to the artboard.
+- `dispatchPointerExit` - *(optional)* For Rive Listeners, dispatches a pointer exit event when the pointer exits the canvas. This can be useful for ensuring hover states are properly reset when the user's cursor leaves the canvas area. Defaults to true.
+- `enableMultiTouch` - *(optional)* Enables multi-touch support for Rive Listeners. When enabled, the runtime will track and respond to multiple simultaneous touch points on touch-enabled devices. Defaults to false.
+- `drawingOptions` - *(optional)* An enum (`DrawOptimizationOptions`) that provides drawing optimization options. This can be used to configure rendering performance optimizations. The default is `DrawOptimizationOptions.DrawOnChanged`, which will only submit a draw command if the artboard has visually updated.
+  - `DrawOptimizationOptions.DrawOnChanged` - Only submit a draw command if the artboard has visually updated
+  - `DrawOptimizationOptions.AlwaysDraw` - Always submit a draw command, even if the artboard has not visually updated.
+- `onLoad` - *(optional)* Callback that gets fired when the .riv file loads.
+- `onLoadError` - *(optional)* Callback that gets fired when an error occurs loading the .riv file.
+- `onPlay` - *(optional)* Callback that gets fired when the animation starts playing.
+- `onPause` - *(optional)* Callback that gets fired when the animation pauses.
+- `onStop` - *(optional)* Callback that gets fired when the animation stops playing.
+- `onLoop` - *(optional)* Callback that gets fired when the animation completes a loop.
+- `onStateChange` - *(optional)* Callback that gets fired when a state change occurs.
+- `onAdvance` - *(optional)* Callback that gets fired every frame when the Artboard has advanced.
+- `assetLoader` - *(optional)* Per-asset load hook (**`FileAsset`**, **`bytes`**, return boolean). Full patterns and examples: [Loading assets](/runtimes/web/loading-assets).
+- `enablePerfMarks` - *(optional)* Emits `performance.mark` / `performance.measure` entries for key Rive startup and render events for performance profiling purposes. False by default. Also available on `RuntimeLoader` and `RiveFile`.
+
+### Deprecated parameters
+- `animations` - *(optional)* Deprecated in favor of `stateMachines`. Name of a singular timeline animation to load from the `.riv` file. If not provided, Rive will pull the first linear animation it finds. In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
+
 
 ## APIs
 
-The following API's are available after instantiating Rive:
+The following APIs are available on a `Rive` instance after construction.
 
-### play()
+---
+
+### Data binding (View Models)
+
+View model APIs on `Rive` are documented in depth on [Data binding](/runtimes/web/data-binding). For a quick reference on available APIs on the `Rive` instance, see below:
+
+- `viewModelInstance` (getter) — currently bound instance, if any. From an instance, you can get a reference to view model properties based on type:
+  - `.number(path: string): ViewModelInstanceNumber`
+  - `.boolean(path: string): ViewModelInstanceBoolean`
+  - `.string(path: string): ViewModelInstanceString`
+  - `.color(path: string): ViewModelInstanceColor`
+  - `.trigger(path: string): ViewModelInstanceTrigger`
+  - `.enum(path: string): ViewModelInstanceEnum`
+  - `.list(path: string): ViewModelInstanceList`
+  - `.image(path: string): ViewModelInstanceAssetImage`
+  - `.artboard(path: string): ViewModelInstanceArtboard`
+  - `.viewModel(path: string): ViewModelInstance`
+  - `.viewModelName` - Getter property to return the name of the `ViewModel` the instance is created from
+  - `.properties` - Getter property to return the list of properties available on this `ViewModel`
+- `viewModelCount` (getter)
+- `viewModelByIndex(index: number): ViewModel | null` - returns a `ViewModel` specified by index from the `.riv` file, or null if it doesn't exist or the file isn't loaded yet
+- `viewModelByName(name: string): ViewModel | null` - returns a `ViewModel` specified by name, or null if it doesn't exist or the file isn't loaded yet
+- `defaultViewModel(): ViewModel | null` - returns the default `ViewModel` for the file, or null if it doesn't exist or the file isn't loaded yet
+- `bindViewModelInstance(instance: ViewModelInstance | null): void` - Binds a `ViewModelInstance` to the state machine. Note that this is taken care of automatically if `autoBind` is `true`.
+- `enums(): DataEnum[]`
+- `getBindableArtboard(name: string): BindableArtboard | null` - Returns a named artboard as a `BindableArtboard`, which exposes data-binding APIs. Once you have a bindable artboard, you can set the `.viewModel` property on that artboard to bind a `ViewModelInstance`. Bindable artboards can be set as a value to an artboard property on a different ViewModel. Returns `null` if the artboard doesn't exist or the file isn't loaded.
+- `getDefaultBindableArtboard(): BindableArtboard | null` - Returns the file's default artboard as a `BindableArtboard`, or `null` if not available.
+
+---
+
+### Playback
+
+Examples and UX-oriented discussion: [State machine playback](/runtimes/web/state-machines).
+
+#### play()
 
 `play(names?: string | string[], autoplay?: true): void`
 
-Plays a specified linear timeline animation(s) or state machine via the passed-in name. Useful if you have either programmatically called `pause()` or `stop()` or set `autoplay: false` when instantiating Rive. If no name is passed in, it plays all instantiated timeline animations or state machines (or the default animation if neither is instantiated).
+Plays a specified state machine via the passed-in name. Useful if you have either programmatically called `pause()` or `stop()` or set `autoplay: false` when instantiating Rive. If no name is passed in, it plays all instantiated state machines (or the default linear animation if a state machine is not instantiated).
 
-**Example**:
-
-```typescript
-import {Rive} from '@rive-app/canvas';
-
-const riveInstance = new Rive({
-  src: "https://cdn.rive.app/animations/vehicles.riv",
-  autoplay: false,
-  canvas: document.querySelector("canvas"),
-});
-
-const buttonEl = document.querySelector("button");
-buttonEl.onclick = function() {
-  // Play the 'bumpy' state machine
-  riveInstance.play("bumpy");
-};
-```
-
-### pause()
+#### pause()
 
 `pause(names?: string | string[]): void`
 
-Pauses a specified linear timeline animation(s) or state machine via the passed-in name. Useful if you want to programmatically pause the playing animation and pause the render loop. You may want to use this API too if the associated Rive instance's `<canvas>` element is scrolled offscreen. If no name is passed in, it pauses all instantiated timeline animations or state machines.
+Pauses a specified state machine via the passed-in name. If no name is passed in, it pauses all instantiated timeline animations or state machines.
 
-**Example**:
-
-```typescript
-import {Rive} from '@rive-app/canvas';
-
-const riveInstance = new Rive({
-  src: "https://cdn.rive.app/animations/vehicles.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-});
-
-const buttonEl = document.querySelector("button");
-buttonEl.onclick = function() {
-  // Pause the 'bumpy' state machine
-  riveInstance.pause("bumpy");
-};
-```
-
-### stop()
+#### stop()
 
 `stop(names?: string | string[]): void`
 
-Stops a specified linear timeline animation(s) or state machine via the passed-in name. Useful if you want to programmatically stop the playing animation and render loop. You may want to use this API too if the associated Rive instance's state machine is "done," or in an exit state. If no name is passed in, it stops all instantiated timeline animations or state machines.
+Stops a specified state machine via the passed-in name. If no name is passed in, it stops all instantiated timeline animations or state machines.
 
-**Example**:
-
-```typescript
-import {Rive} from '@rive-app/canvas';
-
-const riveInstance = new Rive({
-  src: "https://cdn.rive.app/animations/vehicles.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-});
-
-const buttonEl = document.querySelector("button");
-buttonEl.onclick = function() {
-  // Stop the 'bumpy' state machine
-  riveInstance.stop("bumpy");
-};
-```
-
-### reset()
+#### reset()
 
 ```typescript
 interface RiveResetParameters {
@@ -170,177 +164,146 @@ interface RiveResetParameters {
   animations?: string | string[];
   stateMachines?: string | string[];
   autoplay?: boolean;
+  autoBind?: boolean;
 }
 
 reset(params?: RiveResetParameters): void
 ```
 
-Resets the Rive Artboard, linear timeline animations, and/or the state machine from the start (or entry state) based on the parameters passed in. Implicitly, this method will also cleanup any existing instances (Artboard, Animation, and/or State Machine) created already before creating new ones. The instantiated timeline animation or state machine will play immediately depending on the `autoplay` property passed in.
+Resets the artboard, timeline animations, and/or state machines from the start (or entry state). Cleans up existing artboard/animation/state machine instances first. Playback after reset follows `autoplay` and `autoBind` (same meaning as constructor parameters). Example: [State machine playback](/runtimes/web/state-machines).
 
-**Example**:
+---
 
-```typescript
-import {Rive} from '@rive-app/canvas';
+### Canvas size and layout
 
-const riveInstance = new Rive({
-  src: "https://cdn.rive.app/animations/vehicles.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-  stateMachines: "bumpy"
-});
+Use these APIs to respond to canvas or window resize changes to ensure Rive content continues to render crisply.
 
-const buttonEl = document.querySelector("button");
-buttonEl.onclick = function() {
-  // Reset the 'bumpy' state machine
-  riveInstance.reset({
-    stateMachines: "bumpy",
-    autoplay: true,
-  });
-};
-```
+#### resizeDrawingSurfaceToCanvas()
 
-### on()
+`resizeDrawingSurfaceToCanvas(customDevicePixelRatio?: number): void`
+
+Sets the canvas element’s `width` and `height` from its CSS layout size and device pixel ratio (or your optional `customDevicePixelRatio`). Reduces blur on high-DPI displays. Calls `resizeToCanvas()` and updates **`devicePixelRatioUsed`**. If `layout.fit` is set to `Fit.Layout`, artboard width/height are adjusted from the layout.
+
+<Note>
+In a future major version of this runtime, this API may be called internally on initialization by default, with an option to opt-out if you have specific `width` and `height` properties you want to set on the canvas.
+</Note>
+
+Typical usage (e.g. call from `onLoad` once layout is known): [Getting started](/runtimes/web/web-js), [Layout](/runtimes/web/layouts).
+
+#### resizeToCanvas()
+
+`resizeToCanvas(): void`
+
+Sets layout bounds (`minX`, `minY`, `maxX`, `maxY`) from the current canvas pixel width and height. Call when the canvas backing store size changes.
+
+
+#### devicePixelRatioUsed
+
+Getter/setter for the DPR value applied when sizing the drawing surface (updated by `resizeDrawingSurfaceToCanvas()`).
+
+#### resetArtboardSize()
+
+`resetArtboardSize(): void`
+
+Restores artboard dimensions to the file's original values.
+
+#### bounds
+
+Artboard axis-aligned bounds, or `undefined` if the artboard is not ready.
+
+#### layout (get/set)
+
+Get this property to return the current `Layout` instance (treat as immutable; use `new Layout({...})` or `copyWith` to change). Set this property to replace the layout. Examples: [Layout](/runtimes/web/layouts).
+
+#### artboardWidth / artboardHeight
+
+Getters/setters for logical artboard dimensions. If the artboard is not loaded and you have not set a value, you may see `0`.
+
+Avoid setting these manually when using [`resizeDrawingSurfaceToCanvas()`](#resizedrawingsurfacetocanvas) with `Fit.Layout`, because the runtime sets width/height from the canvas.
+
+---
+
+### Audio
+
+#### volume
+
+Getter/setter for artboard audio volume (combined with system audio when applicable). The default value is `1.0`, which means the volume is set by the default level for that artboard.
+
+See the [playing audio](/runtimes/web/playing-audio) guide for more details.
+
+---
+
+### Events
+
+In addition to the event callbacks you can set in the `Rive` constructor (i.e. `onLoad`), you can also subscribe to events using the `on` and `off` methods for more controlled Rive event subscription.
+
+#### on()
 
 `on(type: EventType, callback: EventCallback): void`
 
-Similar to the Web API's `addEventListener` functionality on DOM elements, you can subscribe to specific "events" in a render loop cycle via providing an `EventType` enum and a callback for the runtime to invoke with different parameters depending on the event you want to subscribe to.
+Subscribe to runtime events (similar to `addEventListener`).
 
-`EventType` has the following enums to subscribe to that may or may not trigger during the lifespan of the Rive animation/state machine:
-
-```typescript
-export enum EventType {
-  Load = "load", // When Rive has successfully loaded in the Rive file
-  LoadError = "loaderror", // When Rive cannot load the Rive file
-  Play = "play", // When Rive plays an entity or resumes the render loop
-  Pause = "pause", // When Rive pauses the render loop and playing entity
-  Stop = "stop", // When Rive stops the render loop and playing entity
-  Loop = "loop", // (Singular animations only) When Rive loops an animation
-  Advance = "advance", // When Rive advances the animation in a frame
-  StateChange = "statechange", // When a Rive state change is detected
-  RiveEvent = "riveevent", // When a Rive Event gets reported
-}
-```
-
-**Example**
-
-```typescript
-import {Rive, EventType} from '@rive-app/canvas';
-
-const riveInstance = new Rive({
-  src: "/rating-animation.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-  stateMachines: "State Machine 1",
-});
-
-const riveEventHandler = (event) => {
-  if (event.data.name === "rating1") {
-    // Send feedback to API
-  } else if (event.data.name === "redirect") {
-    const newAnchorTag = document.createElement("a");
-    const {url, target} = (event as rc.OpenUrlEvent);
-    url && newAnchorTag.setAttribute("href", url);
-    target && newAnchorTag.setAttribute("target", target);
-    if (url) {
-      newAnchorTag.click();
-    }
-  }
-};
-
-riveInstance.on(EventType.RiveEvent, riveEventHandler);
-```
-
-### off()
+#### off()
 
 `off(type: EventType, callback: EventCallback): void`
 
-Similar to the Web API's `removeEventListener` functionality on DOM elements, you can unsubscribe to specific "events" in a render loop cycle via providing an `EventType` enum and the callback reference that was registered via the `on()` API.
+Unsubscribe using the same `EventType` and callback reference passed to `on()`.
+
+#### removeAllRiveEventListeners()
+
+`removeAllRiveEventListeners(type?: EventType): void`
+
+Removes all listeners for a given `EventType`, or all types if `type` is omitted.
+
+#### EventType
 
 ```typescript
-import {Rive, EventType} from '@rive-app/canvas';
-
-const riveInstance = new Rive({
-  src: "/rating-animation.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-  stateMachines: "State Machine 1",
-});
-
-const riveEventHandler = (event) => {
-  if (event.data.name === "rating1") {
-    // Send feedback to API
-  } else if (event.data.name === "redirect") {
-    const newAnchorTag = document.createElement("a");
-    const {url, target} = (event as rc.OpenUrlEvent);
-    url && newAnchorTag.setAttribute("href", url);
-    target && newAnchorTag.setAttribute("target", target);
-    if (url) {
-      newAnchorTag.click();
-    }
-  }
-};
-
-riveInstance.on(EventType.RiveEvent, riveEventHandler);
-// ...
-riveInstance.off(EventType.RiveEvent, riveEventHandler);
+export enum EventType {
+  Load = "load",
+  LoadError = "loaderror",
+  Play = "play",
+  Pause = "pause",
+  Stop = "stop",
+  Loop = "loop", // Only applicable for timeline animations, not state machines
+  Advance = "advance", // Called each frame after state machine advance
+  StateChange = "statechange",
+  RiveEvent = "riveevent",
+}
 ```
 
-### removeAllEventListeners()
+- **`Draw`** — Fired when a draw pass occurs (useful for advanced instrumentation).
 
-`removeAllEventListeners(type?: EventType): void`
+#### Event payload (`event.data`)
 
-This effectively removes all event listening subscriptions for a single particular `EventType` that may have been added via the `on()` API.
+The `Event` type is `{ type: EventType; data?: ... }`. The shape of `data` depends on `type`:
 
-### scrub()
+- **Load** — `RiveFile`  (the loaded file handle) or the string "buffer" indicating a load from an ArrayBuffer
+- **LoadError** — `string` (error message)
+- **Play**, **Pause**, **Stop** — `string[]` (names of the animations or state machines affected)
+- **Loop** — `LoopEvent` (`{ animation: string; type: LoopType }`)
+- **Advance** — `number` (elapsed seconds for that frame)
+- **StateChange** — `string[]` (state names that changed)
+- **RiveEvent** — custom or built-in Rive event payload (for example open-URL events)
 
-`scrub(animationNames?: string | string[], value?: number): void`
+`LoopType` is `OneShot`, `Loop`, or `PingPong`.
 
-Scrubs through (a) linear timeline animation(s) by a specified amount of seconds.
+For **`EventType.RiveEvent`** listener examples (including `automaticallyHandleEvents`), see [Rive Events](/runtimes/web/rive-events). Prefer [Data binding](/runtimes/web/data-binding) for new work where it applies.
 
-<Note>
-Note: This will not do anything if you are playing through a state machine. This only applies if you are using instantiated animations through the `animations` property.
-</Note>
-### cleanup()
+---
 
-`cleanup(): void`
+### File and lifecycle
 
-This API is **important** to call, as it will stop the animation render loop, and clean up all created instances for the Rive file, artboard, linear timeline animation(s), state machine, and the renderer. The reason it's important to delete these instances is because these entities hold generated C++ references through WASM behind-the-scenes, and therefore will not automatically get garbage collected like normal JS objects, and must be "cleaned up" manually, to prevent memory leaks. Once you are done with the Rive instance (i.e., a state machine has finished running, a user is navigating off the page, etc.), call `.cleanup()` to ensure all underlying memory allocated is freed up.
+When using Rive to load different Rive content, or to cleanup resources when Rive is no longer needed, the following APIs may be useful.
 
-<Note>
-If you want to present a different Artboard from the same Rive file dynamically, you can call `cleanupInstances()` which will only delete the Artboard, animation, and state machine instances (but not the Rive file or renderer object, which you can still reuse).
-</Note>
-
-**Example:**
-
-```typescript
-import {Rive} from '@rive-app/canvas';
-
-const riveInstance = new Rive({
-  src: "https://cdn.rive.app/animations/vehicles.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-  stateMachines: "bumpy"
-});
-
-const buttonEl = document.querySelector("button");
-buttonEl.onclick = function() {
-  // Cleanup Rive before navigating user off page
-  riveInstance.cleanup();
-  window.location.href = "https://google.com";
-};
-```
-
-### cleanupInstances()
-
-Similar to `cleanup()`, but will only clean up instances for the Artboard, linear timeline animation(s), and/or state machine, thus allowing you to re-initialize a different Artboard from the same Rive file, different timeline animation(s), or a different state machine. You can do this with `reset()`.
-
-### load()
+#### load()
 
 ```typescript
 interface RiveLoadParameters {
   src?: string;
   buffer?: ArrayBuffer;
+  riveFile?: RiveFile;
   autoplay?: boolean;
+  autoBind?: boolean;
   artboard?: string;
   animations?: string | string[];
   stateMachines?: string | string[];
@@ -351,270 +314,361 @@ interface RiveLoadParameters {
 load(params: RiveLoadParameters): void
 ```
 
-Replace the existing Rive instance with a new one, with potentially new parameters (including a new `src` file). This API also implicitly cleans up existing references to the old animation(s)/state machine/artboard. The backing WASM code that powers the Rive Web (JS) runtime shouldn't have to be loaded in again, so there should be no other network overhead unless you are loading in a new Rive file over the web.
+Replaces the current `.riv` source and reinitializes the instance. Stops current playback and clears the previous file reference. One of `src`, `buffer`, or `riveFile` must be provided (same rule as the constructor). WASM is typically already loaded, so you usually only pay network cost if you point at a new URL.
 
-### resizeToCanvas()
+#### cleanup()
 
-`resizeToCanvas(): void`
+`cleanup(): void`
 
-This sets the layout bounds to the current canvas size. You may want to call this if your canvas is resized.
+Stops the render loop and disposes artboard, animations, state machines, renderer, file handle, listeners, and view model instance references. Call when the Rive instance is no longer needed to avoid memory leaks.
 
-### resizeDrawingSurfaceToCanvas()
+#### cleanupInstances()
 
-`resizeDrawingSurfaceToCanvas(): void`
+`cleanupInstances(): void`
 
-This resets the `<canvas>` width and height properties to render at its current bounding rect size (CSS `height` and `width` properties) with the browser's `devicePixelRatio` in mind. This prevents blurry output on high-dpi screens (i.e., a `<canvas>` that is 500x500 on the page may render with an internal area size of 1000x1000 while still maintaining its original canvas size). This calls `resizeToCanvas()` implicitly. It's recommended to call this in the `onLoad` callback.
+Disposes only artboard, timeline animation, and state machine instances. The file and renderer remain valid so you can switch artboards or re-init via `reset()` / `load()`.
 
-<Note>
-In a future major version of this runtime, this API may be called internally on initialization by default, with an option to opt-out if you have specific `width` and `height` properties you want to set on the canvas
-</Note>
-```typescript
-import {Rive} from '@rive-app/canvas';
+#### deleteRiveRenderer()
 
-const riveInstance = new Rive({
-  src: "https://cdn.rive.app/animations/vehicles.riv",
-  autoplay: true,
-  canvas: document.querySelector("canvas"),
-  stateMachines: "bumpy",
-  onLoad: () => {
-    riveInstance.resizeDrawingSurfaceToCanvas();
-  },
-});
-```
+`deleteRiveRenderer(): void`
 
-### stateMachineInputs()
+Deletes the underlying renderer object, releasing GPU/WebGL resources. Call this only after `cleanup()` when you need a full teardown — for example, when removing a WebGL canvas from the DOM entirely. In most cases `cleanup()` alone is sufficient.
 
-```typescript
-class StateMachineInput {
-  // name of the input
-  public get name: string
-  // value of the input (for number or boolean inputs)
-  public get value: number | boolean
-  // directly set the input value (for number or boolean inputs)
-  public set value: number | boolean
-  // Method call to fire a trigger input
-  public fire(): void
-}
+---
 
-stateMachineInputs(stateMachineName: string): StateMachineInput[]
-```
+### Rendering loop
 
-Returns a list of state machine input objects from the given state machine name passed in (if the state machine has been instantiated). Use these state machine inputs to drive the state machine forward.
-
-```typescript
-const riveInstance = new rive.Rive({
-  src: 'https://cdn.rive.app/animations/vehicles.riv',
-  canvas: document.getElementById('canvas'),
-  autoplay: true,
-  stateMachines: 'bumpy',
-  onLoad: () => {
-    // Get the inputs via the name of the state machine
-    const inputs = riveInstance.stateMachineInputs('bumpy');
-    // Find the input you want to set a value for, or trigger
-    const bumpTrigger = inputs.find(i => i.name === 'bump');
-    button.onclick = () => bumpTrigger.fire();
-  },
-});
-```
-
-### stopRendering()
+#### stopRendering()
 
 `stopRendering(): void`
 
-Stops the render loop, and can only be resumed with `startRendering()`. This is useful for situations when the `<canvas>` is not visible. The React runtime utilizes this for that particular situation implicitly.
+Stops scheduling frames. Does not change play/pause/stop state of animations. Resume with `startRendering()`. This is useful for situations when the `<canvas>` is not visible.
 
-### startRendering()
+#### startRendering()
 
-`startRendering()`
+`startRendering(): void`
 
-Starts the render loop if it has been previously stopped. It will have no effect if the render loop is already active.
+Starts the render loop if it was stopped with `stopRendering()`. No-op if already running.
 
-### getTextRunValue()
+#### drawFrame()
+
+`drawFrame(): void`
+
+Advances and draws one frame. Use this when you need an explicit draw after certain updates, but typically you do not need to manually call this API.
+
+#### `resolveAnimationFrame()`
+
+Not a method on the high-level **`Rive`** class, but available for using the low-level APIs when constructing a render loop from scratch. On the loaded **`RiveCanvas`** (`@rive-app/canvas-advanced` / `@rive-app/webgl2-advanced`), call **`rive.resolveAnimationFrame()`** after drawing when using the browser’s **`requestAnimationFrame`** yourself. The high-level **`Rive`** instance uses **`drawFrame()`** and its internal loop instead. Full loop example: [Low-level API — Integrating Rive into Existing rAF Loop](/runtimes/web/low-level-api-usage#integrating-rive-into-existing-raf-loop).
+
+---
+
+### Rive Listeners
+
+Editor-side setup: [Listeners](/editor/state-machine/listeners) in the state machine. In most cases, this is automatically handled by the runtime.
+
+#### setupRiveListeners()
+
+`setupRiveListeners(options?: { isTouchScrollEnabled?: boolean }): void`
+
+(Re)attaches pointer/touch listeners on the canvas for active state machines that use Rive Listeners. Called automatically when appropriate; use after dynamic changes if listeners must be refreshed. Optional `isTouchScrollEnabled` overrides the instance default for this setup only.
+
+#### removeRiveListeners()
+
+`removeRiveListeners(): void`
+
+Removes listener callbacks installed for Rive Listeners on the canvas.
+
+---
+
+### Deprecated
+
+The following APIs on the `Rive` instance are deprecated. They may still work but for future-proofing your Rive grpahics, we recommend migrating away from these patterns.
+
+Setting state machine inputs and text runs directly are deprecated. Use [Data binding](/runtimes/web/data-binding) for new work where possible.
+
+#### stateMachineInputs()
+
+`stateMachineInputs(stateMachineName: string): StateMachineInput[] | undefined`
+
+Returns inputs for an **instantiated** state machine with the given name, or `undefined` if the file is not loaded yet. See the below interface on getting/setting values and firing trigger inputs.
+
+```typescript
+export enum StateMachineInputType {
+  Number = 56,
+  Trigger = 58,
+  Boolean = 59,
+}
+
+class StateMachineInput {
+  public readonly type: StateMachineInputType;
+  public get name(): string;
+  public get value(): number | boolean;
+  public set value(value: number | boolean);
+  public fire(): void; // trigger inputs only
+  public delete(): void; // clears the wrapper’s reference to the native input
+}
+```
+
+---
+
+#### Nested artboard paths (deprecated)
+
+For inputs and text runs on **nested artboards**, use a path string (for example `"parentArtboard"` or `"group/nested"`) to set input and text run values.
+
+- `setBooleanStateAtPath(inputName: string, value: boolean, path: string): void`
+- `setNumberStateAtPath(inputName: string, value: number, path: string): void`
+- `fireStateAtPath(inputName: string, path: string): void`
+- `getTextRunValueAtPath(textName: string, path: string): string | undefined`
+- `setTextRunValueAtPath(textName: string, value: string, path: string): void`
+
+Prefer data binding with [Nested Property Paths](/runtimes/web/data-binding#nested-property-paths) for nested artboard properties.
+
+---
+
+#### getTextRunValue() / setTextRunValue()
 
 `getTextRunValue(textRunName: string): string | undefined`
 
-Returns the text value of the text run component (from the hierarchy of your `.riv` file) you want to retrieve from. Returns `undefined` if the text run cannot be queried from the active Artboard (you may see console warnings in this case for further guidance).
-
-### setTextRunValue()
-
 `setTextRunValue(textRunName: string, textValue: string): void`
 
-Sets the text value of the text run component (from the hierarchy of your `.riv` file) you specify via `textRunName`. You may see console warnings if the text run cannot be queried from the active Artboard, and thus the provided `textValue` you want to set on the run may not be successful.
+These target named text runs on the **currently active** artboard. Console warnings are emitted when the run cannot be resolved.
 
-### resolveAnimationFrame()
+Prefer data binding with [Text data binding](/runtimes/web/data-binding#reading-and-writing-properties) for new work where possible.
 
-`resolveAnimationFrame(): void`
+---
 
-You only need to use this function if you are using Rive's [low-level APIs](/runtimes/web/low-level-api-usage) to build the render loop manually and are integrating Rive into your existing `requestAnimationFrame()` loop
+## Debugging and inspection
 
-Resolves deferred drawing commands with the renderer. You must call this at the end of your render loop if you decide to use your own `requestAnimationFrame()` loop and are adding Rive graphics into it. Otherwise, if you are using Rive's wrapped `rAF` loop (i.e., `rive.requestAnimatimationFrame()` ), you do not need to call this method, as Rive will worry about resolving any rendering calls related to Rive graphics.
+Once Rive is instantiated, you can inspect various properties of the playing instance by reading some of the following properties/getters on the `Rive` instance.
 
-See example usage below:
+### `contents`
+
+`get contents(): RiveFileContents | undefined`
+
+When the file has finished loading, `contents` describes artboards, animations, state machines, and each state machine’s inputs. If not loaded, `undefined`.
+
+Shape (conceptual):
 
 ```typescript
-let lastTime = 0;
-function draw(time) {
-  if (!lastTime) {
-    lastTime = time;
-  }
-  const elapsedMs = time - lastTime;
-  const elapsedSeconds = elapsedMs / 1000;
-  lastTime = time;
-
-  renderer.clear();
-
-  if (artboard) {
-    if (stateMachine) {
-      stateMachine.advance(elapsedSeconds);
-    }
-    if (animation) {
-      animation.advance(elapsedSeconds);
-      animation.apply(1);
-    }
-    artboard.advance(elapsedSeconds);
-    renderer.save();
-
-    renderer.align(
-      rive.Fit.contain,
-      rive.Alignment.center,
-      {
-        minX: 0,
-        minY: 0,
-        maxX: canvas.width,
-        maxY: canvas.height,
-      },
-      artboard.bounds
-    );
-
-    // Pass along our Renderer to the artboard, so that it can draw onto the canvas
-    artboard.draw(renderer);
-    renderer.restore();
-    renderer.flush();
-  }
-
-  // Needed to actually resolve a queue of drawing and rendering calls with our Renderer
-  // Note: ONLY needed if using a normal JS requestAnimationFrame, rather than our wrapped
-  // one in the rive API
-  rive.resolveAnimationFrame();
-
-  // Call the next frame!
-  requestAnimationFrame(draw);
+// Documented shape; types may not be exported from the package
+interface RiveFileContents {
+  artboards: {
+    name: string;
+    animations: string[];
+    stateMachines: {
+      name: string;
+      inputs: { name: string; type: StateMachineInputType; initialValue?: boolean | number }[];
+    }[];
+  }[];
 }
-// Start the animation loop
-requestAnimationFrame(draw);
 ```
 
-## Debugging Tools
-
-### contents
-
-Unlike other APIs that you call as a method on the Rive instance, `contents` is just a property on the Rive instance you can log to the console to see an object hierarchy of what was loaded in from the Rive file. This is useful to see what Rive file was loaded in, all the artboards associated with the file, animations and state machines, state machine inputs, and more. It's also useful if you don't have access to the file to inspect in the Rive editor directly.
-
-**Example:**
-
-```typescript
-const riveInstance = new rive.Rive({
-  src: 'https://cdn.rive.app/animations/vehicles.riv',
-  canvas: document.getElementById('canvas'),
-  autoplay: true,
-  stateMachines: 'bumpy',
-  onLoad: () => {
-    // Log the contents of the Rive file
-    console.log(riveInstance.contents);
-  },
-});
-```
-
-### enableFPSCounter()
+### `enableFPSCounter()` / `disableFPSCounter()`
 
 ```typescript
 type FPSCallback = (fps: number) => void;
 
-enableFPSCounter(fpsCallback?: FPSCallback): void
+enableFPSCounter(fpsCallback?: FPSCallback): void;
+disableFPSCounter(): void;
 ```
 
-Reports frames-per-second (FPS) for the runtime. You can supply a callback to handle how to display or ingest the data, or if you don't provide a callback, calling this API will append a fixed-position `<div>` in the top-right corner of the page, reading out the FPS. Call this after Rive has initialized in the `onLoad` callback, or at another point in time.
+Without a callback, a fixed-position FPS readout may be injected (runtime-dependent).
 
-### disableFPSCounter()
+### Performance profiling marks
 
-`disableFPSCounter(): void`
+When instantiating `Rive`, set `enablePerfMarks: true` to emit `performance.mark` and `performance.measure` entries for key events like WASM initialization and file loading. This should give you
+insight into where time is being spent during Rive startup and can be used in conjunction with browser profiling tools. Marks emitted may include:
+- Time fetching WASM
+- Time instantiating Rive and the renderer
+- Time parsing and loading `.riv` file setup
+- Time rendering the first few frames on the canvas
 
-Disables the FPS reporting for the runtime.
+Check the [Performance panel](https://developer.chrome.com/docs/devtools/performance/overview#capture_and_analyze_a_performance_report) in Chrome DevTools to see these marks on the flame chart.
+See the [Preloading WASM](/runtimes/web/preloading-wasm) guide and the [Caching a Rive File](/runtimes/web/caching-a-rive-file) guide for more information on ways to optimize Rive load times.
 
-## Other
+### `source`
 
-Other API's and properties are provided to report playing/paused/stopped entities in the Rive instance.
+Getter — current `src` string (if any).
 
-### source
+### `activeArtboard`
 
-Property to get the `src` attribute in the Rive instance
+Name of the active artboard, or `""` if none.
 
-### activeArtboard
+### `animationNames` / `stateMachineNames`
 
-Property to get the name of the active artboard
+All animation and state machine names on the **active** artboard.
 
-### animationNames
+### `playingAnimationNames` / `playingStateMachineNames`
 
-Property to get an array of all animation names on the loaded in Artboard (even if the animations are not specified at instantiation)
+Currently playing animations or state machines on the active artboard.
 
-### stateMachineNames
+### `pausedAnimationNames` / `pausedStateMachineNames`
 
-Property to get an array of all state machine names on the loaded in Artboard (even if the state machine(s) are not specified at instantiation)
+Currently paused animations or state machines on the active artboard.
 
-### playingAnimationNames
+### `isPlaying` / `isPaused` / `isStopped`
 
-Property to get an array of all active playing timeline animation names on the Rive instance (if you are playing a state machine, this will not return the currently active state timeline animations)
+Aggregate playback flags for instantiated animations and state machines.
 
-### playingStateMachineNames
+---
 
-Property to get an array of all active playing state machine names on the Rive instance
+## Related exports (module)
 
-### pausedAnimationNames
+The following below are named exports from the same package.
 
-Property to get an array of all active paused timeline animation names on the Rive instance (if you are playing a state machine, this will not return the currently active state timeline animations)
+### `RiveFile`
 
-### pausedStateMachineNames
+`RiveFile` lets you parse a `.riv` file once and share the result across multiple `Rive` instances — avoiding redundant network fetches and parse overhead. See the full usage guide at [Caching a Rive file](/runtimes/web/caching-a-rive-file).
+In many cases, you may want to load a `RiveFile` before actually rendering the graphic on a canvas, if you want to preload Rive WASM and the `.riv` file ahead of rendering, or to get certain `.riv` file data.
 
-Property to get an array of all active paused state machine names on the Rive instance
-
-### isPlaying
-
-Property that returns `true` if any animation is playing
-
-### isPaused
-
-Property that returns `true` if all instanced animations are paused
-
-### isStopped
-
-Property that returns `true` if no instanced animations are playing or paused
-
-### bounds
-
-Property that returns the bounds of the Artboard
-
-### layout (get/set)
-
-Property to either get or set a Rive `Layout`
-
-**Example:**
+#### `RiveFile` constructor parameters
 
 ```typescript
-import {Rive, Layout, Fit, Alignment} from '@rive-app/canvas';
-
-const riveInstance = new rive.Rive({
-  src: 'https://cdn.rive.app/animations/vehicles.riv',
-  canvas: document.getElementById('canvas'),
-  autoplay: true,
-  stateMachines: 'bumpy',
-});
-
-const buttonEl = document.querySelector("button");
-buttonEl.onclick = function() {
-  // Set new Layout
-  riveInstance.layout = new Layout({
-    fit: Fit.Cover,
-    alignment: Alignment.TopCenter,
-  });
-};
+interface RiveFileParameters {
+  src?: string;           // URL or public path to the .riv file
+  buffer?: ArrayBuffer;   // raw .riv bytes
+  assetLoader?: AssetLoadCallback;
+  enableRiveAssetCDN?: boolean;
+  enablePerfMarks?: boolean;
+  onLoad?: EventCallback;
+  onLoadError?: EventCallback;
+}
 ```
+
+One of `src` or `buffer` is required.
+
+```typescript
+const riveFile = new RiveFile({ src: ‘/my-animation.riv’ });
+await riveFile.init(); // resolves when the file is parsed and ready
+```
+
+Calling `.init()` starts loading and parsing of the `.riv` file. Resolves when the file is ready to be passed to `new Rive({ riveFile })`. If you provide `onLoad` / `onLoadError` callbacks in the `RiveFile` parameters, those fire at the same point.
+
+#### `on()` / `off()`
+
+`on(type: EventType, callback: EventCallback): void`
+`off(type: EventType, callback: EventCallback): void`
+
+Subscribe or unsubscribe from `EventType.Load` and `EventType.LoadError` events on the file itself. Mirrors the same API on the `Rive` instance.
+
+#### `getBindableArtboard()`
+
+`getBindableArtboard(name: string): BindableArtboard | null`
+
+Returns a `BindableArtboard` by name. Returns `null` if the artboard doesn’t exist.
+
+Once you have a bindable artboard, you can set the `.viewModel` property on that artboard to bind a `ViewModelInstance`. Bindable artboards can be set as a value to an artboard property on a different ViewModel.
+
+#### `getDefaultBindableArtboard()`
+
+`getDefaultBindableArtboard(): BindableArtboard | null`
+
+Returns the default artboard as a `BindableArtboard`, or `null` if not available.
+
+#### `viewModelByName()`
+
+`viewModelByName(name: string): ViewModel | null`
+
+Returns a `ViewModel` from the file by name, or `null` if it doesn’t exist or the file isn’t loaded yet. Equivalent to the `Rive` class's `.viewModelByName()` API, but accessible directly on the file handle before a `Rive` instance is created.
+
+#### `cleanup()`
+
+`cleanup(): void`
+
+Unconditionally releases the underlying WASM file handle and all associated listeners. Call when the `RiveFile` is no longer needed and you want to free memory.
+
+---
+
+### `RuntimeLoader`
+
+`RuntimeLoader` is a singleton that manages loading and caching the Rive WASM binary for all Rive instances on the page. Control where the Rive WASM is loaded from and when with this class.
+
+#### `enablePerfMarks`
+
+`static enablePerfMarks: boolean`
+
+When `true`, emits `performance.mark` / `performance.measure` entries for WASM initialization timing. Set before the first `getInstance()` / `awaitInstance()` call. Also available on `RiveFile` and the `Rive` constructor parameter `enablePerfMarks`.
+
+#### `getInstance()`
+
+`static getInstance(callback: (rive: RiveCanvas) => void): void`
+
+Provides the loaded WASM runtime via callback, initiating load if it hasn’t started yet. The callback fires immediately if the runtime is already loaded.
+
+```typescript
+RuntimeLoader.getInstance((runtime) => {
+  // runtime is a RiveCanvas — the low-level WASM module
+});
+```
+
+#### `awaitInstance()`
+
+`static awaitInstance(): Promise<RiveCanvas>`
+
+Promise-based alternative to `getInstance()`. Resolves with the runtime when loading is complete.
+
+```typescript
+const runtime = await RuntimeLoader.awaitInstance();
+```
+
+#### `setWasmUrl()` / `getWasmUrl()`
+
+`static setWasmUrl(url: string): void`
+`static getWasmUrl(): string`
+
+Override the default/primary URL from which the WASM binary is fetched. Call `setWasmUrl()` **before** any `Rive` or `RiveFile` is constructed, as WASM is fetched on first use. By default, Rive pulls from the [UNPKG CDN](https://unpkg.com/) for the version of the package you have installed.
+
+```typescript
+RuntimeLoader.setWasmUrl(‘/static/rive.wasm’);
+```
+
+#### `setWasmFallbackUrl()` / `getWasmFallbackUrl()`
+
+`static setWasmFallbackUrl(url: string | null): void`
+`static getWasmFallbackUrl(): string | null`
+
+Configures a fallback WASM URL to try if the primary URL fails to load. Defaults to pulling from [jsdelivr](https://www.jsdelivr.com/). Pass `null` to disable fallback behavior.
+
+#### `setWasmBinary()` / `getWasmBinary()`
+
+`static setWasmBinary(value: ArrayBuffer | null): void`
+`static getWasmBinary(): ArrayBuffer | null`
+
+Supply the WASM binary as an in-memory `ArrayBuffer` instead of fetching it from a URL — useful for environments without network access or for bundling WASM inline. When supplied, this is used instead of fetching from the primary URL. Pass `null` to clear.
+
+---
+
+### `RiveFont`
+
+`RiveFont` is a static-only utility class (never instantiated) for configuring **fallback fonts** — fonts Rive tries when the primary font is missing a glyph. This is useful for multilingual content where a single font doesn't cover all required Unicode ranges.
+
+#### `setFallbackFontCallback()`
+
+`static setFallbackFontCallback(fontCallback: FallbackFontsCallback | null): void`
+
+
+```typescript
+type FallbackFontsCallback = (
+  missingGlyph: number,
+  weight: number
+) => FontWrapper | FontWrapper[] | null | undefined;
+```
+
+`FallbackFontsCallback` is invoked by the runtime when a glyph cannot be found in the active font. Set this callback to handle the missing glyph codepoint and the current font weight. Return a single `FontWrapper`, an array of `FontWrapper`s, or `null`/`undefined` to indicate no fallback is available. `FontWrapper` is the type returned by `decodeFont`.
+
+This API registers a callback that is invoked whenever the runtime encounters a missing glyph. When an array of fonts is returned from this callback, Rive works through them in order until a match is found. Call  `RiveFont.setFallbackFontCallback(null)` to clear any previously registered callback.
+
+See [fallback fonts](/runtimes/web/fonts#fallback-fonts) for more details.
+
+---
+
+### Utility decoders
+
+`decodeAudio`, `decodeImage`, and `decodeFont` decode raw bytes into asset wrapper classes you can pass to `assetLoader`. See [Loading assets](/runtimes/web/loading-assets) for more details.
+
+#### decodeImage() / decodeFont() / decodeAudio()
+`async decodeImage(bytes: Uint8Array): Promise<ImageWrapper>`
+
+`async decodeFont(bytes: Uint8Array): Promise<FontWrapper>`
+
+`async decodeAudio(bytes: Uint8Array): Promise<AudioWrapper>`

--- a/runtimes/web/state-machines.mdx
+++ b/runtimes/web/state-machines.mdx
@@ -13,7 +13,7 @@ import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-stat
 
 <PlayingStateMachines />
 
-#### Autoplay the State Machine
+### Autoplay the State Machine
 
 To autoplay a state machine immediately after it loads, simply set `autoplay` to `true`.
 
@@ -27,7 +27,7 @@ const r = new rive.Rive({
 });
 ```
 
-#### Controlling State Machine Playback
+### Controlling State Machine Playback
 
 You can manually play and pause the State Machine using the `play`, `pause`, and `stop` methods.
 
@@ -52,7 +52,7 @@ const handleStop = () => {
 }
 ```
 
-#### reset()
+### reset()
 
 To dispose the current artboard / animation / state machine instances and create fresh ones (optionally changing artboard or `stateMachines`), use **`reset()`**. Pass the same kinds of options you use on the constructor. See [Rive Parameters](/runtimes/web/rive-parameters) for the full **`RiveResetParameters`** fields (`artboard`, `stateMachines`, `autoplay`, `autoBind`).
 

--- a/runtimes/web/state-machines.mdx
+++ b/runtimes/web/state-machines.mdx
@@ -51,3 +51,14 @@ const handleStop = () => {
   r.stop()
 }
 ```
+
+#### reset()
+
+To dispose the current artboard / animation / state machine instances and create fresh ones (optionally changing artboard or `stateMachines`), use **`reset()`**. Pass the same kinds of options you use on the constructor. See [Rive Parameters](/runtimes/web/rive-parameters) for the full **`RiveResetParameters`** fields (`artboard`, `stateMachines`, `autoplay`, `autoBind`).
+
+```js
+r.reset({
+  stateMachines: 'bumpy',
+  autoplay: true,
+});
+```


### PR DESCRIPTION
Giving the [Rive Parameters page](https://rive.app/docs/runtimes/web/rive-parameters) a refresh on the APIs we want to surface to users that are available, clarifying some descriptions there, and pointing to relevant other pages for further guidance on usage.