### PR TITLE
docs(mcp): MCP Early Access app works on Windows too

### DIFF
--- a/editor/ai/mcp.mdx
+++ b/editor/ai/mcp.mdx
@@ -32,7 +32,7 @@ You can connect the Rive Editor to AI tools through MCP (Model Context Protocol)
 
 <Steps>
   <Step title="Install Rive Early Access">
-    Install and open the latest version of the [Rive Early Access](https://rive.app/downloads) desktop app for Mac.
+    Install and open the latest version of the [Rive Early Access](https://rive.app/downloads) desktop app for Mac or Windows.
   </Step>
   <Step title="Set up Cursor">
     Create a [Cursor](https://www.cursor.com/) account and install the app.


### PR DESCRIPTION
Updates the MCP Integration install step to mention the Rive Early Access desktop app is available for both Mac and Windows (was Mac-only).

Page: https://rive.app/docs/editor/ai/mcp#rive-mcp-integration

Checked the rest of rive-docs: the only other desktop-app download callout (editor/get-rive.mdx) already says "macOS or Windows", so this was the only spot needing the fix.

Co-authored-by: Hermes (Guido's agent) <hermes@users.noreply.github.com>