### PR TITLE
docs: more clarity around deleting workspaces and cancelling plans

### DIFF
--- a/account-admin/account-overview/billing-changes.mdx
+++ b/account-admin/account-overview/billing-changes.mdx
@@ -29,7 +29,7 @@ From here you can:
 4. Click "Set as default"
 5. Remove the old card (optional)
 
-If your workspace was downgraded due to a failed payment, updating your card alone will not restore access. After updating your payment method, click Upgrade Plan and select a paid plan again.
+If your workspace was downgraded due to a failed payment, updating your card alone will not restore access. After updating your payment method, click "Upgrade Plan" and select a paid plan again.
 
 Access is typically restored within a few minutes.
 

--- a/account-admin/account-overview/billing-changes.mdx
+++ b/account-admin/account-overview/billing-changes.mdx
@@ -29,7 +29,9 @@ From here you can:
 4. Click "Set as default"
 5. Remove the old card (optional)
 
-If your subscription was suspended due to failed payment, you'll need to resubscribe via the Upgrade button after updating your card. Access is restored within minutes.
+If your workspace was downgraded due to a failed payment, updating your card alone will not restore access. After updating your payment method, click Upgrade Plan and select a paid plan again.
+
+Access is typically restored within a few minutes.
 
 ---
 

--- a/account-admin/account-overview/cancel-my-account.mdx
+++ b/account-admin/account-overview/cancel-my-account.mdx
@@ -13,7 +13,7 @@ Plans are managed per workspace. Cancelling a plan only affects the selected wor
     Click **Manage Workspace** for the workspace whose plan you want to cancel.
   </Step>
   <Step>
-    Click **Cancel Plan** which will redirect you to Stripe.
+    Click **Cancel Plan**, which will redirect you to Stripe.
 
     <Info>
       If you don't see the Cancel Plan button, the workspace may already be on the Free plan.

--- a/account-admin/account-overview/cancel-my-account.mdx
+++ b/account-admin/account-overview/cancel-my-account.mdx
@@ -1,17 +1,46 @@
 ---
-title: "Cancel My Subscription"
+title: "Cancelling My Plan"
+description: "Cancel a workspace's paid plan."
 ---
 
-1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
-2. Find the workspace in the left sidebar
-3. Click "Manage Workspace"
-4. Click "Cancel Plan"
-5. You'll be redirected to Stripe—click "Cancel Plan" to confirm
+Plans are managed per workspace. Cancelling a plan only affects the selected workspace and does not affect any other workspaces you belong to.
 
-You'll keep access until the end of your current billing period. After that, the workspace moves to a free plan.
+<Steps>
+  <Step>
+    Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content).
+  </Step>
+  <Step>
+    Click **Manage Workspace** for the workspace whose plan you want to cancel.
+  </Step>
+  <Step>
+    Click **Cancel Plan** which will redirect you to Stripe.
 
-Once you set your subscription to cancel, you can't make other account changes until the cancellation processes at the end of your billing period. If you change your mind or need to make changes, [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) to remove the pending cancellation first.
+    <Info>
+      If you don't see the Cancel Plan button, the workspace may already be on the Free plan.
 
-**Want to delete the workspace entirely?** That's different—see [Delete a Workspace](/home/account-admin/workspaces/delete-a-workspace)
+      If not, please [contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form).
+    </Info>
+  </Step>
+  <Step>
+    Click **Cancel Plan** to confirm.
+  </Step>
+</Steps>
 
-**Questions?** [Contact us here](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form).
+You'll keep access until the end of your current billing period. After that, the workspace will move to a Free plan.
+
+<Note>
+  Once cancellation is scheduled, you won't be able to make changes to the workspace's plan until the cancellation takes effect at the end of the current billing period.
+</Note>
+
+## FAQs
+
+<AccordionGroup>
+	<Accordion title="Can I undo a cancellation?">
+    If you change your mind or need to make changes, [contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) to remove the pending cancellation first.
+  </Accordion>
+  <Accordion title="How do I permanently delete my workspace and all my files?">
+    See [Deleting a Workspace](/home/account-admin/workspaces/delete-a-workspace).
+  </Accordion>
+</AccordionGroup>
+
+**Questions?** [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form).

--- a/account-admin/pricing.mdx
+++ b/account-admin/pricing.mdx
@@ -52,7 +52,7 @@ Annual billing saves money but requires full payment upfront.
 
 ## Legacy Pricing
 
-If you're on a legacy plan, your pricing is locked in as long as your subscription stays active. Adding users may move you to current pricing. If your subscription cancels, legacy pricing cannot be reinstated.
+If you're on a legacy plan, your pricing is locked in as long as your plan stays active. Adding users may move you to current pricing. If your plan cancels, legacy pricing cannot be reinstated.
 
 ---
 

--- a/account-admin/workspaces/workspace-faqs.mdx
+++ b/account-admin/workspaces/workspace-faqs.mdx
@@ -12,9 +12,9 @@ description: "Answers to common Workspace questions."
    You probably upgraded a different workspace. Use the workspace switcher (click the arrow next to your workspace name) to find your paid workspace.
 
    ![PR Workpace Switcher Both Gif](/PR_Workpace_Switcher_both.gif)
-3. **My subscription lapsed and now the price is higher. Can I get my old price back?**
+3. **My plan lapsed and now the price is higher. Can I get my old price back?**
 
-   If you had legacy pricing, it was locked in as long as your subscription stayed active. Once canceled, we can't reinstate it—you'll need to resubscribe at current prices.
+   If you had legacy pricing, it was locked in as long as your plan stayed active. Once canceled, we can't reinstate it—you'll need to upgrade your plan at current prices.
 4. **I upgraded but only one workspace changed. Why aren't all my workspaces paid now?**
 
    Each workspace is billed separately. Upgrading one doesn't affect the others.

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -62,8 +62,8 @@ Not sure where to start? Ask in the [community](https://community.rive.app/c/sup
 		[Upgrade to Voyager](https://rive.app/pricing?utm_source=docs&utm_medium=support_page).
 	</Accordion>
 
-	<Accordion title="How do I cancel my Rive subscription?">
-		See [Cancel My Account](/account-admin/account-overview/cancel-my-account).
+	<Accordion title="How do I cancel my Rive plan?">
+		See [Cancelling My Plan](/account-admin/account-overview/cancel-my-account).
 	</Accordion>
 
 	<Accordion title="Where can I find runtime-specific FAQs?">

--- a/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
+++ b/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
@@ -36,6 +36,6 @@ We'll verify you control the payment method, cancel the plan, and remove your ca
 
 ## Prevent This Next Time
 
-Create a company-owned workspace and add employees as members. When someone leaves, you remove them—no plan to chase down, no files lost.
+Create a company-owned workspace and add employees as members. When someone leaves, you remove them—no plans to chase down, no files lost.
 
 **Questions?** [Contact us here](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form).

--- a/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
+++ b/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Cancel a Former Employee's Subscription"
-description: "If an employee left your company but their Rive subscription is still billing your card, we can help cancel it. You don't need access to their account."
+title: "Cancel a Former Employee's Plan"
+description: "If an employee left your company but their Rive plan is still billing your card, we can help cancel it. You don't need access to their account."
 ---
 
 ## What We Can Do
 
-- ✅ Cancel the subscription
+- ✅ Cancel the plan
 - ✅ Remove your payment method from their account
 - ✅ Refund recent charges (typically 1-2 months after departure)
 
@@ -30,12 +30,12 @@ If you need the files, you'll need to work that out directly with the former emp
 - Last 4 digits of the card being charged
 - Approximate date the employee left
 
-We'll verify you control the payment method, cancel the subscription, and remove your card. You'll get confirmation within 1-2 business days.
+We'll verify you control the payment method, cancel the plan, and remove your card. You'll get confirmation within 1-2 business days.
 
 ---
 
 ## Prevent This Next Time
 
-Create a company-owned workspace and add employees as members. When someone leaves, you remove them—no subscriptions to chase down, no files lost.
+Create a company-owned workspace and add employees as members. When someone leaves, you remove them—no plan to chase down, no files lost.
 
 **Questions?** [Contact us here](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form).

--- a/home/account-admin/account-overview/refunds.mdx
+++ b/home/account-admin/account-overview/refunds.mdx
@@ -4,7 +4,7 @@ title: "Refunds"
 
 ## Our Policy
 
-Per Rive's [Terms of Service](/legal/terms-of-service), fees are non-refundable. If you cancel your subscription, you keep access until the end of your current billing period—we just won't renew it.
+Per Rive's [Terms of Service](/legal/terms-of-service), fees are non-refundable. If you cancel your plan, you keep access until the end of your current billing period—we just won't renew it.
 
 ## Billing Errors
 

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -4,9 +4,7 @@ description: "How to permanently delete a Rive workspace and what happens to you
 ---
 
 <Warning>
-## IMPORTANT
-
-**Deleting a workspace is not the same as cancelling a plan.**
+**IMPORTANT: Deleting a workspace is not the same as cancelling a plan.**
 
 These are different things:
 

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -1,18 +1,22 @@
 ---
-title: "Delete a Workspace"
+title: "Deleting a Workspace"
 description: "How to permanently delete a Rive workspace and what happens to your files."
 ---
 
-## Before You Start: Delete vs Cancel
+<Warning>
+## IMPORTANT
+
+**Deleting a workspace is not the same as cancelling a plan.**
 
 These are different things:
 
-- **Cancel** = Stop paying, keep your workspace and files, can reactivate anytime
-- **Delete** = Permanent removal, files gone forever
+- **Cancel my Plan** = Stop paying, keep your workspace and files, can reactivate anytime
+- **Delete my Workspace** = Permanent removal, files gone forever
 
-If you just want to stop paying, you probably want [Cancel My Account], not this.
+If you just want to stop paying, you probably want to [cancel your plan](/account-admin/account-overview/cancel-my-account), not deleting your workspace.
+</Warning>
 
-## What Happens When You Delete
+## What Happens When You Delete your Workspace
 
 **Immediately:**
 
@@ -34,9 +38,11 @@ If you just want to stop paying, you probably want [Cancel My Account], not this
 
 ## How to Delete a Workspace
 
+If you're certain you want to permanently delete your workspace and files, rather than [cancel your account]((/account-admin/account-overview/cancel-my-account)), follow these steps:
+
 ### Step 1: Back Up Your Files
 
-This is your only chance. After deletion, files cannot be recovered—not by you, not by support, not by anyone.
+This is your only chance. After deletion, files cannot be recovered — not by you, not by support, not by anyone.
 
 For each file you want to keep:
 
@@ -61,7 +67,9 @@ To remove members before deletion: [Removing Workspace Members](/account-admin/w
 6. Click "Delete Workspace"
 7. Type the workspace name to confirm
 
-⚠️ Double-check you're deleting the right workspace, especially if you have multiple workspaces.
+<Warning>
+Double-check you're deleting the right workspace, especially if you have multiple workspaces.
+</Warning>
 
 ### Step 4: Confirmation
 
@@ -73,51 +81,45 @@ After confirming:
 
 ---
 
-## Special Situations
+## FAQs
 
-### I'm Not the Workspace Owner
+<AccordionGroup>
+	<Accordion title="I want to delete a workspace, but I'm not the owner.">
+		- Ask the owner to delete it
+    - Leave the workspace yourself (you can always remove yourself)
+    - [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) if the owner is unreachable
 
-Only the owner can delete a workspace. Your options:
+    Only the owner can delete a workspace. Your options:
+	</Accordion>
+	<Accordion title="I want to delete a workspace, but the owner is no longer with the company.">
+		[Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) with proof of company ownership. We can help transfer ownership first, then you can delete.
+	</Accordion>
+  <Accordion title="Does deleting one workspace affect the others?">
+		Deleting one doesn't affect others—they're completely independent. Triple-check which one you're deleting using the workspace switcher.
+	</Accordion>
+  <Accordion title="I deleted my workspace by mistake. How do I get it back?">
+		**Within 90 days:** [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) immediately with the subject "Recover Deleted Workspace - URGENT." Include the workspace name, your account email, and when you deleted it. We can restore it.
 
-- Ask the owner to delete it
-- Leave the workspace yourself (you can always remove yourself)
-- [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) if the owner is unreachable
-
-### The Owner Left the Company
-
-[Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) with proof of company ownership. We can help transfer ownership first, then you can delete.
-
-### I Have Multiple Workspaces
-
-Deleting one doesn't affect others—they're completely independent. Triple-check which one you're deleting using the workspace switcher.
-
----
-
-## I Deleted by Mistake
-
-**Within 90 days:** [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) immediately with the subject "Recover Deleted Workspace - URGENT." Include the workspace name, your account email, and when you deleted it. We can restore it.
-
-**After 90 days:** Unfortunately, the data is gone. This is why we really push the backup step.
-
----
-
-## Troubleshooting
-
-**I don't see the Delete option** You're probably not the workspace owner. Check who owns it in workspace settings.
-
-**Delete button is grayed out** Usually a billing issue. Resolve any outstanding payments first, or contact support.
-
-**Team members still see the workspace** Cache issue. Have them log out, clear browser cache, and log back in. Should resolve within 30 minutes.
-
----
+    **After 90 days:** Unfortunately, the data is gone. This is why we really push the backup step.
+	</Accordion>
+  <Accordion title="I don't see the Delete button.">
+		You're probably not the workspace owner. Check who owns it in workspace settings.
+	</Accordion>
+  <Accordion title="The Delete button is grayed out.">
+		This is usually a billing issue. Resolve any outstanding payments first, or [contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form).
+	</Accordion>
+  <Accordion title="Some workspace members still see the deleted workspace.">
+		This is probably a caching issue. Have the members log out, clear browser cache, and log back in. It should resolve within 30 minutes.
+	</Accordion>
+</AccordionGroup>
 
 ## Related Articles
 
-- [Cancel My Account](/account-admin/account-overview/cancel-my-account) - Stop paying without deleting
+- [Cancel My Plan](/account-admin/account-overview/cancel-my-account) - Stop paying without deleting
 - [Reactivating a Canceled Workspace](/account-admin/workspaces/reactivating-a-canceled-workspace) - Restore a canceled workspace
 - [Transfer Workspace Ownership](/home/account-admin/workspaces/transfer-workspace-ownership) - Change who owns the workspace
 - [Removing Workspace Members](/account-admin/workspaces/removing-workspace-members) - Remove members from a workspace
 
 ---
 
-**Still not sure?** [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) before you do anything permanent.
+**Still not sure?** [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) before doing anything permanent.

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -85,11 +85,10 @@ After confirming:
 
 <AccordionGroup>
 	<Accordion title="I want to delete a workspace, but I'm not the owner.">
+		Only the owner can delete a workspace. Your options:
 		- Ask the owner to delete it
-    - Leave the workspace yourself (you can always remove yourself)
-    - [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) if the owner is unreachable
-
-    Only the owner can delete a workspace. Your options:
+		- Leave the workspace yourself (you can always remove yourself)
+		- [Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) if the owner is unreachable
 	</Accordion>
 	<Accordion title="I want to delete a workspace, but the owner is no longer with the company.">
 		[Contact support](https://airtable.com/appUtquW7bOB1IIqA/pagzVBE4tO5QdjWTM/form) with proof of company ownership. We can help transfer ownership first, then you can delete.

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -16,7 +16,7 @@ These are different things:
 If you just want to stop paying, you probably want to [cancel your plan](/account-admin/account-overview/cancel-my-account), not delete your workspace.
 </Warning>
 
-## What Happens When You Delete your Workspace
+## What Happens When You Delete Your Workspace
 
 **Immediately:**
 

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -38,7 +38,7 @@ If you just want to stop paying, you probably want to [cancel your plan](/accoun
 
 ## How to Delete a Workspace
 
-If you're certain you want to permanently delete your workspace and files, rather than [cancel your account]((/account-admin/account-overview/cancel-my-account)), follow these steps:
+If you're certain you want to permanently delete your workspace and files, rather than [cancel your plan](/account-admin/account-overview/cancel-my-account), follow these steps:
 
 ### Step 1: Back Up Your Files
 

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -13,7 +13,7 @@ These are different things:
 - **Cancel my Plan** = Stop paying, keep your workspace and files, can reactivate anytime
 - **Delete my Workspace** = Permanent removal, files gone forever
 
-If you just want to stop paying, you probably want to [cancel your plan](/account-admin/account-overview/cancel-my-account), not deleting your workspace.
+If you just want to stop paying, you probably want to [cancel your plan](/account-admin/account-overview/cancel-my-account), not delete your workspace.
 </Warning>
 
 ## What Happens When You Delete your Workspace


### PR DESCRIPTION
The confusion around cancelling plans and deleting workspaces is painful. Hopefully this makes it slightly more clear. 

- We sometimes call it a "plan", sometimes a "subscription". This unifies it to "plan", which is what the Editor calls it. 
- Minor rewrite and reorg of the Cancel Plan page
- Make deleting a workspace even more clear because omg