### PR TITLE
docs(react-native): add Windows CMake long-path troubleshooting

### DIFF
--- a/runtimes/react-native/react-native.mdx
+++ b/runtimes/react-native/react-native.mdx
@@ -422,6 +422,20 @@ This guide documents how to get started using the Rive React Native runtime. The
 
     See the [runtime data binding documentation](/runtimes/react-native/data-binding) for more information.
 
+    ## Troubleshooting
+
+    ### Android build fails on Windows (CMake long-path error)
+
+    On Windows, the Android build can fail with `ninja: error: mkdir(CMakeFiles/rive.dir/...): No such file or directory` because paths exceed the Windows `MAX_PATH` (260-character) limit. This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/).
+
+    To fix this, set the `CMAKE_VERSION` environment variable to a newer CMake version (e.g. `3.31.6`) before building:
+
+    ```bash
+    set CMAKE_VERSION=3.31.6
+    ```
+
+    See the [Reanimated docs on building on Windows](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/) for full setup instructions.
+
     ## Resources
 
     <CardGroup cols={3}>


### PR DESCRIPTION
Adds a troubleshooting section for the Windows CMake long-path build failure on Android. References the `CMAKE_VERSION` env var fix from rive-app/rive-nitro-react-native#265.