### PR TITLE
docs(apple): add semantics

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -611,6 +611,7 @@
                   "runtimes/apple/artboards",
                   "runtimes/apple/layouts",
                   "runtimes/apple/state-machines",
+                  "runtimes/apple/semantics",
                   "runtimes/apple/data-binding",
                   "runtimes/apple/loading-assets",
                   "runtimes/apple/fonts",

--- a/docs.json
+++ b/docs.json
@@ -611,11 +611,11 @@
                   "runtimes/apple/artboards",
                   "runtimes/apple/layouts",
                   "runtimes/apple/state-machines",
-                  "runtimes/apple/semantics",
                   "runtimes/apple/data-binding",
                   "runtimes/apple/loading-assets",
                   "runtimes/apple/fonts",
                   "runtimes/apple/caching-a-rive-file",
+                  "runtimes/apple/semantics",
                   "runtimes/apple/playing-audio",
                   "runtimes/apple/logging",
                   {

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -401,34 +401,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 
 ## Semantics
 
-Rive views can expose [semantics defined in the editor](/editor/accessibility/semantics) to VoiceOver. Semantics are available in the {Apple.currentRuntimeName} only, and are opt-in — the default mode is `.off`, so you enable them by setting a `Semantics` mode on the view.
-
-<CodeGroup>
-    ```swift UIKit
-    let rive = try await Rive(...)
-    let riveView = RiveUIView(rive: rive)
-    riveView.semantics = .automatic
-    ```
-
-    ```swift SwiftUI
-    var body: some View {
-        RiveUIViewRepresentable(rive)
-            .semantics(.automatic)
-    }
-    ```
-
-    ```swift SwiftUI (Async)
-    var body: some View {
-        AsyncRiveUIViewRepresentable {
-            let worker = try await Worker()
-            let file = try await File(source: ..., worker: worker)
-            let rive = try await Rive(file: file)
-            return rive
-        }
-        .semantics(.automatic)
-    }
-    ```
-</CodeGroup>
+Rive views can expose [semantics defined in the editor](/editor/accessibility/semantics) to VoiceOver. Semantics are available in the {Apple.currentRuntimeName} only.
 
 See [Semantics](/runtimes/apple/semantics) for the available modes and more detail.
 

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -399,6 +399,39 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
     </Tab>
 </Tabs>
 
+## Semantics
+
+Rive views can expose [semantics defined in the editor](/editor/accessibility/semantics) to VoiceOver. Semantics are available in the {Apple.currentRuntimeName} only, and are opt-in — the default mode is `.off`, so you enable them by setting a `Semantics` mode on the view.
+
+<CodeGroup>
+    ```swift UIKit
+    let rive = try await Rive(...)
+    let riveView = RiveUIView(rive: rive)
+    riveView.semantics = .automatic
+    ```
+
+    ```swift SwiftUI
+    var body: some View {
+        RiveUIViewRepresentable(rive)
+            .semantics(.automatic)
+    }
+    ```
+
+    ```swift SwiftUI (Async)
+    var body: some View {
+        AsyncRiveUIViewRepresentable {
+            let worker = try await Worker()
+            let file = try await File(source: ..., worker: worker)
+            let rive = try await Rive(file: file)
+            return rive
+        }
+        .semantics(.automatic)
+    }
+    ```
+</CodeGroup>
+
+See [Semantics](/runtimes/apple/semantics) for the available modes and more detail.
+
 ## Threading
 
 <Tabs>

--- a/runtimes/apple/semantics.mdx
+++ b/runtimes/apple/semantics.mdx
@@ -1,0 +1,82 @@
+---
+title: "Semantics"
+description: "Make your Rive views accessible to VoiceOver by enabling semantics in the Apple runtime."
+---
+
+import { Apple } from "/snippets/constants.mdx"
+
+<Note>
+  Semantics is currently only available in [Early Access](https://rive.app/downloads?utm_source=docs&utm_medium=content). Runtime support is in development or released as experimental.
+
+  Have feedback? Join the [Early Access community](https://community.rive.app/c/early-access/) to share your thoughts and help shape the feature.
+</Note>
+
+Semantics describe what the elements of your scene *are* — a button, a checkbox, a tab, an image — so that screen readers can describe and navigate your content. You define semantics in the Rive Editor, and at runtime the {Apple.currentRuntimeName} exposes them to [VoiceOver](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios).
+
+<Warning>
+  Semantics are **opt‑in**. The default mode is `.off`, so no accessibility elements are created until you enable semantics on the view.
+</Warning>
+
+<Info>
+  To add roles, properties, traits, and states to your scene, see the [Semantics](/editor/accessibility/semantics) editor documentation. For which runtimes currently support semantics, see [Feature Support](/feature-support).
+</Info>
+
+## Availability
+
+Semantics in the Apple runtime are available in the {Apple.currentRuntimeName} on all supported Apple platforms **except macOS (AppKit)**. Mac Catalyst *is* supported. They are not available in the {Apple.legacyRuntimeName}.
+
+## Semantics modes
+
+Semantics are controlled by the `Semantics` enum, which sets the VoiceOver integration mode for a Rive view:
+
+| Mode | Description |
+| --- | --- |
+| `.off` | **Default.** Accessibility semantics are disabled. No accessibility elements are created, regardless of VoiceOver state. |
+| `.on` | Accessibility semantics are always active. Elements are created and kept up‑to‑date on every frame. |
+| `.automatic` | Accessibility semantics activate and deactivate automatically based on whether VoiceOver is currently running. |
+
+For most apps, prefer `.automatic` — it keeps the accessibility tree in sync only while VoiceOver is active, avoiding unnecessary work when it isn't.
+
+## Usage
+
+Set the semantics mode on the view (UIKit) or with the `.semantics(_:)` modifier (SwiftUI).
+
+<CodeGroup>
+    ```swift UIKit
+    let rive = try await Rive(...)
+    let riveView = RiveUIView(rive: rive)
+    // Enable semantics only while VoiceOver is running
+    riveView.semantics = .automatic
+    // Always keep semantics active
+    riveView.semantics = .on
+    // Disable semantics (default)
+    riveView.semantics = .off
+    ```
+
+    ```swift SwiftUI
+    var body: some View {
+        RiveUIViewRepresentable(rive)
+            .semantics(.automatic)
+        // or .semantics(.on)
+        // or .semantics(.off)
+    }
+    ```
+
+    ```swift SwiftUI (Async)
+    var body: some View {
+        AsyncRiveUIViewRepresentable {
+            let worker = try await Worker()
+            let file = try await File(source: ..., worker: worker)
+            let rive = try await Rive(file: file)
+            return rive
+        }
+        .semantics(.automatic)
+    }
+    ```
+</CodeGroup>
+
+## How it works
+
+When semantics are enabled, Rive reads the semantic nodes produced by the running state machine and exposes them as the view's `accessibilityElements`. Each node carries a role (such as button, checkbox, tab, slider, image, link, list, or dialog) along with its label, value, state, and any available actions. As the state machine advances, Rive applies per‑frame updates so VoiceOver always reflects the current state of your scene.
+
+Because the accessibility tree is derived from the state machine, make sure your scene's elements have semantics assigned in the editor — without them, there is nothing for VoiceOver to read even when the mode is `.on` or `.automatic`.

--- a/runtimes/apple/semantics.mdx
+++ b/runtimes/apple/semantics.mdx
@@ -11,19 +11,31 @@ import { Apple } from "/snippets/constants.mdx"
   Have feedback? Join the [Early Access community](https://community.rive.app/c/early-access/) to share your thoughts and help shape the feature.
 </Note>
 
-Semantics describe what the elements of your scene *are* — a button, a checkbox, a tab, an image — so that screen readers can describe and navigate your content. You define semantics in the Rive Editor, and at runtime the {Apple.currentRuntimeName} exposes them to [VoiceOver](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios).
+This page covers enabling [semantics](/editor/accessibility/semantics) in the {Apple.currentRuntimeName} so your Rive views are accessible to VoiceOver. To learn what semantics are and how to add them to a graphic, see the [Semantics](/editor/accessibility/semantics) editor documentation.
+
+## Overview
+
+You add semantics to the elements of your graphic in the Rive Editor — roles such as button, checkbox, tab, slider, image, link, list, or dialog, along with their labels, values, states, and actions. At runtime, the {Apple.currentRuntimeName} reads those semantics from the running state machine and exposes them to [VoiceOver](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios) as the view's `accessibilityElements`, keeping them up to date as the state machine advances.
 
 <Warning>
   Semantics are **opt‑in**. The default mode is `.off`, so no accessibility elements are created until you enable semantics on the view.
 </Warning>
 
-<Info>
-  To add roles, properties, traits, and states to your scene, see the [Semantics](/editor/accessibility/semantics) editor documentation. For which runtimes currently support semantics, see [Feature Support](/feature-support).
-</Info>
+<Note>
+  Semantics must be defined in the editor to have any effect. If an element has no semantics, it is not exposed to VoiceOver — regardless of the mode you set. See [Feature Support](/feature-support) for which runtimes currently support semantics.
+</Note>
 
 ## Availability
 
-Semantics in the Apple runtime are available in the {Apple.currentRuntimeName} on all supported Apple platforms **except macOS (AppKit)**. Mac Catalyst *is* supported. They are not available in the {Apple.legacyRuntimeName}.
+Semantics are available in the {Apple.currentRuntimeName} only (not the {Apple.legacyRuntimeName}), on every Apple platform the runtime supports except macOS (AppKit):
+
+| Platform | Supported |
+| --- | --- |
+| iOS / iPadOS | ✅ |
+| tvOS | ✅ |
+| visionOS | ✅ |
+| Mac Catalyst | ✅ |
+| macOS (AppKit) | ❌ |
 
 ## Semantics modes
 
@@ -74,9 +86,3 @@ Set the semantics mode on the view (UIKit) or with the `.semantics(_:)` modifier
     }
     ```
 </CodeGroup>
-
-## How it works
-
-When semantics are enabled, Rive reads the semantic nodes produced by the running state machine and exposes them as the view's `accessibilityElements`. Each node carries a role (such as button, checkbox, tab, slider, image, link, list, or dialog) along with its label, value, state, and any available actions. As the state machine advances, Rive applies per‑frame updates so VoiceOver always reflects the current state of your scene.
-
-Because the accessibility tree is derived from the state machine, make sure your scene's elements have semantics assigned in the editor — without them, there is nothing for VoiceOver to read even when the mode is `.on` or `.automatic`.

--- a/snippets/feature-support.jsx
+++ b/snippets/feature-support.jsx
@@ -96,7 +96,7 @@ export const FeatureSupportGroup = ({
                 reactNative: { supported: false, description: "Coming soon" },
                 reactNativeLegacy: { supported: false, description: "Not supported" },
                 flutter: { supported: true, version: "0.14.6" },
-                apple: { supported: false, description: "Coming soon" },
+                apple: { supported: true, version: "v6.21.0" },
                 android: { supported: false, description: "Coming soon" },
                 cpp: { supported: true, description: "Supported" },
                 unity: { supported: false, description: "Not yet supported" },


### PR DESCRIPTION
## Overview

Documents the new Apple runtime `Semantics` API, which exposes editor-authored semantics to VoiceOver. This is the runtime counterpart to the existing [editor Semantics](/editor/accessibility/semantics) docs — until now there was nothing explaining how to enable accessibility at runtime on Apple.

## What changed

- **New page `runtimes/apple/semantics.mdx`** — a dedicated guide covering:
  - Early Access note (mirrors the editor semantics page)
  - Availability (New Runtime only; all supported Apple platforms except macOS/AppKit; Mac Catalyst supported)
  - The `Semantics` modes (`.off` default, `.on`, `.automatic`) in a table
  - Usage `<CodeGroup>` for UIKit / SwiftUI / SwiftUI (Async)
  - A "How it works" section
- **`runtimes/apple/apple.mdx`** — a brief `## Semantics` section after Frame Rate with the three-tab `<CodeGroup>` (consistent with other sections) linking to the full guide.
- **`docs.json`** — registers the page in the Apple nav group, after `state-machines`.

## Notes for reviewers

- The feature is **opt-in**: the default mode is `.off`, called out in both the overview blurb and the dedicated page.
- Both spots note it is **New Runtime only** (not available in the Legacy Runtime).
- Verified locally with `mintlify broken-links` (no broken links) and `docs.json` validates as JSON.