### PR TITLE
Update scripting API documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -386,6 +386,7 @@
                   "scripting/api-reference/gpu/gpu-sampler",
                   "scripting/api-reference/gpu/gpu-texture",
                   "scripting/api-reference/gpu/load-op",
+                  "scripting/api-reference/gpu/pipeline-stage",
                   "scripting/api-reference/gpu/primitive-topology",
                   "scripting/api-reference/gpu/render-pass-desc",
                   "scripting/api-reference/gpu/sampler-entry",

--- a/scripting/api-reference/gpu/gpu-canvas.mdx
+++ b/scripting/api-reference/gpu/gpu-canvas.mdx
@@ -31,7 +31,8 @@ Height in pixels.
 
 ### `format`
 
-Native pixel format of the canvas backing texture ('bgra8unorm' on D3D, 'rgba8unorm' elsewhere).
+Pixel format of the canvas backing texture, always 'rgba8unorm'. A
+deferred canvas reports this before its texture is allocated.
 MSAA resolve requires source and target to have identical formats — always
 derive GPUTexture and pipeline formats from this value:
 ```lua

--- a/scripting/api-reference/gpu/gpu-pipeline.mdx
+++ b/scripting/api-reference/gpu/gpu-pipeline.mdx
@@ -10,8 +10,8 @@ A compiled GPU render pipeline (shaders + fixed-function state).
 ### `new`
 
 {/* new: (desc: {
-        vertex: Shader,
-        fragment: Shader?,
+        vertex: PipelineStage,
+        fragment: PipelineStage?,
         vertexLayout: { VertexBufferLayout },
         bindGroupLayouts: { GPUBindGroupLayout }?,
         colorTargets: { ColorTarget }?,
@@ -22,7 +22,7 @@ A compiled GPU render pipeline (shaders + fixed-function state).
     }) -> GPUPipeline */}
 <div class="signature">
 ```lua
-new(desc: {vertex: Shader, fragment: Shader?, vertexLayout:{VertexBufferLayout}, bindGroupLayouts:{GPUBindGroupLayout}?, colorTargets:{ColorTarget}?, depthStencil: DepthStencilState?, cullMode: CullMode?, topology: PrimitiveTopology?, sampleCount: number?,}) -> GPUPipeline
+new(desc: {vertex: PipelineStage, fragment: PipelineStage?, vertexLayout:{VertexBufferLayout}, bindGroupLayouts:{GPUBindGroupLayout}?, colorTargets:{ColorTarget}?, depthStencil: DepthStencilState?, cullMode: CullMode?, topology: PrimitiveTopology?, sampleCount: number?,}) -> GPUPipeline
 ```
 </div>
 

--- a/scripting/api-reference/gpu/pipeline-stage.mdx
+++ b/scripting/api-reference/gpu/pipeline-stage.mdx
@@ -1,0 +1,10 @@
+---
+title: PipelineStage
+---
+
+A pipeline stage: a Shader, or WebGPU-style `{ module = Shader,
+entryPoint = name }`. The Shader's `@vertex`/`@fragment` functions are the
+selectable entry points; omit `entryPoint` to use the first one of that
+stage (like WebGPU). Vertex and fragment may come from different Shaders.
+
+

--- a/scripting/api-reference/gpu/shader.mdx
+++ b/scripting/api-reference/gpu/shader.mdx
@@ -2,22 +2,9 @@
 title: Shader
 ---
 
-An opaque compiled shader module. Create via `context:loadShader`.
-
-
-## Constructors
-
-### `new`
-
-{/* new: (wgslAssetName: string) -> Shader */}
-<div class="signature">
-```lua
-new(wgslAssetName: string) -> Shader
-```
-</div>
-
-Load a pre-compiled WGSL shader embedded in the Rive file.
-The name must match a shader asset added in the editor (e.g. "myEffect.wgsl").
-Raw WGSL source strings are not accepted at runtime.
+An opaque compiled shader module. Get one with `context:shader(name)`,
+where `name` is the shader asset's name as added in the editor (e.g.
+"myEffect" — no ".wgsl" extension). Raw WGSL source strings are not
+accepted at runtime.
 
 

--- a/scripting/api-reference/interfaces/context.mdx
+++ b/scripting/api-reference/interfaces/context.mdx
@@ -298,46 +298,18 @@ Query GPU capabilities. Returns a table of supported features
 and limits for the current backend.
 
 
-### `preferredCanvasFormat`
+### `shader`
 
-{/* function preferredCanvasFormat(self): TextureFormat */}
+{/* function shader(self, name: string): Shader? */}
 <div class="signature">
 ```lua
-preferredCanvasFormat() -> TextureFormat
+shader(name: string) -> Shader?
 ```
 </div>
 
-Returns the native canvas texture format for the current platform.
-
-This is the format that `context:gpuCanvas(...)` backing textures use,
-and therefore what `canvas.format` will report. Equivalent to WebGPU's
-`navigator.gpu.getPreferredCanvasFormat()`.
-
-- Metal (macOS/iOS): `'rgba8unorm'` (off-screen canvas, not a CAMetalLayer surface)
-- D3D11/D3D12 (Windows): `'bgra8unorm'`
-- Vulkan, OpenGL, WebGPU: `'rgba8unorm'` (safe default; actual surface format
-may vary — use `canvas.format` for the authoritative value once a
-canvas exists)
-
-Use this at init time to create [GPUTexture](/scripting/api-reference/gpu/gpu-texture) and [GPUPipeline](/scripting/api-reference/gpu/gpu-pipeline)
-with a matching format before any canvas is drawn:
-```lua
-local fmt = context:preferredCanvasFormat()
-self.pipeline = GPUPipeline.new({ colorTargets = {{ format = fmt }}, ... })
-```
-
-
-### `loadShader`
-
-{/* function loadShader(self, name: string): Shader? */}
-<div class="signature">
-```lua
-loadShader(name: string) -> Shader?
-```
-</div>
-
-Load a compiled shader by asset name. Returns a Shader ready for use
-in GPUPipeline.new(), or nil if the named shader is not found.
+Get a compiled shader by asset name (the name as added in the editor,
+with no ".wgsl" extension). Returns a Shader ready for use in
+GPUPipeline.new(), or nil if the named shader is not found.
 
 
 ### `decodeImage`


### PR DESCRIPTION
This PR updates the scripting API documentation generated from the rive repository.

Generated from commit: b553e7dcb1aaeef0c02dc7bec17fbc753bc0b3fa
Repository: rive-app/rive
Workflow run: https://github.com/rive-app/rive/actions/runs/26786168147