### PR TITLE
docs(js/react): update guidance on preloading WASM and the .riv file

### DIFF
--- a/runtimes/react/preloading-wasm.mdx
+++ b/runtimes/react/preloading-wasm.mdx
@@ -8,47 +8,69 @@ import Thanks from '/snippets/runtimes/preloading-wasm/thanks.mdx'
 
 <Overview />
 
-If you're using `@rive-app/react-canvas` or `@rive-app/react-webgl2`, import the WASM resource into your app, as well as the `RuntimeLoader` API:
+The React runtimes are thin wrappers around the JS runtimes, so they load the same WASM file from the same place.
 
-```javascript
-import riveWASMResource from '@rive-app/canvas/rive.wasm';
-import { useRive, RuntimeLoader } from '@rive-app/react-canvas';
+<Warning>
+  Matching the WASM version in React: the `@rive-app/react-canvas` version is not the same as the underlying `@rive-app/canvas` version it wraps. The `rive.wasm` must match the canvas version. To find it, open your installed React runtime's [package.json on GitHub](https://github.com/rive-app/rive-react/blob/v4.29.5/package.json#L38) and read the `@rive-app/canvas` dependency — e.g. `rive-react@v4.29.5` pins `@rive-app/canvas@2.38.5`. Swap the tag in that URL to match the version you have installed.
+</Warning>
 
-RuntimeLoader.setWasmUrl(riveWASMResource);
+## Initializing Rive on page load
 
-const MyComponent = () => {
-  const { rive, RiveComponent } = useRive({
-    src: 'foo.riv',
-    ...
-  });
-};
+If you need Rive to be ready to render your graphics immediately on page load (i.e. hero animations), we recommend preloading both the `rive.wasm` file and the .riv file so the browser begins downloading the necessary resources up front. On the JS side, you can use the RuntimeLoader API to begin downloading and compiling the WASM early, before the Rive component mounts.
+
+By default, the React runtime fetches `rive.wasm` from unpkg at the `@rive-app/canvas` version it pins — you don't need to call `RuntimeLoader.setWasmUrl()` for this. To preload it, just point a `<link rel="preload">` at that same URL (see the version note above for finding the version):
+
+```html
+<!-- index.html (or main app entry point) -->
+<!-- Open the connection to the wasm CDN as early as possible -->
+<link rel="preconnect" href="https://unpkg.com" crossorigin />
+
+<!-- If hosting the WASM file yourself, point this to the appropriate location rive.wasm lives in your CDN  -->
+<link
+  rel="preload"
+  as="fetch"
+  crossorigin
+  href="https://unpkg.com/@rive-app/canvas@2.38.5/rive.wasm"
+/>
+
+<!-- Preload the main hero .riv file too -->
+<link rel="preload" as="fetch" crossorigin href="/assets/hero.riv" />
 ```
 
-The `RuntimeLoader` is a singleton that manages loading in the WASM file behind the scenes when loading in the `Rive` instance. By calling the `setWasmUrl` API, you can load in WASM for the Rive runtime with the data URI from the direct import of the WASM file. Run this API on any page that has a Rive animation to load.
+Then in your React app, begin the process to compile the WASM file as early as possible.
 
-<Note>
- You may need to add configuration into your build tool to import WASM files. See the [original blog post](https://dev.to/alex_barashkov/optimization-techniques-for-rive-animations-in-react-apps-1a8p) that inspired us to add these to docs for some guidance here
-</Note>
+```jsx
+import {useRive, RuntimeLoader} from '@rive-app/react-canvas';
 
-You can additionally preload the WASM module if you set up your build tools to load Web Assembly for your application in relevant pages where you create Rive instances to instance your Rive animations quickly.
+// (Optional) Only add this if you serve rive.wasm from your own CDN and are not using unpkg.
+// This should match the URL you preload 
+// RuntimeLoader.setWasmUrl("https://cdn.example.com/assets/rive-2.38.5.wasm");
 
-For example, with Next.js, you may attach the following to your main page layout:
+if (typeof window !== 'undefined') {
+  RuntimeLoader.awaitInstance().catch(() => {});
+}
 
-```javascript
-import { Html, Head } from "next/document";
-import riveWASMResource from '@rive-app/canvas/rive.wasm';
+export default function Hero() {
+  const { RiveComponent } = useRive({
+    src: '/assets/hero.riv',
+    stateMachines: 'State Machine 1',
+    autoplay: true,
+    autoBind: true,
+  });
 
-export default function Document() {
-  return (
-    <Html>
-      <Head>
-        <link rel="preload" href={riveWASMResource} as="fetch" crossOrigin="anonymous" />
-      </Head>
-    </Html>
-  );
+  return <RiveComponent style={{ width: 400, height: 400 }} />;
 }
 ```
 
-You may need to install `@rive-app/canvas` at the version tied down with the correlated React version on `@rive-app/react-canvas` or you may notice issues at runtime. For example, `@rive-app/react-canvas@3.0.33` ties down the JS dependency at `@rive-app/canvas@1.0.95`; therefore you may want to install that specific version of the JS runtime to ensure compatibility.
+Alternatively, if you'd rather let your bundler self-host and version-match the WASM file alongside your app build, you can import it. Because `@rive-app/canvas` is only a transitive 
+dependency of the React runtime, this import resolves under npm/yarn (which hoist it) but fails under pnpm unless you add `@rive-app/canvas` to your own package.json at the matching version.
+
+```js
+import riveWASMResource from '@rive-app/canvas/rive.wasm'; // Vite: append ?url
+import {RuntimeLoader} from '@rive-app/react-canvas';
+RuntimeLoader.setWasmUrl(riveWASMResource);
+```
+
+The import emits rive.wasm as a separate hashed file, not inlined into your JS bundle.
 
 <Thanks />

--- a/runtimes/react/preloading-wasm.mdx
+++ b/runtimes/react/preloading-wasm.mdx
@@ -10,15 +10,17 @@ import Thanks from '/snippets/runtimes/preloading-wasm/thanks.mdx'
 
 The React runtimes are thin wrappers around their JavaScript counterparts and load the same WASM file from the same location.
 
-<Warning>
-  Matching the WASM version in React: the `@rive-app/react-canvas` version is not the same as the underlying `@rive-app/canvas` version it wraps. The `rive.wasm` must match the canvas version. To find it, open your installed React runtime's [package.json on GitHub](https://github.com/rive-app/rive-react/blob/v4.29.5/package.json#L38) and read the `@rive-app/canvas` dependency — e.g. `rive-react@v4.29.5` pins `@rive-app/canvas@2.38.5`. Swap the tag in that URL to match the version you have installed.
-</Warning>
-
 ## Initializing Rive on page load
 
 If you need Rive to be ready to render your graphics immediately on page load (i.e. hero animations), we recommend preloading both the `rive.wasm` file and the .riv file so the browser begins downloading the necessary resources up front. On the JS side, you can use the RuntimeLoader API to begin downloading and compiling the WASM early, before the Rive component mounts.
 
-By default, the React runtime fetches `rive.wasm` from unpkg at the `@rive-app/canvas` version it pins — you don't need to call `RuntimeLoader.setWasmUrl()` for this. To preload it, just point a `<link rel="preload">` at that same URL (see the version note above for finding the version):
+By default, the React runtime fetches `rive.wasm` from unpkg at the `@rive-app/canvas` version it pins — you don't need to call `RuntimeLoader.setWasmUrl()` for this. 
+
+<Note>
+  Matching the WASM version in React: the `@rive-app/react-canvas` version is not the same as the underlying `@rive-app/canvas` version it wraps. The `rive.wasm` must match the canvas version. To find it, open your installed React runtime's [package.json on GitHub](https://github.com/rive-app/rive-react/blob/v4.29.5/package.json#L38) and read the `@rive-app/canvas` dependency — e.g. `rive-react@v4.29.5` pins `@rive-app/canvas@2.38.5`. Swap the tag in that URL to match the version you have installed.
+</Note>
+
+To preload it, just point a `<link rel="preload">` at that same URL (see the version note above for finding the version):
 
 ```html
 <!-- index.html (or main app entry point) -->

--- a/runtimes/react/preloading-wasm.mdx
+++ b/runtimes/react/preloading-wasm.mdx
@@ -8,7 +8,7 @@ import Thanks from '/snippets/runtimes/preloading-wasm/thanks.mdx'
 
 <Overview />
 
-The React runtimes are thin wrappers around the JS runtimes, so they load the same WASM file from the same place.
+The React runtimes are thin wrappers around their JavaScript counterparts and load the same WASM file from the same location.
 
 <Warning>
   Matching the WASM version in React: the `@rive-app/react-canvas` version is not the same as the underlying `@rive-app/canvas` version it wraps. The `rive.wasm` must match the canvas version. To find it, open your installed React runtime's [package.json on GitHub](https://github.com/rive-app/rive-react/blob/v4.29.5/package.json#L38) and read the `@rive-app/canvas` dependency — e.g. `rive-react@v4.29.5` pins `@rive-app/canvas@2.38.5`. Swap the tag in that URL to match the version you have installed.

--- a/runtimes/web/preloading-wasm.mdx
+++ b/runtimes/web/preloading-wasm.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Preloading WASM'
-description: ''
+description: 'Optimize loading Rive animations on page load'
 ---
 
 import Overview from '/snippets/runtimes/preloading-wasm/overview.mdx'
@@ -8,25 +8,65 @@ import Thanks from '/snippets/runtimes/preloading-wasm/thanks.mdx'
 
 <Overview />
 
-If you're using the base `@rive-app/canvas` or `@rive-app/webgl2` (or any plain JS-variant runtime), import the WASM resource into your app, as well as the `RuntimeLoader` API:
+A few notes if you do decide to host the WASM file yourself:
+  1. The `rive.wasm` file version must match the `@rive-app` package version in your package.json — they are built as a pair, and a mismatch can break rendering/functionality at runtime. Put the version in the path or filename (e.g. `rive-2.38.5.wasm`) and update the hosted file in the same change as any dependency bump.
+  2. The `<link rel="preload">` href and the URL passed to `setWasmUrl()` must be exactly the same, or the preloaded bytes are discarded and the file downloads twice. See example below.
+  3. Serve the file with the `application/wasm` MIME type — anything else silently disables streaming compilation.
+  4. If the file is on a different origin than the page (e.g. a CDN subdomain), send `Access-Control-Allow-Origin` for your page origin, and keep the `crossorigin` attribute on the preload tag.
+  5. Serve the versioned file with `Cache-Control: public, max-age=31536000, immutable`, and confirm your CDN applies brotli/gzip to .wasm (some only compress text types by default).
 
-```javascript
-import riveWASMResource from '@rive-app/canvas/rive.wasm';
-import { Rive, RuntimeLoader } from '@rive-app/canvas';
+## Initializing Rive on page load
 
-RuntimeLoader.setWasmUrl(riveWASMResource);
-...
-const riveInstance = new Rive({
-  src: 'foo.riv',
-  ...
-});
+If you need Rive to be ready to render your graphics immediately on page load (i.e. hero animations), we recommend preloading both the `rive.wasm` file and the actual `.riv` file to
+begin downloading of the necessary resources up front. On the JS side, you can use the `RuntimeLoader` API to begin downloading and compiling the WASM early on before instancing the Rive graphic on the page.
+One other optimization is to fetch the `.riv` file and get the bytes as an ArrayBuffer early so you can pass it to the Rive instance.
+
+```html
+<!-- index.html -->
+<!-- Open the connection to the wasm CDN as early as possible -->
+<!-- If you are hosting the WASM file yourself, set this to your CDN URL instead -->
+<link rel="preconnect" href="https://unpkg.com" crossorigin />
+
+<!-- Preload the exact versioned wasm URL the runtime will request.
+     The version MUST match the installed @rive-app package version, or the
+     runtime re-fetches the resource -->
+<!-- If you are hosting the WASM file yourself, set this to the rive.wasm location on your server -->
+<link
+  rel="preload"
+  as="fetch"
+  crossorigin
+  href="https://unpkg.com/@rive-app/canvas@2.38.5/rive.wasm"
+/>
+
+<!-- Preload the main hero .riv file too -->
+<link rel="preload" as="fetch" crossorigin href="/assets/hero.riv" />
 ```
 
-The `RuntimeLoader` is a singleton that manages loading in the WASM file behind the scenes when loading in the `Rive` instance. By calling the `setWasmUrl` API, you can load in WASM for the Rive runtime with the data URI from the direct import of the WASM file. Run this API on any page that has a Rive animation to load.
 
-<Note>
- You may need to add configuration into your build tool to import WASM files and inline it as a data URI. See the [original blog post](https://dev.to/alex_barashkov/optimization-techniques-for-rive-animations-in-react-apps-1a8p) that inspired us to add these to docs for some guidance here
-</Note>
+```javascript
+import { Rive, RuntimeLoader } from '@rive-app/canvas';
+
+// (Optional) Only add this if you are hosting the WASM file on your own servers
+// const WASM_URL = "https://cdn.example.com/assets/rive-2.38.5.wasm";
+// RuntimeLoader.setWasmUrl(WASM_URL);
+
+// Run this API as early as possible on page load to begin compiling the rive.wasm file
+RuntimeLoader.awaitInstance().catch(() => {});
+
+const heroFetch = fetch("/assets/hero.riv").then((r) => r.arrayBuffer());
+
+// ... later, when mounting:
+async function mountHero(canvas) {
+  const riveInstance = new Rive({
+    canvas,
+    buffer: await heroFetch,
+    stateMachines: "State Machine 1",
+    autoBind: true,
+    autoplay: true,
+    // ... other configuration
+  });
+}
+```
 
 <Thanks />
 

--- a/runtimes/web/preloading-wasm.mdx
+++ b/runtimes/web/preloading-wasm.mdx
@@ -11,8 +11,8 @@ import Thanks from '/snippets/runtimes/preloading-wasm/thanks.mdx'
 A few notes if you do decide to host the WASM file yourself:
   1. The `rive.wasm` file version must match the `@rive-app` package version in your package.json — they are built as a pair, and a mismatch can break rendering/functionality at runtime. Put the version in the path or filename (e.g. `rive-2.38.5.wasm`) and update the hosted file in the same change as any dependency bump.
   2. The `<link rel="preload">` href and the URL passed to `setWasmUrl()` must be exactly the same, or the preloaded bytes are discarded and the file downloads twice. See example below.
-  3. Serve the file with the `application/wasm` MIME type — anything else silently disables streaming compilation.
-  4. If the file is on a different origin than the page (e.g. a CDN subdomain), send `Access-Control-Allow-Origin` for your page origin, and keep the `crossorigin` attribute on the preload tag.
+  3. Serve the file with the `application/wasm` MIME type — anything else drops you off the streaming-compilation path and onto a slower fallback.
+  4. If the file is on a different origin than the page (e.g. a CDN subdomain), also send `Access-Control-Allow-Origin` for your page origin.
   5. Serve the versioned file with `Cache-Control: public, max-age=31536000, immutable`, and confirm your CDN applies brotli/gzip to .wasm (some only compress text types by default).
 
 ## Initializing Rive on page load

--- a/snippets/runtimes/preloading-wasm/overview.mdx
+++ b/snippets/runtimes/preloading-wasm/overview.mdx
@@ -1,7 +1,9 @@
 When rending a Rive instance, your browser is making a network request to `https://unpkg.com/@rive-app/canvas@x.x.x/rive.wasm` which retrieves a [Web Assembly](https://developer.mozilla.org/en-US/docs/WebAssembly) (WASM) file that contains Rive-specific APIs to build the render loop. [unkpg](https://unpkg.com/) is a global CDN that quickly allows for loading in NPM packages, which in this case includes a WASM file. This allows for a smaller bundle size when pulling in the Rive JS-based runtimes, while only loading in WASM when Rive instances are created.
 
-While `unpkg` should provide WASM quickly and can cache across sites that load from this CDN, you may want to preload and host the WASM file yourself for any of the following reasons:
+## Self-hosting Rive WASM
 
-- Better reliability of the WASM powering the Rive animations
-- Quicker load times for your animations
-- Control over when resources get loaded into your web apps
+While `unpkg` should provide WASM quickly, you may want to preload and host the WASM file yourself as a static same-origin asset for any of the following reasons:
+
+- Strict control over the origin of the WASM powering the Rive animations, as opposed to relying on a third-party unpkg CDN
+- Faster load times for initializing Rive
+- Ability to control caching policy of the `rive.wasm` file


### PR DESCRIPTION
Updating the preloading guidance for rive.wasm on JS and React pages for more in-depth explanation and code examples. 