### PR TITLE
Update scripting API documentation

### DIFF
--- a/scripting/api-reference/gpu/shader.mdx
+++ b/scripting/api-reference/gpu/shader.mdx
@@ -2,22 +2,9 @@
 title: Shader
 ---
 
-An opaque compiled shader module. Create via `context:loadShader`.
-
-
-## Constructors
-
-### `new`
-
-{/* new: (wgslAssetName: string) -> Shader */}
-<div class="signature">
-```lua
-new(wgslAssetName: string) -> Shader
-```
-</div>
-
-Load a pre-compiled WGSL shader embedded in the Rive file.
-The name must match a shader asset added in the editor (e.g. "myEffect.wgsl").
-Raw WGSL source strings are not accepted at runtime.
+An opaque compiled shader module. Get one with `context:shader(name)`,
+where `name` is the shader asset's name as added in the editor (e.g.
+"myEffect" — no ".wgsl" extension). Raw WGSL source strings are not
+accepted at runtime.
 
 

--- a/scripting/api-reference/interfaces/context.mdx
+++ b/scripting/api-reference/interfaces/context.mdx
@@ -327,17 +327,18 @@ self.pipeline = GPUPipeline.new({ colorTargets = {{ format = fmt }}, ... })
 ```
 
 
-### `loadShader`
+### `shader`
 
-{/* function loadShader(self, name: string): Shader? */}
+{/* function shader(self, name: string): Shader? */}
 <div class="signature">
 ```lua
-loadShader(name: string) -> Shader?
+shader(name: string) -> Shader?
 ```
 </div>
 
-Load a compiled shader by asset name. Returns a Shader ready for use
-in GPUPipeline.new(), or nil if the named shader is not found.
+Get a compiled shader by asset name (the name as added in the editor,
+with no ".wgsl" extension). Returns a Shader ready for use in
+GPUPipeline.new(), or nil if the named shader is not found.
 
 
 ### `decodeImage`


### PR DESCRIPTION
This PR updates the scripting API documentation generated from the rive repository.

Generated from commit: cb60c2b8939514a95b061ae13f670857df451bf9
Repository: rive-app/rive
Workflow run: https://github.com/rive-app/rive/actions/runs/26672351983