### PR TITLE
docs(runtimes): add API Reference link to navbar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -682,7 +682,8 @@
                       "runtimes/android/rive-events"
                     ]
                   },
-                  "runtimes/android/migrating-from-legacy"
+                  "runtimes/android/migrating-from-legacy",
+                  "runtimes/android/api-reference"
                 ]
               },
               {
@@ -827,10 +828,6 @@
       {
         "label": "Support",
         "href": "/community/support"
-      },
-      {
-        "label": "API Reference",
-        "href": "https://api.rive.app/android/latest/"
       }
     ],
     "primary": {

--- a/docs.json
+++ b/docs.json
@@ -827,6 +827,10 @@
       {
         "label": "Support",
         "href": "/community/support"
+      },
+      {
+        "label": "API Reference",
+        "href": "https://api.rive.app/android/latest/"
       }
     ],
     "primary": {

--- a/runtimes/android/api-reference.mdx
+++ b/runtimes/android/api-reference.mdx
@@ -1,0 +1,4 @@
+---
+title: 'API Reference'
+url: https://api.rive.app/android/latest/
+---

--- a/runtimes/android/api-reference.mdx
+++ b/runtimes/android/api-reference.mdx
@@ -1,4 +1,4 @@
 ---
 title: 'API Reference'
-url: https://api.rive.app/android/latest/
+url: https://api-docs.rive.app/android/latest/
 ---


### PR DESCRIPTION
# Description

Generates the Android runtime API reference from KDoc using Dokka and publishes it
as a versioned static site to `https://api.rive.app/android/<version>/` (with a
`latest/` alias) on each release. First step toward hosting per-runtime API docs in
one place, linked to and from the main Rive docs.

This is part of a three-repo change:
- **infrastructure** (separate PR): the `rive-runtime-api-docs` bucket, CloudFront
  distribution + `index.html`-rewrite function, Route 53 record for `api.rive.app`,
  and the OIDC publish role scoped to `rive-app/rive-android`.
- **rive-docs** (separate PR, merge last): an "API Reference" navbar link to
  `api.rive.app/android/latest/`.

