### PR TITLE
docs(editor): add constraints demos, rewrite ik constraints

### DIFF
--- a/editor/constraints/constraints-overview.mdx
+++ b/editor/constraints/constraints-overview.mdx
@@ -12,9 +12,9 @@ import { Demos } from "/snippets/demos.jsx";
 
 Constraints are a way to control the properties of an object through another target object. Some constraints can set limits on these properties (and their hierarchical relationships), while others can copy properties from one object to another.
 
-## Examples
+## Learn By Example
 
-<Demos examples={["constraints"]} />
+<Demos examples={["constraints", "ikConstraint"]} />
 
 ## Common Use Cases
 

--- a/editor/constraints/constraints-overview.mdx
+++ b/editor/constraints/constraints-overview.mdx
@@ -5,13 +5,18 @@ description: 'Learn how to use constraints in Rive.'
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
+import { Demos } from "/snippets/demos.jsx";
 
 
 <YouTube id="jYW0WuvEw_4" />
 
 Constraints are a way to control the properties of an object through another target object. Some constraints can set limits on these properties (and their hierarchical relationships), while others can copy properties from one object to another.
 
-Examples of where to use constraints:
+## Examples
+
+<Demos examples={["constraints"]} />
+
+## Common Use Cases
 
 - Make a character's eyes follow a target.
 

--- a/editor/constraints/ik-constraint.mdx
+++ b/editor/constraints/ik-constraint.mdx
@@ -1,85 +1,92 @@
 ---
 title: 'IK Constraint'
-description: 'Learn how to use Inverse Kinematics in Rive.'
+description: 'Use IK constraints to control bone chains with a target.'
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
-
-## About Inverse Kinematics (IK) 
+import { Demos } from "/snippets/demos.jsx";
 
 <YouTube id="8FK5E5WBUpM" />
 
-### Forward Kinematics 
+## Forward vs Inverse Kinematics
 
-Most skeletal animation in Rive is done by rotating the angles of bones. The position of a child bone changes according to the rotation of its parent. Positioning a bone at the end of a chain requires rotating multiple parent bones (the bones up the chain) to reach the desired pose. This type of skeletal posing is called Forward Kinematics.
+Most skeletal animation in Rive uses **Forward Kinematics**. With Forward Kinematics, you pose a bone chain by rotating each bone. Child bones move based on the rotation of their parents.
 
-### Inverse Kinematics 
-
-Inverse Kinematics allows you to place a target at the end of the chain and the system works backward to find a valid orientation for the parent bones above it.
+**Inverse Kinematics** works in the opposite direction. Instead of rotating each bone manually, you place a target at the end of the chain and Rive solves the bone rotations needed to reach it.
 
 ![Image](https://ucarecdn.com/ffcfbb2c-ad3a-49d4-a4ef-ec83a7e2780c/)
 
-There are many applications for this technique, but some of the more common examples include making a character point at an item or making a character's feet stay planted on the ground.
+IK is useful for rigs where the end of a chain needs to follow something else. For example, you might use IK to make a character point at an object or keep a character's feet planted on the ground.
 
-## How to create an IK constraint 
+<Demos examples={["ikConstraint"]} />
+
+## Creating an IK constraint
 
 To use IK, you need a bone chain and a target. The target can be any object, though in most cases you'll want to use a group with its [Style set to Target](/editor/fundamentals/groups#group-style).
 
 <Steps>
     <Step title="Create a bone chain and a target">
-        Use the **B** shortcut to create a [bone chain](/editor/manipulating-shapes/bones#how-to-create-bones). Then use the **G** shortcut to create a [group](/editor/fundamentals/groups). Set the group's Style option in the Inspector to Target.
+        Use the **B** shortcut to create a [bone chain](/editor/manipulating-shapes/bones#how-to-create-bones).
+
+        Then use the **G** shortcut to create a [group](/editor/fundamentals/groups).
+
+        With the group selected, set **Style** in the Inspector to **Target**. A target group stays selectable, even when other objects are above it. See [Targets](/editor/fundamentals/groups#target).
 
         ![Image](https://ucarecdn.com/efde9d84-1364-4cf7-b7a4-16c4834f14f9/)
-
-        Use the B and G shortcuts to activate the Bone and Group tools
     </Step>
     <Step title="Add an IK constraint">
-        Select the last bone you want to affect and add an IK constraint using the Constraints section of the Inspector.
+        Select the last bone you want the IK constraint to affect. In the Inspector, use the **Constraints** section to add an **IK** constraint.
 
         ![Image](https://ucarecdn.com/9b320235-1cfb-4a11-9e02-f64d2149cf11/)
     </Step>
     <Step title="Select a target">
-        Open the constraint fly-out menu and use the target button to select the empty group created in step 1.
+        Open the constraint flyout menu and use the target button to select the target group you created in step 1.
 
         ![Image](https://ucarecdn.com/9646ddc3-b452-41a8-894f-635ccd12df09/)
     </Step>
     <Step title="Test the IK system">
-        Move the target group to test the system is working.
+        Move the target group. The affected bones should rotate toward the target.
 
         ![Image](https://ucarecdn.com/d646176c-f782-4b04-acf2-2c69ae495e36/)
     </Step>
 </Steps>
 
-## Bone Count 
+## IK Properties
 
-Use the Bone Count property to set how far up the chain the IK system should work. Note that bones affected by the IK system are highlighted when the target is selected.
+### Bone Count
+
+Use **Bone Count** to set how far up the bone chain the IK constraint should reach.
+
+When the target is selected, bones affected by the IK constraint are highlighted.
 
 ![Image](https://ucarecdn.com/de7b0c48-49b2-4c6b-8935-1530fef7bffa/)
 
-## Invert Direction 
+### Invert Direction
 
-Use the Invert Direction toggle to swap the angle at which your IK system solves.
+Use **Invert Direction** to swap the angle used to solve the IK chain.
 
 ![Image](https://ucarecdn.com/c25849b6-b06f-4bd4-a921-fa16fa8de3a9/)
 
-## Strength 
+### Strength
 
-Use the Strength property to control how much the influenced bones should follow the target. A Strength of 0% means the target won't affect the influenced bones at all.
+Use Strength to control how much the affected bones follow the target. A Strength of 0% means the target does not affect the bones.
 
-Note that Strength can be animated, like most properties in Rive. Use this to create unique effects or to blend between two or more IK constraints (each with their own target).
+Strength can be animated like most properties in Rive. This is useful for blending between Forward Kinematics and Inverse Kinematics, or for blending between multiple IK constraints with different targets.
 
 ![Image](https://ucarecdn.com/b6d8a9bf-c604-4f91-86fe-1c1223aedd89/)
 
-## Constraints order 
+### Constraints order
 
-The order of constraints matters. For example, if a bone has two IK constraints, both with a strength of 100%, the second constraint (bottom-most) will cancel out the first one. If they don't have 100% strength, then the IK system will blend between the two. Use drag and drop to change the order of constraints.
+The order of constraints matters. If a bone has two IK constraints and both have a Strength of 100%, the lower constraint overrides the one above it.
+
+If the constraints use lower Strength values, Rive blends between them. Drag constraints in the Inspector to change their order.
 
 ![Image](https://ucarecdn.com/4751a9cd-f2c8-4b4a-9043-bd71276315f6/)
 
-Use drag and drop to change the order of constraints
+## Multiple IK constraints and nested targets
 
-## Multiple IK constraints and nested targets 
+You can use multiple IK constraints to create more complex rigs.
 
-You can set up multiple IK constraints for more complex rigs. A common setup is to have an IK constraint on the feet of a character (note that in our example below it only affects 1 bone) and another IK constraint for the leg bones (two bones). The leg target is a child of the foot target so that moving the feet will also move the legs.
+For example, a character leg might use one IK constraint on the foot and another IK constraint on the leg bones. The leg target can be a child of the foot target, so moving the foot target also moves the leg target.
 
 ![Image](https://ucarecdn.com/553313ae-136c-456f-9a72-d756904fa823/)

--- a/editor/constraints/rotation-constraint.mdx
+++ b/editor/constraints/rotation-constraint.mdx
@@ -4,10 +4,13 @@ description: "The Rotation Constraint allows you to set limits on an object's ro
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
+import { Demos } from "/snippets/demos.jsx";
 
 <YouTube id="YrQeUrzYoi8" />
 
-## How to create a Rotation Constraint 
+<Demos examples={["constraints"]} learnByExample />
+
+## How to create a Rotation Constraint
 
 <Steps>
 <Step title="Add a Rotation Constraint to an object">
@@ -27,7 +30,7 @@ import { YouTube } from '/snippets/youtube.mdx'
     </Step>
 </Steps>
 
-## Strength 
+## Strength
 
 The Strength property determines how much the constrained object is affected.
 
@@ -35,9 +38,9 @@ A Strength of 0% means the constraint won't have any effect.
 
 A Strength of 50% means half the value from the target will be applied.
 
-## Transform Space 
+## Transform Space
 
-### Source Space 
+### Source Space
 
 Choose whether this constraint should use World or Local coordinates for the Source Space.
 
@@ -45,20 +48,20 @@ Choose whether this constraint should use World or Local coordinates for the Sou
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
-### Min/Max Space 
+### Min/Max Space
 
 Choose whether this constraint should use World or Local coordinates for the Min/Max Space.
 
-## Offset 
+## Offset
 
 Allows the constraint owner to be manually offset from the constraint source.
 
 ![Image](https://ucarecdn.com/d58cee7e-20cd-4586-b1c3-f1a807e94e84/)
 
-## Copy 
+## Copy
 
 Define the rate at which the rotation property is copied.
 
-## Min/Max 
+## Min/Max
 
 Use the numerical values to define the minimum and maximum limits of the constraint.

--- a/editor/constraints/scale-constraint.mdx
+++ b/editor/constraints/scale-constraint.mdx
@@ -4,10 +4,13 @@ description: "The Scale Constraint allows you to set limits on an object's scale
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
+import { Demos } from "/snippets/demos.jsx";
 
 <YouTube id="4fFuGQHAiIQ" />
 
-## How to create a Scale Constraint 
+<Demos examples={["constraints"]} learnByExample />
+
+## How to create a Scale Constraint
 
 <Steps>
     <Step title="Add a Scale Constraint to an object">
@@ -27,7 +30,7 @@ import { YouTube } from '/snippets/youtube.mdx'
     </Step>
 </Steps>
 
-## Strength 
+## Strength
 
 The Strength property determines how much the constrained object is affected.
 
@@ -35,16 +38,16 @@ A Strength of 0% means the constraint won't have any effect.
 
 A Strength of 50% means half the value from the target will be applied.
 
-## Transform Space 
+## Transform Space
 
-### Source Space 
+### Source Space
 
 Choose whether this constraint should use World or Local coordinates for the Source Space.
 
-### Destination Space 
+### Destination Space
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
-### Min/Max Space 
+### Min/Max Space
 
 Choose whether this constraint should use World or Local coordinates for the Min/Max Space.

--- a/editor/constraints/transform-constraint.mdx
+++ b/editor/constraints/transform-constraint.mdx
@@ -4,10 +4,13 @@ description: 'The Transform Constraint allows its owner to copy all the transfor
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
+import { Demos } from "/snippets/demos.jsx";
 
 <YouTube id="pJfWNtVBrvM" />
 
-## How to create a Transform Constraint 
+<Demos examples={["constraints"]} learnByExample />
+
+## How to create a Transform Constraint
 
 <Steps>
     <Step title="Add a Transform Constraint to an object">
@@ -27,7 +30,7 @@ import { YouTube } from '/snippets/youtube.mdx'
     </Step>
 </Steps>
 
-## Strength 
+## Strength
 
 The Strength property determines how much the constrained object is affected.
 
@@ -37,17 +40,17 @@ A Strength of 50% means half the value from the target will be applied.
 
 ![50% Strength](https://ucarecdn.com/73b4a724-6707-4cd0-80a0-5e6813327a5a/)
 
-## Transform Space 
+## Transform Space
 
-### Source Space 
+### Source Space
 
 Choose whether this constraint should use World or Local coordinates for the Source Space.
 
-### Destination Space 
+### Destination Space
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
-## Example: mechanical arm 
+## Example: mechanical arm
 
 Consider the package resting on the table and the mechanical arm below.
 

--- a/editor/constraints/translation-constraint.mdx
+++ b/editor/constraints/translation-constraint.mdx
@@ -4,12 +4,15 @@ description: ''
 ---
 
 import { YouTube } from '/snippets/youtube.mdx'
+import { Demos } from "/snippets/demos.jsx";
 
 The Translation Constraint allows you to set limits on an object's position and/or copy the position properties from a target object. These properties can be independently activated.
 
 <YouTube id="i6OAPcqcPBw" />
 
-## How to create a Translation Constraint  
+<Demos examples={["constraints"]} learnByExample />
+
+## How to create a Translation Constraint
 
 <Steps>
     <Step title="Add a Translation Constraint to an object">
@@ -29,7 +32,7 @@ The Translation Constraint allows you to set limits on an object's position and/
     </Step>
 </Steps>
 
-## Strength 
+## Strength
 
 The Strength property determines how much the constrained object is affected.
 
@@ -37,13 +40,13 @@ A Strength of 0% means the constraint won't have any effect.
 
 A Strength of 50% means half the value from the target will be applied.
 
-## Transform Space 
+## Transform Space
 
-### Source Space 
+### Source Space
 
 Choose whether this constraint should use World or Local coordinates for the Source Space.
 
-### Destination Space 
+### Destination Space
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
@@ -51,16 +54,16 @@ Choose whether this constraint should use World or Local coordinates for the Des
 
 Choose whether this constraint should use World or Local coordinates for the Min/Max Space.
 
-## Offset 
+## Offset
 
 Allows the constraint owner to be manually offset from the constraint source.
 
 ![Image](https://ucarecdn.com/caac6969-e4b6-4bdb-877d-fe548833fd90/)
 
-## Copy X &Y 
+## Copy X &Y
 
 Allows you to decide if the constraint owner will copy the translation in the X and Y direction. Additionally, use the numerical value to define the rate at which it copies the value.
 
-## Max/Min 
+## Max/Min
 
 Use the numerical values to define the minimum and maximum limits of the constraint.

--- a/snippets/demos.jsx
+++ b/snippets/demos.jsx
@@ -6,7 +6,9 @@ export const Demos = ({
   // For custom cards
   children,
   // where in the list do you want to put the custom children
-  childrenIndex = 0
+  childrenIndex = 0,
+  // Override the title and description, say "Learn by Example" instead
+  learnByExample = false
 }) => {
   const examplesData = {
     cachingARiveFile: {
@@ -272,6 +274,14 @@ export const Demos = ({
       links: {
         editor: "https://rive.app/marketplace/25772-blinko-scripted-game/"
       },
+    },
+    constraints: {
+      title: "Constraints",
+      image: "https://static.rive.app/docs/constraints.gif",
+      description: "Transform, Translate, Scale, and Rotation Constraints.",
+      links: {
+        editor: "https://rive.app/community/files/28081-53040-constraints/"
+      },
     }
   }
 
@@ -456,30 +466,34 @@ export const Demos = ({
               </div>
               <div className="flex flex-grow flex-col px-6 py-5 relative" data-component-part="card-content-container">
                 <div className="flex flex-col grow">
-                  <h2 className="not-prose font-semibold text-base text-gray-800 dark:text-white" data-component-part="card-title">{ title }</h2>
+                  <h2 className="not-prose font-semibold text-base text-gray-800 dark:text-white" data-component-part="card-title">{ learnByExample ? "Learn by Example" : title }</h2>
 
                   <div className="flex flex-col grow prose mt-1 font-normal text-sm leading-6 text-gray-600 dark:text-gray-400" data-component-part="card-content">
                     <div className="grow flex flex-col">
-                        <p>{description}</p>
-                        {
-                          source && source.length > 0 && (
-                            <p className="mt-3">
-                              {
-                                source.map((item, index) => {
-                                  if (source.length == 1) {
-                                    return <>Open the <a  href={item}>Rive file</a>.</>
-                                  }
-
-                                  if (index == 0) {
-                                    return <>Open <a  href={item}>Rive file 1</a></>
-                                  }
-
-                                  return <>, <a href={item}>file {index + 1}</a></>
-                                })
-                              }
-                            </p>
+                      {
+                        description && !learnByExample && (
+                            <p>{description}</p>
                           )
-                        }
+                      }
+                      {
+                        source && source.length > 0 && (
+                          <p className="mt-3">
+                            {
+                              source.map((item, index) => {
+                                if (source.length == 1) {
+                                  return <>Open the <a  href={item}>Rive file</a>.</>
+                                }
+
+                                if (index == 0) {
+                                  return <>Open <a  href={item}>Rive file 1</a></>
+                                }
+
+                                return <>, <a href={item}>file {index + 1}</a></>
+                              })
+                            }
+                          </p>
+                        )
+                      }
                     </div>
                     {
 

--- a/snippets/demos.jsx
+++ b/snippets/demos.jsx
@@ -9,6 +9,15 @@ export const Demos = ({
   childrenIndex = 0
 }) => {
   const examplesData = {
+    ikConstraint: {
+      title: 'IK Constraints',
+      description: 'Check out this example to see IK constraints in action.',
+      image: "https://static.rive.app/docs/ik-constraint.gif",
+      stateMachines: "State Machine 1",
+      links: {
+        editor: "https://rive.app/community/files/28080-53039-ik-constraint/",
+      }
+    },
     cachingARiveFile: {
       title: 'Caching a Rive File',
       description: 'Load the .riv into memory once, use it multiple times.',


### PR DESCRIPTION
- Rewite IK to be a little more clear, concise. 
- Add a marketplace demo so users can see IK constraints in action. 
- Add maketplace demo for transform, translate, scale, rotation constraints. 

<img width="400" height="300" alt="constraints" src="https://github.com/user-attachments/assets/473e2ec9-265d-4248-93f9-085a9abf8cb4" />
<img width="640" height="478" alt="ik-constraint" src="https://github.com/user-attachments/assets/d8fe9bca-2c77-43e7-9a17-fed31d63bdc2" />
