### PR TITLE
feat: use mintlify variables

### DIFF
--- a/account-admin/pricing.mdx
+++ b/account-admin/pricing.mdx
@@ -7,11 +7,11 @@ For full details and feature comparison, see [rive.app/pricing](https://rive.app
 ## Plans
 
 | Plan           | Monthly      | Annual (paid upfront) | Best for                                                 |
-| :------------- | :----------- | :-------------------- | :------------------------------------------------------- |
-| **Free**       | \$0          | \$0                   | Learning Rive, personal projects                         |
-| **Cadet**      | \$17/seat/mo | \$108/seat/year       | Small teams shipping to production (3 seats max)         |
-| **Voyager**    | \$49/seat/mo | \$384/seat/year       | Teams needing Libraries and collaboration (25 seats max) |
-| **Enterprise** | —            | \$1,440/seat/year     | Large organizations (\$10M+ annual revenue)              |
+| :------------- | :---------------------------------- | :--------------------------------------- | :------------------------------------------------------- |
+| **Free**       | \$0                                 | \$0                                      | Learning Rive, personal projects                         |
+| **Cadet**      | {{ pricingCadetMonthly }}/seat/mo   | {{ pricingCadetYearly }}/seat/year       | Small teams shipping to production (3 seats max)         |
+| **Voyager**    | {{ pricingVoyagerMonthly }}/seat/mo | {{ pricingVoyagerYearly }}/seat/year     | Teams needing Libraries and collaboration (25 seats max) |
+| **Enterprise** | —                                   | {{ pricingEnterpriseYearly }}/seat/year  | Large organizations (\$10M+ annual revenue)              |
 
 Annual billing saves money but requires full payment upfront.
 
@@ -32,7 +32,7 @@ Annual billing saves money but requires full payment upfront.
 - Libraries
 - CDN asset hosting
 - Embed link hosting
-- \$20/seat monthly agent credits
+- {{ monthlyCreditsVoyager }}/seat monthly agent credits
 - Priority Community support
 
 **Enterprise** (everything in Voyager, plus)
@@ -45,7 +45,7 @@ Annual billing saves money but requires full payment upfront.
 - Onboarding and training
 - Custom runtime support
 - Centralized billing
-- \$40/seat monthly agent credits
+- {{ monthlyCreditsEnterprise }}/seat monthly agent credits
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -16,6 +16,19 @@
       "claude"
     ]
   },
+  "variables": {
+    "runtimeCurrentNameApple": "New Runtime",
+    "runtimeLegacyNameApple": "Legacy Runtime",
+    "monthlyCreditsVoyager": "$20",
+    "monthlyCreditsEnterprise": "$40",
+    "pricingCadetMonthly": "$17",
+    "pricingCadetYearly": "$108",
+    "pricingVoyagerMonthly": "$39",
+    "pricingVoyagerYearly": "$304",
+    "pricingEnterpriseYearly": "$1,440",
+    "versionMajorWebGL2": "2",
+    "versionWebGL2": "2.38.3"
+  },
   "navigation": {
     "tabs": [
       {

--- a/editor/ai-agent/ai-agent.mdx
+++ b/editor/ai-agent/ai-agent.mdx
@@ -48,8 +48,8 @@ Use the AI Agent toolbar to manage your conversations:
 
     Each paid seat adds monthly AI credits to your workspace:
 
-    - Voyager: $20/seat/month in AI credits
-    - Enterprise: $40/seat/month in AI credits
+    - Voyager: {{ monthlyCreditsVoyager }}/seat/month in AI credits
+    - Enterprise: {{ monthlyCreditsEnterprise }}/seat/month in AI credits
 
     **AI credit rules**
 

--- a/runtimes/apple/animation-playback.mdx
+++ b/runtimes/apple/animation-playback.mdx
@@ -8,8 +8,6 @@ import Overview from "/snippets/runtimes/animation-playback/overview.mdx"
 import ChoosingStartingAnimations from "/snippets/runtimes/animation-playback/choosing-starting-animations.mdx"
 import ControllingPlayback from "/snippets/runtimes/animation-playback/controlling-playback.mdx"
 
-import { Apple } from "/snippets/constants.mdx"
-
 <Overview />
 
 <ChoosingStartingAnimations />
@@ -17,7 +15,7 @@ import { Apple } from "/snippets/constants.mdx"
 By default, `RiveViewModel` will automatically play the animation or state machine you've given it.
 
 <Warning>
-  This deprecated feature is only supported in the Legacy Runtime, not the {Apple.currentRuntimeName}.
+  This deprecated feature is only supported in the Legacy Runtime, not the {{runtimeCurrentNameApple}}.
 </Warning>
 
 ### SwiftUI

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -5,7 +5,6 @@ description: 'Apple runtime for Rive. '
 
 import NoteOnFeatureSupport from "/snippets/runtimes/rendering-feature-support.mdx"
 import { Demos } from '/snippets/demos.jsx'
-import { Apple } from "/snippets/constants.mdx"
 
 <NoteOnFeatureSupport/>
 
@@ -34,7 +33,7 @@ Most APIs are marked as `throws`, with `Error` types available for the different
 Follow the steps below for a quick start on integrating Rive into your Apple app.
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         <Steps>
             <Step title="Install the Runtime">
                 With CocoaPods going into [maintenance mode](https://blog.cocoapods.org/CocoaPods-Support-Plans/), we recommend using Swift Package Manager.
@@ -222,7 +221,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
             </Step>
         </Steps>
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         <Steps>
             <Step title="Install the Runtime">
                 **Swift Package Manager**
@@ -307,7 +306,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 ## Playing / Pausing
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         <CodeGroup>
             ```swift UIKit
             let rive = try await Rive(...)
@@ -337,7 +336,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
             ```
         </CodeGroup>
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let viewModel = RiveViewModel(fileName: "...")
         viewModel.pause() // or play() to resume
@@ -348,7 +347,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 ## Frame Rate
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         <CodeGroup>
             ```swift UIKit
             let rive = try await Rive(...)
@@ -389,7 +388,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
             ```
         </CodeGroup>
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let viewModel = RiveViewModel(fileName: "...")
         viewModel.setPreferredFramesPerSecond(preferredFramesPerSecond: 30)
@@ -402,7 +401,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 ## Threading
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         The new runtime supports multi-threading through the introduction of `Worker` objects.
 
         ```swift
@@ -453,7 +452,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
         let rive = try await Rive(file: file)
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName} borderBottom>
+    <Tab title={"{{runtimeLegacyNameApple}}"}> borderBottom>
         The legacy runtime is currently single-threaded on the main thread. This means that all Rive calls must be made on the main thread. It is recommended that if you are on a background thread, you should dispatch to the main queue before making any Rive calls.
     </Tab>
 </Tabs>
@@ -461,10 +460,10 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 ## Logging
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         The new runtime does not yet include logging, but will be added in the near future.
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         Enabling logging is as simple as setting `RiveLogger.isEnabled` to `true`.
 
         ```swift

--- a/runtimes/apple/artboards.mdx
+++ b/runtimes/apple/artboards.mdx
@@ -6,14 +6,12 @@ description: 'Selecting which artboard to render at runtime'
 import Header from "/snippets/runtimes/artboards/overview.mdx"
 import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboard.mdx"
 
-import { Apple } from "/snippets/constants.mdx"
-
 <Header />
 
 <ChoosingAnArtboard />
 
 <Tabs>
-  <Tab title={Apple.currentRuntimeName}>
+  <Tab title={"{{runtimeCurrentNameApple}}"}>
   The following section assumes that you have read through the [Apple](/runtimes/apple/apple) overview.
 
   ### Getting an Artboard
@@ -45,7 +43,7 @@ import { Apple } from "/snippets/constants.mdx"
 
   Artboards then become the source of truth for state machines. See [State Machine](/runtimes/apple/state-machines) for more details.
   </Tab>
-  <Tab title={Apple.legacyRuntimeName}>
+  <Tab title={"{{runtimeLegacyNameApple}}"}>>
   **SwiftUI**
   ```swift
   struct AnimationView: View {

--- a/runtimes/apple/caching-a-rive-file.mdx
+++ b/runtimes/apple/caching-a-rive-file.mdx
@@ -3,7 +3,6 @@ title: "Caching a Rive File"
 description: ""
 ---
 
-import { Apple } from "/snippets/constants.mdx";
 import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
@@ -11,7 +10,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 ## Example Usage
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         To cache a Rive file, you can create a strong reference to a `File` object. This `File` can then be reused to create `Rive` objects.
 
         Artboards and state machines are unique when created using the `create` functions. This means that you can create a new `Rive` object with the same file, but with different (and unique) artboards and state machines.
@@ -48,7 +47,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
         let rive5 = try await builder.createRive(artboard: "MainArtboard", stateMachine: "Idle") // Creates a unique artboard and state machine, behaving separately from the first four Rive objects
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         // Cache a RiveFile somewhere to cache for reuse
         let file = try! RiveFile(resource: "file", loadCdn: false)

--- a/runtimes/apple/data-binding.mdx
+++ b/runtimes/apple/data-binding.mdx
@@ -21,7 +21,6 @@ import Enums from "/snippets/runtimes/data-binding/enums.mdx"
 
 import { YouTube } from "/snippets/youtube.mdx";
 import { Demos } from "/snippets/demos.jsx";
-import { Apple } from "/snippets/constants.mdx"
 
 <Overview />
 
@@ -30,7 +29,7 @@ import { Apple } from "/snippets/constants.mdx"
 <ViewModels />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
     View models are not their own type; rather, they are a source when creating a view model instance from a `File`.
 
     You can define the source of a view model via the `ViewModelSource` type.
@@ -42,7 +41,7 @@ import { Apple } from "/snippets/constants.mdx"
 
     These sources are used in conjunction with getting a view model instance. See [View Model Instances](#view-model-instances) for more information.
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
     ```swift
     let riveViewModel = RiveViewModel(...)
     let file = riveViewModel.riveModel!.riveFile
@@ -65,7 +64,7 @@ import { Apple } from "/snippets/constants.mdx"
 <ViewModelInstances />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         The following section assumes that you have read through the [Apple](/runtimes/apple/apple) overview.
 
         ```swift
@@ -90,7 +89,7 @@ import { Apple } from "/snippets/constants.mdx"
         namedInstance = try await file.createViewModelInstance(.name("Instance", from: .artboardDefault(Artboard)))
         ```
     </Tab>
-        <Tab title={Apple.legacyRuntimeName}>
+        <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
         let viewModel = riveViewModel.riveModel!.riveFile.viewModelNamed("...")!
@@ -117,7 +116,7 @@ import { Apple } from "/snippets/constants.mdx"
 <Binding />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         Given the following example code:
         ```swift
         let file: File = ...
@@ -141,7 +140,7 @@ import { Apple } from "/snippets/constants.mdx"
         var rive = try await Rive(file: file, artboard: artboard, stateMachine: stateMachine, dataBind: .none)
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
         let artboard = riveViewModel.riveModel!.artboard,
@@ -160,7 +159,7 @@ import { Apple } from "/snippets/constants.mdx"
 <AutoBinding />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         Given the following example code:
         ```swift
         let file: File = ...
@@ -177,7 +176,7 @@ import { Apple } from "/snippets/constants.mdx"
         var rive = try await Rive(file: file, artboard: artboard, stateMachine: stateMachine)
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
         riveViewModel.riveModel?.enableAutoBind { instance in
@@ -196,7 +195,7 @@ import { Apple } from "/snippets/constants.mdx"
 <ListingProperties />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         ```swift
         let file: File = ...
         let properties = try await file.getProperties(of: "ViewModel")
@@ -207,7 +206,7 @@ import { Apple } from "/snippets/constants.mdx"
         }
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
         let viewModel = riveViewModel.riveModel!.file.viewModelNamed(...)!
@@ -222,7 +221,7 @@ import { Apple } from "/snippets/constants.mdx"
 <ReadingAndWritingProperties />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         Property types are a very thin wrapper around the path and return type of a property.
 
         All property APIs (e.g setters, getters, and triggers) are available as part of a `ViewModelInstance` object.
@@ -283,7 +282,7 @@ import { Apple } from "/snippets/constants.mdx"
             ```
         </CodeGroup>
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
 
@@ -361,12 +360,12 @@ import { Apple } from "/snippets/constants.mdx"
 <NestedPropertyPaths />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         Property types are no longer reference types, and require the name or full path to a property when initializing the property value type. There is no longer an API to chain nested properties.
 
         See [Properties](#properties) for usage details.
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
 
@@ -394,7 +393,7 @@ import { Apple } from "/snippets/constants.mdx"
 <Observability />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         Property listeners utilize Swift Concurrency's async throwing stream API. If a property returns a value, you can listen to its changes by calling the `valueStream(of:)` method on a `ViewModelInstance` object.
 
         ```swift
@@ -433,7 +432,7 @@ import { Apple } from "/snippets/constants.mdx"
         }
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
 
@@ -470,7 +469,7 @@ import { Apple } from "/snippets/constants.mdx"
 <Images />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         To set an image, you first need to decode an image from a `Worker`. This has to be the `Worker` that was used when initializing a `File`, from which you are setting the image property of a view model instance.
 
         ```swift
@@ -483,7 +482,7 @@ import { Apple } from "/snippets/constants.mdx"
         viewModelInstance.setValue(of: imageProperty, to: image)
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let riveViewModel = RiveViewModel(...)
 
@@ -519,7 +518,7 @@ import { Apple } from "/snippets/constants.mdx"
 <Lists />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         ```swift
         let file: File = ...
         let viewModelInstance = try await file.createViewModelInstance(...)
@@ -551,7 +550,7 @@ import { Apple } from "/snippets/constants.mdx"
         let size = try await viewModelInstance.size(of: listProperty)
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```swift
         let listProperty = viewModelInstance.listProperty(fromPath: "list")!
 
@@ -579,7 +578,7 @@ import { Apple } from "/snippets/constants.mdx"
 <Artboards />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
     ```swift
     let file: File = ...
     let viewModelInstance = try await file.createViewModelInstance(...)
@@ -588,7 +587,7 @@ import { Apple } from "/snippets/constants.mdx"
     viewModelInstance.setValue(of: artboardProperty, to: artboard)
     ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         Use the `artboardProperty` method on a `RiveDataBindingViewModel.Instance` object to get the artboard property.
 
         Then use the `setValue` method on the artboard property object to set the new artboard value.

--- a/runtimes/apple/inputs.mdx
+++ b/runtimes/apple/inputs.mdx
@@ -7,12 +7,11 @@ noindex: true
 import Overview from "/snippets/runtimes/inputs/overview.mdx"
 import ControllingInputs from "/snippets/runtimes/inputs/controlling-inputs.mdx"
 import NestedInputs from "/snippets/runtimes/inputs/nested-inputs.mdx"
-import { Apple } from "/snippets/constants.mdx"
 
 <Overview />
 
 <Warning>
-  This deprecated feature is only supported in the Legacy Runtime, not the {Apple.currentRuntimeName}.
+  This deprecated feature is only supported in the Legacy Runtime, not the {{runtimeCurrentNameApple}}.
 </Warning>
 
 

--- a/runtimes/apple/layouts.mdx
+++ b/runtimes/apple/layouts.mdx
@@ -24,7 +24,7 @@ import ResponsiveLayouts from "/snippets/runtimes/layouts/responsive-layouts.mdx
 <ApplyingFitMode />
 
 <Tabs>
-  <Tab title={Apple.currentRuntimeName}>
+  <Tab title={"{{runtimeCurrentNameApple}}"}>
     You can set the fit and layout options on a `Rive` object. The `.fit` can be updated at runtime without creating a new `Rive` object.
 
     For all possible options, see [Fit.swift](https://github.com/rive-app/rive-ios/blob/main/Source/Concurrency/View/Fit.swift)
@@ -38,7 +38,7 @@ import ResponsiveLayouts from "/snippets/runtimes/layouts/responsive-layouts.mdx
     rive.fit = .fitWidth(alignment: .topCenter)
     ```
   </Tab>
-  <Tab title={Apple.legacyRuntimeName}>
+  <Tab title={"{{runtimeLegacyNameApple}}"}>>
     The runtime provides the following enums to set on layout parameters:
 
     - **Fit**
@@ -154,7 +154,7 @@ import ResponsiveLayouts from "/snippets/runtimes/layouts/responsive-layouts.mdx
 <ResponsiveLayouts />
 
 <Tabs>
-  <Tab title={Apple.currentRuntimeName}>
+  <Tab title={"{{runtimeCurrentNameApple}}"}>
     When creating a new `Rive` object, you can set the fit to layout, with two options for the scale factor: automatic or explicit.
 
     ```swift
@@ -166,7 +166,7 @@ import ResponsiveLayouts from "/snippets/runtimes/layouts/responsive-layouts.mdx
     rive.fit = .layout(scaleFactor: .explicit(2.0))
     ```
   </Tab>
-  <Tab title={Apple.legacyRuntimeName} borderBottom>
+  <Tab title={"{{runtimeLegacyNameApple}}"}> borderBottom>
     **Examples**
 
     - [SwiftUI](https://github.com/rive-app/rive-ios/blob/main/Example-iOS/Source/Examples/SwiftUI/SwiftLayout.swift)

--- a/runtimes/apple/loading-assets.mdx
+++ b/runtimes/apple/loading-assets.mdx
@@ -4,7 +4,6 @@ description: "Loading and replacing assets dynamically at runtime"
 ---
 
 import { YouTube } from "/snippets/youtube.mdx";
-import { Apple } from "/snippets/constants.mdx";
 
 import Overview from '/snippets/runtimes/loading-assets/overview.mdx'
 import MethodsForLoadingAssets from '/snippets/runtimes/loading-assets/methods-for-loading.mdx'
@@ -22,7 +21,7 @@ import Resources from '/snippets/runtimes/loading-assets/resources.mdx'
 <HandlingAssets />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         This section assumes that you have read through the [Apple](/runtimes/apple/apple) overview.
 
         Referenced assets can be added using the global asset APIs of a `Worker`.
@@ -67,7 +66,7 @@ import Resources from '/snippets/runtimes/loading-assets/resources.mdx'
             ```
         </CodeGroup>
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ### Examples
 
         - [(SwiftUI) Swap out images and fonts](https://github.com/rive-app/rive-ios/blob/main/Example-iOS/Source/Examples/SwiftUI/SwiftSimpleAssets.swift)

--- a/runtimes/apple/logging.mdx
+++ b/runtimes/apple/logging.mdx
@@ -10,7 +10,7 @@ import Overview from '/snippets/runtimes/logging/overview.mdx'
 <Overview />
 
 <Tabs>
-    <Tab title={Apple.currentRuntimeName}>
+    <Tab title={"{{runtimeCurrentNameApple}}"}>
         The new runtime supports logging via the `RiveLog` type. To enable logging, set the `RiveLog.logger` property to a `RiveLog.Logger` implementation. The new runtime defaults to no logging, which can be set at any time by setting `RiveLog.logger` to `RiveLog.none`. The new runtime ships with a default implementation that logs to the console, which can be set by using the `RiveLog.system(levels:)` helper function. When using the system logger, any logs that are not emitted at the levels specified will be suppressed.
 
         ```swift
@@ -61,7 +61,7 @@ import Overview from '/snippets/runtimes/logging/overview.mdx'
         RiveLog.logger = MyLogger()
         ```
     </Tab>
-    <Tab title={Apple.legacyRuntimeName}>
+    <Tab title={"{{runtimeLegacyNameApple}}"}>>
         ```
         RiveLogger.isEnabled = true // Enable logging; false by default
         RiveLogger.levels = [.debug] // Filter logs; all by default

--- a/runtimes/apple/migrating-from-legacy.mdx
+++ b/runtimes/apple/migrating-from-legacy.mdx
@@ -4,8 +4,6 @@ sidebarTitle: "Migrating from Legacy"
 description: "A guide to help you transition from the legacy Rive Apple runtime to the new runtime."
 ---
 
-import { Apple } from "/snippets/constants.mdx"
-
 ## Overview
 
 The [new Rive Apple runtime](/runtimes/apple/apple) is a **near-complete rewrite** of both the public API and the internal architecture. While conceptually most operations have an equivalent, the two APIs are incompatible. Any existing work in the legacy API that you would like to migrate must be rebuilt using the new API.
@@ -96,7 +94,7 @@ Use the sections below as a migration map: [Loading a File from Disk](#loading-a
 
 ### Loading a File from Disk
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 // Cache this file for reuse
@@ -105,7 +103,7 @@ let model = RiveModel(riveFile: file)
 let viewModel = RiveViewModel(model)
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let worker = try await WorkerProvider.shared.worker()
@@ -115,7 +113,7 @@ let rive = try await Rive(file: file)
 
 ### Loading a File from URL
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let webURL = URL(string: "https://example.com/my_rive_file.riv")!
@@ -124,7 +122,7 @@ let model = RiveModel(riveFile: file)
 let viewModel = RiveViewModel(model)
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let worker = try await WorkerProvider.shared.worker()
@@ -138,7 +136,7 @@ let rive = try await Rive(file: file)
 
 ### Loading a File from Data (Bytes)
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let data: Data = ...
@@ -147,7 +145,7 @@ let model = RiveModel(riveFile: file)
 let viewModel = RiveViewModel(model)
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 Use the `.data` file source when your `.riv` bytes are already available in memory.
 
@@ -165,7 +163,7 @@ For common setup operations (loading files, creating artboards, creating state m
 - Legacy runtime: many lookup APIs return optionals (`nil` on failure), so handle with `guard let` / fallback logic.
 - New runtime: APIs throw errors, so use `do/catch`.
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 Legacy APIs commonly return `nil` for lookup/create-style operations:
 
@@ -183,7 +181,7 @@ guard let stateMachine = artboard.defaultStateMachine() else {
 }
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 New runtime APIs throw errors, so failure handling moves to `do/catch`:
 
@@ -211,7 +209,7 @@ This pattern applies equally in UIKit and SwiftUI. The key migration change is o
   For more information, see state machines documentation for more details.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let file = try RiveFile(name: "my_rive_file")
@@ -220,7 +218,7 @@ model.setArtboard("My Artboard")
 model.setStateMachine("My State Machine")
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let worker = try await WorkerProvider.shared.worker()
@@ -232,7 +230,7 @@ let rive = try await Rive(file: file, artboard: artboard, stateMachine: stateMac
 
 ### Creating a Rive View
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let viewModel = RiveViewModel(...)
@@ -246,7 +244,7 @@ var body: some View {
 }
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let worker = try await WorkerProvider.shared.worker()
@@ -284,7 +282,7 @@ var body: some View {
   For more information, see the layout docs for all fit and alignment options.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let viewModel = RiveViewModel(
@@ -308,7 +306,7 @@ viewModel.layoutScaleFactor = RiveViewModel.layoutScaleFactorAutomatic // defaul
 viewModel.layoutScaleFactor = 2.0
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let worker = try await WorkerProvider.shared.worker()
@@ -334,11 +332,11 @@ rive.fit = .layout(scaleFactor: .explicit(2.0))
 
 When using layout fit, both runtimes support automatic and explicit scale factors.
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 Use `RiveViewModel.layoutScaleFactorAutomatic` (default) or set an explicit numeric value on `layoutScaleFactor`.
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 Use `.layout(scaleFactor: .automatic)` or `.layout(scaleFactor: .explicit(...))` on `Rive.fit`.
 
@@ -348,7 +346,7 @@ Use `.layout(scaleFactor: .automatic)` or `.layout(scaleFactor: .explicit(...))`
   For more information, see the data binding docs for complete view model instance APIs.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 In legacy, view models are queried from `RiveFile`, then instances are created from that queried view model.
 
@@ -366,7 +364,7 @@ let defaultInstance = viewModel.createDefaultInstance()
 let namedInstance = viewModel.createInstance(fromName: "My Instance")
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 In the new runtime, the view model is represented as source metadata passed directly into `createViewModelInstance`.
 
@@ -397,7 +395,7 @@ let defaultFromArtboard = try await file.createViewModelInstance(
 
 ### View Model Instance Properties
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 Legacy data-binding instances expose typed property objects that you query from the instance.
 
@@ -419,7 +417,7 @@ stringProperty.value = "Hello, Rive"
 let currentValue = stringProperty.value
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 The new runtime uses typed path descriptors with methods on `ViewModelInstance` for set/get/observe.
 
@@ -447,7 +445,7 @@ for try await updatedValue in valueStream {
 
 ### Bindable Artboards
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 Legacy artboard property binding uses a bindable artboard wrapper type.
 
@@ -465,7 +463,7 @@ guard let bindableArtboard = components.bindableArtboard(withName: "My Artboard"
 artboardProperty.setValue(bindableArtboard)
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 The new runtime binds artboards with a typed property descriptor and `setValue` on the instance.
 
@@ -485,7 +483,7 @@ viewModelInstance.setValue(of: artboardProperty, to: artboard)
   For more information, see the data binding docs for full API coverage.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let file = try RiveFile(...)
@@ -507,7 +505,7 @@ guard let instance = viewModel.createDefaultInstance() else { return }
 stateMachine.bindViewModelInstance(instance) // bound successfully
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let worker = try await WorkerProvider.shared.worker()
@@ -538,7 +536,7 @@ Best practice for migration: if you need initial values, set them **before** cre
 
 This avoids showing default values for a frame before your app-provided values are applied.
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 When updating a bound value after the view is created, keep a reference to the instance and call `play()` after mutation:
 
@@ -556,7 +554,7 @@ instance?.stringProperty(fromPath: "path/to/string")?.value = "Updated Value"
 viewModel.play() // Required to advance/unsettle after mutation
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 In the new runtime, update the bound value after the view is created. No explicit `play()` call is needed.
 
@@ -578,14 +576,14 @@ instance.setValue(of: property, to: "Updated Value") // Applies without play()
   For more information, see playback controls in the Apple runtime guide.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let viewModel = RiveViewModel(fileName: "...")
 viewModel.pause() // or play() to resume
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let rive = try await Rive(...)
@@ -603,14 +601,14 @@ RiveUIViewRepresentable(rive)
   For more information, see frame rate controls and ProMotion notes.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 let viewModel = RiveViewModel(fileName: "...")
 viewModel.setPreferredFramesPerSecond(preferredFramesPerSecond: 30)
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 let rive = try await Rive(...)
@@ -624,7 +622,7 @@ riveView.frameRate = .default
 
 ### Loading Referenced Assets
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 The legacy runtime uses a pull model via a callback that resolves assets on demand.
 
@@ -648,7 +646,7 @@ let viewModel = RiveViewModel(fileName: "my_rive_file") { asset, _, factory in
 }
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 The new runtime uses a push model, where assets are registered on the worker ahead of use.
 
@@ -670,7 +668,7 @@ worker.addGlobalAudioAsset(audio, name: "MyAudio-1234")
   For more information, see the logging guide for shared concepts and filtering options.
 </Card>
 
-#### {Apple.legacyRuntimeName}
+#### {{runtimeLegacyNameApple}}
 
 ```swift
 RiveLogger.isEnabled = true
@@ -679,7 +677,7 @@ RiveLogger.categories = [.stateMachine, .artboard, .viewModel]
 RiveLogger.isVerbose = true
 ```
 
-#### {Apple.currentRuntimeName}
+#### {{runtimeCurrentNameApple}}
 
 ```swift
 RiveLog.logger = RiveLog.system(levels: .default)

--- a/runtimes/apple/rive-events.mdx
+++ b/runtimes/apple/rive-events.mdx
@@ -9,10 +9,8 @@ import { YouTube } from "/snippets/youtube.mdx";
 import Overview from "/snippets/runtimes/events/overview.mdx"
 import AdditionalResources from "/snippets/runtimes/events/additional-resources.mdx"
 
-import { Apple } from "/snippets/constants.mdx"
-
 <Warning>
-  This deprecated feature is only supported in the Legacy Runtime, not the {Apple.currentRuntimeName}.
+  This deprecated feature is only supported in the Legacy Runtime, not the {{runtimeCurrentNameApple}}.
 </Warning>
 
 <Overview />

--- a/runtimes/apple/state-machines.mdx
+++ b/runtimes/apple/state-machines.mdx
@@ -7,8 +7,6 @@ import Overview from "/snippets/runtimes/state-machines/overview.mdx"
 import ControllingPlayback from "/snippets/runtimes/state-machines/controlling-playback.mdx"
 import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-state-machines.mdx"
 
-import { Apple } from "/snippets/constants.mdx"
-
 <Overview />
 
 <ControllingPlayback />
@@ -16,7 +14,7 @@ import { Apple } from "/snippets/constants.mdx"
 <PlayingStateMachines />
 
 <Tabs>
-  <Tab title={Apple.currentRuntimeName}>
+  <Tab title={"{{runtimeCurrentNameApple}}"}>
     By default, the state machine of a `Rive` object will automatically play when in use by a `RiveUIView`.
 
     The following sections assumes that you have read through the [Getting an Artboard](/runtimes/apple/artboards#getting-an-artboard) overview.
@@ -50,7 +48,7 @@ import { Apple } from "/snippets/constants.mdx"
     let rive = try await Rive(file: file, artboard: artboardByName, stateMachine: stateMachine)
     ```
   </Tab>
-  <Tab title={Apple.legacyRuntimeName}>
+  <Tab title={"{{runtimeLegacyNameApple}}"}>>
       #### Autoplay the State Machine
 
       By default, RiveViewModel will automatically play the given state machine.

--- a/runtimes/apple/text.mdx
+++ b/runtimes/apple/text.mdx
@@ -8,10 +8,9 @@ import Overview from "/snippets/runtimes/text/overview.mdx"
 import NestedArtboard from "/snippets/runtimes/text/nested-artboard.mdx"
 import SemanticsForAccessibility from "/snippets/runtimes/text/semantics-for-accessibility.mdx"
 import Resources from "/snippets/runtimes/text/resources.mdx"
-import { Apple } from "/snippets/constants.mdx"
 
 <Warning>
-  This deprecated feature is only supported in the Legacy Runtime, not the {Apple.currentRuntimeName}.
+  This deprecated feature is only supported in the Legacy Runtime, not the {{runtimeCurrentNameApple}}.
 </Warning>
 
 <Overview />

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -4,8 +4,6 @@ sidebarTitle: "Overview"
 description: "Specify a renderer to use at runtime."
 ---
 
-import { Apple } from "/snippets/constants.mdx";
-
 Rive makes use of various different renderers depending on platform and runtime. We're working towards unifying the default renderer used across all platforms/runtimes with the [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content).
 
 <Warning>
@@ -49,12 +47,12 @@ It also allows Rive to innovate with new features, such as [Vector Feathering](h
         The Rive Renderer will shine best on Apple runtimes in memory usage as an animation plays out, in comparison to previous default renderers.
 
         <Tabs>
-            <Tab title={Apple.currentRuntimeName}>
+            <Tab title={"{{runtimeCurrentNameApple}}"}>
                 The Rive renderer is the sole renderer for the Apple runtime.
 
                 The renderer is multi-threaded per `Worker` object. This means that for each `Worker` object, a new thread will be created to process and render the Rive graphics.
             </Tab>
-            <Tab title={Apple.legacyRuntimeName}>
+            <Tab title={"{{runtimeLegacyNameApple}}"}>>
                 With UIKit, you'll be able to see the best performance differences by drawing multiple times on a single `RiveView`, rather than creating multiple instances of `RiveView`s, or multiple `RiveViewModel`s.
 
                 **Example:** See this [stress test example](https://github.com/rive-app/rive-ios/blob/main/Example-iOS/Source/Examples/Storyboard/StressTest.swift) to see how you can override the drawing function on `RiveView` to draw multiple times on the same view, with each graphic at an offset. You can switch out the renderer with the above config and test out the performance for yourself!

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -38,7 +38,7 @@ See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which pack
 
         Add the following script tag to your web page to load v2 of the web runtime, which will get the latest patches/minor updates on major version 2:
         ```html
-        <script src="https://unpkg.com/@rive-app/webgl2@2"></script>
+        <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWebGL2}}"></script>
         ```
         If you see a newer major version to upgrade to, ensure your code accounts for breaking changes in the migration guide
 
@@ -46,7 +46,7 @@ See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which pack
 
         Alternatively, pin to a specific version for more control over what is loaded in your app. As Rive's feature set grows, you'll want to manually update this version to a newer one to ensure best compatibility.
         ```html
-        <script src="https://unpkg.com/@rive-app/webgl2@2.38.0"></script>
+        <script src="https://unpkg.com/@rive-app/webgl2@{{versionWebGL2}}"></script>
         ```
 
         This will make a global `rive` object available, allowing you to access the Rive API via the `rive` entry point. Follow the next steps below.
@@ -154,7 +154,7 @@ Bringing it all together, here's how to load a Rive graphic in a single HTML fil
   <body>
     <canvas id="canvas" width="500" height="500"></canvas>
 
-    <script src="https://unpkg.com/@rive-app/webgl2@2"></script>
+    <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWebGL2}}"></script>
     <script>
       const r = new rive.Rive({
         src: "https://cdn.rive.app/animations/vehicles.riv",

--- a/snippets/constants.mdx
+++ b/snippets/constants.mdx
@@ -1,1 +1,0 @@
-export const Apple = { currentRuntimeName: "New Runtime", legacyRuntimeName: "Legacy Runtime" };

--- a/snippets/snippet-intro.mdx
+++ b/snippets/snippet-intro.mdx
@@ -1,6 +1,0 @@
----
-title: 'Snippet Intro'
-description: ''
----
-
-


### PR DESCRIPTION
It's hard to keep docs up to date when versions, names, and prices change - especially when prices are listed in multiple places. [Mintlify variables](https://www.mintlify.com/docs/organize/settings-structure#variables-2) to the rescue. 

This PR adds variables for the following: 

```
  "variables": {
    "runtimeCurrentNameApple": "New Runtime",
    "runtimeLegacyNameApple": "Legacy Runtime",
    "monthlyCreditsVoyager": "$20",
    "monthlyCreditsEnterprise": "$40",
    "pricingCadetMonthly": "$17",
    "pricingCadetYearly": "$108",
    "pricingVoyagerMonthly": "$39",
    "pricingVoyagerYearly": "$304",
    "pricingEnterpriseYearly": "$1,440",
    "versionMajorWebGL2": "2",
    "versionWebGL2": "2.38.3"
  },
```

## Usage 

```
{{ monthlyCreditsVoyager }}/seat monthly agent credits
```