### PR TITLE
docs(editor): controlling data

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -205,6 +205,7 @@
                     ]
                   },
                   "editor/data-binding/converters",
+                  "editor/data-binding/controlling-data",
                   "editor/data-binding/property-groups",
                   "editor/data-binding/migration-guide"
                 ]

--- a/editor/data-binding/controlling-data.mdx
+++ b/editor/data-binding/controlling-data.mdx
@@ -1,0 +1,60 @@
+---
+title: "Controlling Data"
+description: "Update and react to data from within Rive or from your application code."
+---
+
+Once you've bound data to properties in your file, changing that data will automatically update the connected elements.
+
+You can control data from within your Rive file, or from your application at runtime.
+
+## Controlling data within Rive
+
+Rive includes several ways to update data directly inside your file:
+
+<CardGroup cols="2">
+  <Card
+    title="State machine actions"
+    href="/editor/state-machine/states#actions"
+  >
+    Update property values when [transitions](/editor/state-machine/transitions#actions) or [state changes](/editor/state-machine/states#actions) occur.
+  </Card>
+
+  <Card
+    title="Listener actions"
+    href="/editor/listeners"
+  >
+    Update data in response to interactions and events.
+  </Card>
+
+  <Card
+    title="Scripting"
+    href="/scripting/data-binding"
+  >
+    Write custom logic that reads and updates data.
+  </Card>
+
+  <Card
+    title="Target-to-source Binding"
+    href="/editor/data-binding/overview#bind-direction"
+  >
+    Update data using an element's property value.
+  </Card>
+
+  <Card
+    title="Property Groups"
+    href="/editor/data-binding/property-groups"
+  >
+    Animate values and bind them back to data.
+  </Card>
+</CardGroup>
+
+## Controlling data from code
+
+Your application can also update data at runtime. For example, you might:
+
+- Update a player's score
+- Change a username or profile image
+- Display live stock prices
+- Trigger UI states based on user interaction
+
+See the [Runtime Data Binding Overview](/runtimes/data-binding) for implementation details.

--- a/editor/data-binding/controlling-data.mdx
+++ b/editor/data-binding/controlling-data.mdx
@@ -21,7 +21,7 @@ Rive includes several ways to update data directly inside your file:
 
   <Card
     title="Listener actions"
-    href="/editor/listeners"
+    href="/editor/state-machine/listeners"
   >
     Update data in response to interactions and events.
   </Card>

--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -87,13 +87,3 @@ Additionally, a binding may be marked as "Bind Once". This means that the initia
 ### View Model Nesting
 
 View models can have another view model as one of their properties. This is referred to as "nesting". This is useful when a parent instance wants to associate with a particular child instance, similar to components.
-
-# Runtime APIs
-
-<YouTube id="IvkNSOFLdNg" />
-
-To continue reading about how to interact with data binding in code, see the [Runtime Overview](/runtimes/data-binding) page.
-
-<Card title="Data Binding Runtime Overview" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>} href="/runtimes/data-binding">
-  A dive into using data binding at runtime.
-</Card>


### PR DESCRIPTION
_The is part of the larger editor data binding rewrite. This is one of the 4 main concepts of data binding (vm's, vmi's, binding, controlling data)_ 

The current docs only mention controlling data from code, but not from scripting or within Rive. This page focuses on controlling your data from code, scripting, or from within Rive. 

This page is just a landing page with links to existing instructions on controlling data. 