### PR TITLE
Update scripting API documentation

### DIFF
--- a/scripting/api-reference/gpu/gpu-canvas.mdx
+++ b/scripting/api-reference/gpu/gpu-canvas.mdx
@@ -31,7 +31,8 @@ Height in pixels.
 
 ### `format`
 
-Native pixel format of the canvas backing texture ('bgra8unorm' on D3D, 'rgba8unorm' elsewhere).
+Pixel format of the canvas backing texture, always 'rgba8unorm'. A
+deferred canvas reports this before its texture is allocated.
 MSAA resolve requires source and target to have identical formats — always
 derive GPUTexture and pipeline formats from this value:
 ```lua

--- a/scripting/api-reference/gpu/shader.mdx
+++ b/scripting/api-reference/gpu/shader.mdx
@@ -2,22 +2,9 @@
 title: Shader
 ---
 
-An opaque compiled shader module. Create via `context:loadShader`.
-
-
-## Constructors
-
-### `new`
-
-{/* new: (wgslAssetName: string) -> Shader */}
-<div class="signature">
-```lua
-new(wgslAssetName: string) -> Shader
-```
-</div>
-
-Load a pre-compiled WGSL shader embedded in the Rive file.
-The name must match a shader asset added in the editor (e.g. "myEffect.wgsl").
-Raw WGSL source strings are not accepted at runtime.
+An opaque compiled shader module. Get one with `context:shader(name)`,
+where `name` is the shader asset's name as added in the editor (e.g.
+"myEffect" — no ".wgsl" extension). Raw WGSL source strings are not
+accepted at runtime.
 
 

--- a/scripting/api-reference/interfaces/context.mdx
+++ b/scripting/api-reference/interfaces/context.mdx
@@ -298,46 +298,18 @@ Query GPU capabilities. Returns a table of supported features
 and limits for the current backend.
 
 
-### `preferredCanvasFormat`
+### `shader`
 
-{/* function preferredCanvasFormat(self): TextureFormat */}
+{/* function shader(self, name: string): Shader? */}
 <div class="signature">
 ```lua
-preferredCanvasFormat() -> TextureFormat
+shader(name: string) -> Shader?
 ```
 </div>
 
-Returns the native canvas texture format for the current platform.
-
-This is the format that `context:gpuCanvas(...)` backing textures use,
-and therefore what `canvas.format` will report. Equivalent to WebGPU's
-`navigator.gpu.getPreferredCanvasFormat()`.
-
-- Metal (macOS/iOS): `'rgba8unorm'` (off-screen canvas, not a CAMetalLayer surface)
-- D3D11/D3D12 (Windows): `'bgra8unorm'`
-- Vulkan, OpenGL, WebGPU: `'rgba8unorm'` (safe default; actual surface format
-may vary — use `canvas.format` for the authoritative value once a
-canvas exists)
-
-Use this at init time to create [GPUTexture](/scripting/api-reference/gpu/gpu-texture) and [GPUPipeline](/scripting/api-reference/gpu/gpu-pipeline)
-with a matching format before any canvas is drawn:
-```lua
-local fmt = context:preferredCanvasFormat()
-self.pipeline = GPUPipeline.new({ colorTargets = {{ format = fmt }}, ... })
-```
-
-
-### `loadShader`
-
-{/* function loadShader(self, name: string): Shader? */}
-<div class="signature">
-```lua
-loadShader(name: string) -> Shader?
-```
-</div>
-
-Load a compiled shader by asset name. Returns a Shader ready for use
-in GPUPipeline.new(), or nil if the named shader is not found.
+Get a compiled shader by asset name (the name as added in the editor,
+with no ".wgsl" extension). Returns a Shader ready for use in
+GPUPipeline.new(), or nil if the named shader is not found.
 
 
 ### `decodeImage`


### PR DESCRIPTION
This PR updates the scripting API documentation generated from the rive repository.

Generated from commit: cccee5e48067d82560153f361b555214f9778628
Repository: rive-app/rive
Workflow run: https://github.com/rive-app/rive/actions/runs/26698466062