### PR TITLE
docs(format): Fix broken/outdated links to binary readers

### DIFF
--- a/runtimes/advanced-topic/format.mdx
+++ b/runtimes/advanced-topic/format.mdx
@@ -27,7 +27,7 @@ A binary reader for Rive runtime files needs to be able to read these data types
 <Note>
  Reference Binary Readers
 <br/>
-[Dart](https://github.com/rive-app/rive-flutter/blob/master/lib/src/utilities/binary_buffer/binary_reader.dart) [C++ Reader](https://github.com/rive-app/rive-cpp/blob/master/src/core/binary_reader.cpp) [C++ Decoder](https://github.com/rive-app/rive-cpp/blob/master/include/core/reader.h)
+[C++ Reader](https://github.com/rive-app/rive-cpp/blob/master/src/core/binary_reader.cpp) [C++ Decoder](https://github.com/rive-app/rive-cpp/blob/master/include/core/reader.h)
 </Note>
 
 ### Header

--- a/runtimes/advanced-topic/format.mdx
+++ b/runtimes/advanced-topic/format.mdx
@@ -27,7 +27,7 @@ A binary reader for Rive runtime files needs to be able to read these data types
 <Note>
  Reference Binary Readers
 <br/>
-[C++ Reader](https://github.com/rive-app/rive-cpp/blob/master/src/core/binary_reader.cpp) [C++ Decoder](https://github.com/rive-app/rive-cpp/blob/master/include/core/reader.h)
+[C++ Reader](https://github.com/rive-app/rive-cpp/blob/master/src/core/binary_reader.cpp) [C++ Decoder](https://github.com/rive-app/rive-cpp/blob/master/include/rive/core/binary_reader.hpp)
 </Note>
 
 ### Header


### PR DESCRIPTION
- Remove old Flutter binary reader link.
- Fix broken C++ binary reader link.

Resolves #337