### PR TITLE
docs(runtimes): runtime changelog + periodic update tooling

### DIFF
--- a/.claude/skills/runtime-announcement/SKILL.md
+++ b/.claude/skills/runtime-announcement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runtime-announcement
-description: Write the fortnightly Rive runtime update entry in runtimes/changelog.mdx. Use when the user asks to generate, draft, or publish a runtime changelog entry, runtime update announcement, or "what shipped in the runtimes" post.
+description: Write a Rive runtime update entry in runtimes/changelog.mdx. Use when the user asks to generate, draft, or publish a runtime changelog entry, runtime update announcement, or "what shipped in the runtimes" post.
 ---
 
 # Runtime update announcement
@@ -123,7 +123,7 @@ Cut entirely: CI and release plumbing, dependency bumps with no user impact, for
 internal refactors with no stated effect. `pin npm down to v11 as latest compatible
 version for our node runner` is not an announcement.
 
-Collapse consecutive versions. Five patch releases in a fortnight usually contain one or
+Collapse consecutive versions. Five patch releases in one window usually contain one or
 two things a user cares about — write those, not five sections. Never pad a section to
 make a runtime look busy; a runtime with one real fix gets one bullet.
 
@@ -134,10 +134,12 @@ announced per runtime. It is the boundary for the next entry, which is why it mu
 committed in the **same commit** as the entry it describes — and why you never advance it
 before the user approves.
 
-Once a runtime has a recorded version, its range is pure version comparison up to the
-latest published release. The two-week window is bootstrap-only and is never consulted
-again for that runtime. A runtime added to the config later has no state, so it
-bootstraps from the window on its first run — it will not dump its whole history.
+Run this whenever — weekly, biweekly, or ad hoc. Once a runtime has a recorded version,
+its range is a pure version comparison up to the latest published release, so the result
+is the same no matter how much time has passed since the last entry. The lookback window
+is used only to seed a runtime that has no state yet (its first-ever entry); after that it
+is never consulted again. A runtime added to the config later bootstraps from that window
+on its first run rather than dumping its whole history.
 
 A runtime marked `baselineOnly: true` shipped nothing in the window and is present only
 because the first entry establishes a starting point. Say so plainly in its section

--- a/.claude/skills/runtime-announcement/SKILL.md
+++ b/.claude/skills/runtime-announcement/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: runtime-announcement
+description: Write the fortnightly Rive runtime update entry in runtimes/changelog.mdx. Use when the user asks to generate, draft, or publish a runtime changelog entry, runtime update announcement, or "what shipped in the runtimes" post.
+---
+
+# Runtime update announcement
+
+You turn collected release notes into one changelog entry. You do **not** decide what
+shipped — `scripts/runtime-changelog/collect.mjs` already did, from the package
+registries and repos. Never add a version, date, or URL that isn't in its output, and
+never "check GitHub" to fill a gap. A gap is a finding to report, not one to fill.
+
+## Workflow
+
+The whole run is: **collect → draft → review → approve → record → (user commits) →
+share.** Facts come from the collector; you own only the prose; the user owns approval
+and the commit. Walk it in order.
+
+1. **Collect.** Run `node scripts/runtime-changelog/collect.mjs`. It only writes
+   `scripts/runtime-changelog/generated/release-data.json`; it never touches state.
+   If it reports no new releases, stop and tell the user. Don't write an entry.
+   (`--baseline` exists only for the very first entry, when `state.json` does not yet
+   exist; the script refuses it once any state is recorded. You will not normally use it.)
+2. **Read.** Read `generated/release-data.json` in full — including every `notes` body
+   and `data.core`, not just the version list.
+3. **Draft.** Write the entry per the format and editorial rules below.
+4. **Insert.** Place it in `runtimes/changelog.mdx` immediately after the
+   `{/* RUNTIME_UPDATE_INSERTION_POINT ... */}` line, so newest sits first. Leave the
+   marker in place and change nothing else on the page. If the marker is gone, stop and
+   ask — don't guess where the entry belongs.
+5. **Preview for review.** Show the user the entry, any `warnings`, and the
+   `docsVersionUpdates` (the `docs.json` install-version bumps queued for step 6). Also run
+   `node scripts/runtime-changelog/digest.mjs --since <window
+   start>` and show that too — reviewing the docs entry and the community post together
+   catches wording that reads fine on the page but oddly out of context. The digest reads
+   the file on disk, so it reflects the draft you just wrote. Say plainly nothing is
+   committed and no state has moved.
+6. **Record — only after they approve.** Run
+   `node scripts/runtime-changelog/collect.mjs --advance-state`. This does two things:
+   records what was announced into `state.json`, and syncs the docs install-version
+   variables in `docs.json` (`versionApple`, `versionAndroid`, …) to each runtime's
+   latest version. Never run it before approval: state is the boundary for the *next*
+   entry, so advancing it early silently skips releases forever. It writes the two files
+   but does not commit. The collect step (1) already previewed the `docs.json` bumps.
+7. **Hand off the commit.** Tell the user to commit `runtimes/changelog.mdx`,
+   `scripts/runtime-changelog/state.json`, and `docs.json` **together** (one logical
+   change), after running `mint broken-links`. Never commit, push, or open a PR yourself.
+8. **Share.** When they want the community post, run
+   `node scripts/runtime-changelog/digest.mjs --since <window start>`. It reassembles the
+   changelog into one markdown post grouped by runtime, inheriting the reviewed prose and
+   the deep per-release links — so the shared post can never diverge from the published
+   page. The post prints to stdout (show it to the user) and is saved to
+   `scripts/runtime-changelog/generated/community-post.md` (git-ignored). **Tell the user
+   that path** so they know where to grab it; that file is for copy-pasting into
+   Discord/forum/email and must not be committed. Generate it from the finalized entry,
+   never from raw collected data.
+
+## Format
+
+The label is the permalink anchor and cannot be changed later without breaking inbound
+links — use `Month D, YYYY` and never edit a published one. Tag every entry with exactly
+the runtimes it covers: tags are AND-filtered, and an untagged entry disappears the
+moment a reader filters by anything.
+
+```mdx
+<Update label="July 17, 2026" description="Apple, Android, Web, React, React Native, Unreal" tags={["Apple", "Android", "Web", "React", "React Native", "Unreal"]}>
+
+## Core runtime
+
+- Fixed the Lua `Data` global being `nil` in scripts, which broke script-driven view model instance creation.
+
+Shipped in the Apple, Android, and Web releases below.
+
+[Core runtime](https://github.com/rive-app/rive-runtime)
+
+## Apple v6.21.1
+
+- …
+
+[Apple release notes](https://github.com/rive-app/rive-ios/releases)
+
+</Update>
+```
+
+Rules:
+
+- `## Core runtime` comes first, with no version (see the core section below). Then one
+  `##` heading per runtime, `## <Runtime> <versionRange>`, using `displayName` and
+  `versionRange` verbatim from the JSON. Each heading becomes its own RSS entry, which
+  is why the version belongs in the heading — `## Android v11.7.2` is a good feed title,
+  `## Android` is not.
+- Order runtime sections by how much users care: Apple, Android, Web, React,
+  React Native, Flutter, Unity, Unreal. Omit any runtime with `hasUpdates: false`
+  entirely.
+- Close each section with a **version-specific** link, never a repo's general releases
+  index. Every release in `release-data.json` carries a deep `url` already: a GitHub
+  release-tag page, a pub.dev version page, or a GitHub compare link. Use those.
+  - Single version: `[Apple v6.21.1 release notes](<that release's url>)`.
+  - A range (e.g. React Native's five releases): list each version's link on one line,
+    `Releases: [v0.4.14](url) · [v0.4.15](url) · …`, so each points at its own notes.
+  - `links.releases` (the general index) is only a fallback if a release somehow has no
+    `url`, which should not happen.
+- `description` and `tags` list the shipping runtimes covered, comma-separated. Core is
+  not a tag — it isn't something anyone installs, and it appears in nearly every entry,
+  so it would be a useless filter.
+- Don't set `mode` in the page frontmatter and don't add an `rss` prop to the `<Update>`
+  — both suppress features we want.
+
+## Editorial rules
+
+Write for a developer deciding whether to upgrade. Technical, plain, no marketing. Lead
+each section with what matters most: breaking changes and migrations first, then new
+APIs, then meaningful fixes, then everything else.
+
+Include only what the source notes support. If notes say "fixed a crash," don't write
+"major stability improvements." If something is ambiguous, keep the source's neutral
+wording or flag it to the user — never resolve ambiguity by inventing detail.
+
+Never drop a breaking change, even a small one. If the notes hint at one and you're
+unsure, surface it to the user rather than omitting it.
+
+Cut entirely: CI and release plumbing, dependency bumps with no user impact, formatting,
+internal refactors with no stated effect. `pin npm down to v11 as latest compatible
+version for our node runner` is not an announcement.
+
+Collapse consecutive versions. Five patch releases in a fortnight usually contain one or
+two things a user cares about — write those, not five sections. Never pad a section to
+make a runtime look busy; a runtime with one real fix gets one bullet.
+
+## How the version range is decided
+
+`scripts/runtime-changelog/state.json` is the committed record of the last version
+announced per runtime. It is the boundary for the next entry, which is why it must be
+committed in the **same commit** as the entry it describes — and why you never advance it
+before the user approves.
+
+Once a runtime has a recorded version, its range is pure version comparison up to the
+latest published release. The two-week window is bootstrap-only and is never consulted
+again for that runtime. A runtime added to the config later has no state, so it
+bootstraps from the window on its first run — it will not dump its whole history.
+
+A runtime marked `baselineOnly: true` shipped nothing in the window and is present only
+because the first entry establishes a starting point. Say so plainly in its section
+("The current Flutter release, included here to set a starting point for this
+changelog") rather than implying it just shipped.
+
+## The core section
+
+`data.core` holds changes to the shared C++ runtime (`rive-app/rive-runtime`). It is
+**derived, not collected**: that repo publishes no releases, so the collector
+reconstructs core changes from the upstream commits that Apple, Android and Web each
+vendored into a shipped release. Two consequences:
+
+- Every core change listed has, by construction, actually shipped in a released runtime.
+  Do not go read `rive-runtime`'s `main` branch to fill gaps — it contains unreleased
+  work, and announcing that repeats the Flutter `## Upcoming` mistake.
+- `## Core runtime` carries **no version**. rive-runtime cuts a tag per commit
+  (`runtime-v0.1.191`); those numbers are meaningless to users. Don't invent a range.
+
+Each change has `shippedIn` (which runtimes carried it), `scope`, `type`, and `pr`. Most
+are in more than one runtime — that is the whole point of the section. State plainly
+which releases carry them, e.g. "Shipped in the Apple, Android, and Web releases below",
+using `derivedFrom`.
+
+**Never repeat a core change inside a runtime's own section.** If Core says the Lua
+`Data` global was fixed, Apple's section must not say it again. A runtime's section
+covers only its `platformChanges` plus any genuinely platform-specific curated notes.
+This is why a runtime section may be very short — Android often has one or two real
+changes of its own. That is honest; do not pad it.
+
+Editor-only commits are already excluded by the collector. A change marked
+`ambiguous: true` had a mixed scope like `fix(editor and runtime)` — decide whether the
+runtime-facing half is worth announcing, and say so when you report back.
+
+Core's outbound link is the `rive-app/rive-runtime` repo, since it has no releases yet.
+**Future:** rive-runtime will publish official releases, at which point every runtime
+will vendor a named core version and Core can link that specific version (and each
+runtime section can state which core version it carries). Don't build for that now — a
+plain repo link is correct until those releases exist.
+
+Core still contains plenty of noise the collector deliberately does not judge: `chore`,
+`perf(tests)`, `fix(build)`, CI, and test-harness work. Cut it. `perf(tests): Spawn
+image_diff.py only once per job` is not an announcement.
+
+## Runtimes wrap other runtimes — do not double-report
+
+This is the easiest way to write a bad entry. Several runtimes are thin wrappers, so
+their release notes are mostly *bumps of a runtime already covered elsewhere in the
+same entry*:
+
+- **React** wraps the Web (`rive-wasm`) runtime. A React release is often only
+  `chore(react): bump js runtime to 2.38.5`.
+- **React Native** wraps Android and Apple: `bump rive-android to 11.7.1 and rive-ios
+  to 6.21.0`.
+- **Flutter** wraps `rive_native`: `Bumps to rive_native: 0.1.9`.
+
+When a wrapper's only changes are bumps of something else in this entry, say so in one
+line and link across — don't restate the wrapped runtime's changes under the wrapper's
+heading. Something like "Updated to the Rive JS runtime 2.38.5 (see Web above)" is
+right. Restating Web's fixes under React is wrong: it reads as separate work, and it
+inflates the entry.
+
+If a wrapper *also* has its own changes (a new hook, a platform-specific fix), those are
+the real content — lead with them and treat the bump as a footnote.
+
+## Per-source quirks
+
+The collector already picks the correct source per runtime, but the notes it hands you
+vary wildly in shape and quality:
+
+- **Apple** — hand-written prose with `## Added` / `## Fixed`. Highest quality; mostly
+  needs condensing, not rewriting.
+- **Unreal**, **Unity** — hand-written prose. Unreal notes may carry a `## Known Issues`
+  section; that is worth surfacing.
+- **Android** — a raw commit list (`fix(Android): Add dirtying to VMI triggers (#13051)`).
+  Not user-facing English. Translate into what a developer would notice, and if a commit
+  is too internal to explain in user terms, drop it rather than paraphrasing the commit
+  message back. Read the linked PR or the Rive docs if you need to understand a term
+  before writing about it.
+- **Web** (`rive-wasm`) — a raw dump of the **whole monorepo's** commits. It contains
+  work that never touched the web runtime at all: `feat(apple): add semantics support`,
+  `feature (Unreal) Ore Support`, `chore(editor): add view model uses to dependencies
+  panel`. Include only what affects the web runtime. This one needs the most filtering.
+- **React** — `auto-changelog` output, one commit line per version, usually just a
+  runtime bump. See the wrapper rule above.
+- **React Native** — `semantic-release` output, conventional-commit bullets. Ships very
+  often; expect to collapse several versions hard.
+- **Flutter** — notes come from the version published to pub.dev, which is the only
+  correctly-versioned copy. Do not read `CHANGELOG.md` on `master`: it keeps released
+  notes under `## Upcoming` and appends unreleased work to that same block, so it will
+  hand you changes nobody can install yet.
+
+## Reporting back
+
+Along with the entry, tell the user:
+
+- any `warnings` on a runtime;
+- the `docsVersionUpdates` the collector reported — the `docs.json` install-version
+  variables that `--advance-state` will bump (e.g. `versionApple 6.13.0 -> 6.21.1`). These
+  are applied automatically on approval; just surface them so the reviewer knows the docs
+  install snippets are moving too;
+- anything you deliberately cut that they might expect to see;
+- anything ambiguous you had to make a judgment call on.

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ Temporary Items
 *.icloud
 
 # End of https://www.toptal.com/developers/gitignore/api/macos
+### Rive runtime changelog tooling ###
+# Collector output: a rebuildable artifact of each run. state.json is NOT ignored —
+# it is the committed record of what has actually been announced.
+scripts/runtime-changelog/generated/
+
+# Personal Claude Code settings. .claude/skills/ is shared and stays tracked.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,23 +10,24 @@ This is the official documentation repository for Rive (https://rive.app/docs), 
 
 ### Setup
 ```bash
-npm i -g mintlify
+npm i -g mint
 ```
+The CLI is `mint` (formerly `mintlify`); use `mint` for all commands below.
 
 ### Local Preview
 ```bash
-mintlify dev
+mint dev
 ```
 Run this from the repository root (where docs.json is located). The preview will be available at http://localhost:3000.
 
 ### Link Validation
 ```bash
-mintlify broken-links
+mint broken-links
 ```
 Always run this before creating a pull request to verify there are no broken links.
 
 ### Troubleshooting
-- If `mintlify dev` isn't running, run `mintlify install` to re-install dependencies
+- If `mint dev` isn't running, run `mint install` to re-install dependencies
 - Make sure you're running commands from the repository root directory
 
 ## Architecture
@@ -99,12 +100,35 @@ fix(web): correct broken quickstart link
 project: update navigation structure
 ```
 
+## Runtime Changelog
+
+The runtime changelog at `/runtimes/changelog` (`runtimes/changelog.mdx`) is produced by
+tooling in `scripts/runtime-changelog/`. Regenerate it with the `/runtime-announcement`
+skill; the full runbook is `scripts/runtime-changelog/README.md`. It can be run on any
+cadence (weekly, biweekly, ad hoc) — the diff is state-driven, not time-based.
+
+Rules when touching this system:
+
+- **Facts are script-owned; prose is AI-owned.** `collect.mjs` decides which versions
+  shipped and owns every version, date, and URL (read from the package registries and
+  GitHub). The skill only writes the human-facing wording. Never hand-author a version or
+  link into a changelog entry.
+- **`scripts/runtime-changelog/state.json`** is the committed record of the last version
+  announced per runtime — the boundary for the next entry. Never hand-edit it. It advances
+  only via `node scripts/runtime-changelog/collect.mjs --advance-state`, committed together
+  with the changelog entry and `docs.json`.
+- **`docs.json` runtime version variables** (`versionApple`, `versionAndroid`,
+  `versionFlutter`, `versionWeb` + `versionMajorWeb`, `versionUnity`, `versionUnreal`) are
+  auto-synced to each runtime's latest release by `--advance-state`. Do not hand-edit them.
+  To show a runtime version in an install snippet, reference the variable as
+  `{{versionApple}}` (etc.) instead of hardcoding a number.
+
 ## Pull Request Workflow
 
 1. Fork the repository and branch from `main`
 2. Make your changes following the content guidelines
-3. Preview locally with `mintlify dev`
-4. Run `mintlify broken-links` to verify no broken links
+3. Preview locally with `mint dev`
+4. Run `mint broken-links` to verify no broken links
 5. Create PR with:
    - Title following Conventional Commits format
    - Description summarizing all changes

--- a/docs.json
+++ b/docs.json
@@ -26,8 +26,12 @@
     "pricingVoyagerMonthly": "$39",
     "pricingVoyagerYearly": "$304",
     "pricingEnterpriseYearly": "$1,440",
-    "versionMajorWebGL2": "2",
-    "versionWebGL2": "2.38.3",
+    "versionMajorWeb": "2",
+    "versionWeb": "2.38.5",
+    "versionApple": "6.21.1",
+    "versionAndroid": "11.7.2",
+    "versionFlutter": "0.14.9",
+    "versionUnity": "0.4.3",
     "supportForm": "https://forms.rive.app/support?utm_medium=support_page",
     "supportFormEducational": "https://forms.rive.app/education?utm_medium=support_page"
   },
@@ -536,7 +540,9 @@
               "feature-support",
               "runtimes/runtime-sizes",
               "runtimes/choose-a-renderer/overview",
-              "runtimes/advanced-topic/format"
+              "runtimes/advanced-topic/format",
+              "runtimes/changelog",
+              "runtimes/changelog-per-runtime"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -32,6 +32,7 @@
     "versionAndroid": "11.7.2",
     "versionFlutter": "0.14.9",
     "versionUnity": "0.4.3",
+    "versionUnreal": "0.4.25",
     "supportForm": "https://forms.rive.app/support?utm_medium=support_page",
     "supportFormEducational": "https://forms.rive.app/education?utm_medium=support_page"
   },

--- a/game-runtimes/unity/getting-started.mdx
+++ b/game-runtimes/unity/getting-started.mdx
@@ -49,10 +49,10 @@ The **Unity Asset Store** has a simpler installation process and only includes t
   <Tab title="GitHub">
     The [rive-unity package](https://github.com/rive-app/rive-unity) is also available to install from GitHub using a git dependency.
 
-    Add it via **Window -\> Package Manager** and choose **Add package from git URL...** (replace `0.0.0` with the [latest release](https://github.com/rive-app/rive-unity/releases)):
+    Add it via **Window -\> Package Manager** and choose **Add package from git URL...** (pinned to the [latest release](https://github.com/rive-app/rive-unity/releases); change the version tag if you need a specific one):
 
     ```bash
-    https://github.com/rive-app/rive-unity.git?path=package#v0.0.0
+    https://github.com/rive-app/rive-unity.git?path=package#v{{versionUnity}}
     ```
 
     <Steps>
@@ -63,10 +63,10 @@ The **Unity Asset Store** has a simpler installation process and only includes t
     <Note>
       Unity can occasionally crash when upgrading the packages while the Editor is running. If you experience this, close Unity first, update the version in `Packages/manifest.json`, then reopen the project.
     </Note>
-    You can add it manually to your project's `Packages/manifest.json` (replace `0.0.0` with the [latest release](https://github.com/rive-app/rive-unity/releases)):
+    You can add it manually to your project's `Packages/manifest.json` (pinned to the [latest release](https://github.com/rive-app/rive-unity/releases); change the version tag if you need a specific one):
 
     ```json
-    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v0.0.0"
+    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v{{versionUnity}}"
     ```
   </Tab>
 </Tabs>

--- a/game-runtimes/unreal/getting-started.mdx
+++ b/game-runtimes/unreal/getting-started.mdx
@@ -41,10 +41,10 @@ This guide walks you through installing the Rive Unreal plugin, importing a `.ri
   <Tab title="GitHub">
     <Steps>
       <Step>
-        Clone the repository:
+        Clone the plugin at the latest release (omit `--branch` for the in-development version):
 
         ```bash
-        git clone https://github.com/rive-app/rive-unreal.git
+        git clone --branch {{versionUnreal}} https://github.com/rive-app/rive-unreal.git
         ```
       </Step>
       <Step>

--- a/runtimes/android/android.mdx
+++ b/runtimes/android/android.mdx
@@ -61,7 +61,7 @@ If you are looking for getting started instructions for the Legacy API, see [Get
     ```groovy
     dependencies {
         ...
-        implementation 'app.rive:rive-android:<Latest Version>'
+        implementation 'app.rive:rive-android:{{versionAndroid}}'
         // For initialization, you may want to add a dependency on Jetpack Startup
         implementation "androidx.startup:startup-runtime:1.1.1"
     }

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -44,7 +44,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 
                 ```swift
                 dependencies: [
-                    .package(url: "https://github.com/rive-app/rive-ios", from: "6.13.0")
+                    .package(url: "https://github.com/rive-app/rive-ios", from: "{{versionApple}}")
                 ]
                 ```
 

--- a/runtimes/changelog-per-runtime.mdx
+++ b/runtimes/changelog-per-runtime.mdx
@@ -1,0 +1,124 @@
+---
+title: "Changelog (per-runtime shape)"
+description: "TEMPORARY comparison page — same data, one Update per runtime"
+rss: true
+---
+
+<Note>
+  Temporary page for comparing changelog shapes. Same release data as
+  [Changelog](/runtimes/changelog), but emitted as one `<Update>` per runtime instead of
+  one per fortnight. Try the runtime filters in the right sidebar on both pages.
+</Note>
+
+{/* RUNTIME_UPDATE_INSERTION_POINT — new entries are added directly below this line, newest first. Do not remove. */}
+
+<Update label="Core runtime - July 16, 2026" description="Shipped in Apple 6.21.1, Android 11.7.2, Web 2.38.5" tags={["Apple", "Android", "Web"]}>
+
+Changes to the shared runtime that Rive is built on. These ship inside the runtime releases below, so no separate upgrade is needed.
+
+- Added 3D vector operations, `Mat4.lookAt` and `Mat4.ortho`, vector buffer writes, and a `GPUBuffer` write source range to scripting.
+- Added data binding support for fonts.
+- Added `requestArtboardSize`, artboard volume, and a semantics API to the command queue.
+- Added the enum name to `getProperties`.
+- Updated Luau to 0.728.
+- Layout fit is now composed as a separate scale on images, so a scale you set stays independent of it.
+- Fixed the Lua `Data` global not being initialized, which left view model constructors such as `Data.MyViewModel.new()` unavailable to scripts.
+- Fixed detached view model instances not advancing until the end of the frame.
+- Fixed Lua colors being decoded as signed rather than unsigned integers.
+- Fixed `bindablePropertyInstance` being used without validation.
+- Fixed direct focus resolving to a container rather than the first leaf node.
+- Fixed a per-frame update race on the ore buffer, and fixed texture compression.
+
+[Core runtime](https://github.com/rive-app/rive-runtime)
+
+</Update>
+
+<Update label="React Native v0.4.14–v0.4.18" description="July 15, 2026" tags={["React Native"]}>
+
+- Added asynchronous view model instance creation via `useViewModelInstance({ async: true })`.
+- Fixed a disposed Rive file being re-acquired when a view re-attached.
+- Fixed stale property setter calls after dispose, which now no-op instead.
+- Fixed data binding `HybridObject` native resources not being released on Android.
+- Updated the underlying native runtimes to rive-android 11.7.1 and rive-ios 6.21.0.
+
+Releases: [v0.4.14](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.14) · [v0.4.15](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.15) · [v0.4.16](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.16) · [v0.4.17](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.17) · [v0.4.18](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.18)
+
+</Update>
+
+<Update label="Apple v6.21.1" description="July 10, 2026" tags={["Apple"]}>
+
+- Improved time-to-first-frame by drawing the first frame synchronously when resuming from a paused state, rather than waiting on the display link.
+
+Also includes the core runtime changes above.
+
+[Apple v6.21.1 release notes](https://github.com/rive-app/rive-ios/releases/tag/6.21.1)
+
+</Update>
+
+<Update label="Android v11.7.2" description="July 10, 2026" tags={["Android"]}>
+
+- Added locking around the mutation APIs.
+- View model instance triggers now mark their bindings dirty, so a fired trigger propagates to bound properties.
+
+Also includes the core runtime changes above.
+
+[Android v11.7.2 release notes](https://github.com/rive-app/rive-android/releases/tag/11.7.2)
+
+</Update>
+
+<Update label="Unreal v0.4.25" description="July 10, 2026" tags={["Unreal"]}>
+
+- **Breaking:** `OnRiveReady` has been removed.
+- Added RHI GPU Canvas support, and fixed a crash where mouse sync events caused the GPU canvas to draw on the game thread.
+- Mouse down and up now respond immediately, and layout fit mode mouse events are fixed.
+- Exposed triggers to C++, and Blueprint nodes now produce useful errors when used incorrectly.
+- `SetRiveDescriptor` now re-creates artboards, and `SetOwningArtboard` now sets the owned artboard for all nested view models.
+- View model defaults now use referenced values instead of creating new ones, and nested artboards default correctly for instances.
+
+[Unreal v0.4.25 release notes](https://github.com/rive-app/rive-unreal/releases/tag/0.4.25)
+
+</Update>
+
+<Update label="Web v2.38.5" description="July 8, 2026" tags={["Web"]}>
+
+- Fixed an audio clash between Rive runtimes sharing a page by adding miniaudio to the Closure externs.
+
+Also includes the core runtime changes above.
+
+[Web v2.38.5 changes](https://github.com/rive-app/rive-wasm/compare/2.38.4...2.38.5)
+
+</Update>
+
+<Update label="React v4.29.5" description="July 8, 2026" tags={["React"]}>
+
+- Updated to the Rive JS runtime 2.38.5 — see Web for what that includes.
+
+[React v4.29.5 changes](https://github.com/rive-app/rive-react/compare/v4.29.4...v4.29.5)
+
+</Update>
+
+<Update label="Flutter v0.14.9" description="June 22, 2026" tags={["Flutter"]}>
+
+The current Flutter release, included here to set a starting point for this changelog.
+
+- Touch and stylus pointer up and cancel now also dispatch a pointer exit, so listeners receive a Pointer Exit when a finger or pen lifts. This keeps enter and exit symmetric on mobile and matches the other Rive runtimes. Mouse and trackpad pointers are unaffected.
+- `RiveWidgetController` now advances and applies the state machine with zero elapsed time after pointer down and up events, so intermediate state — such as a view model property set on pointer down — is processed even when both occur in the same frame. Set it to `false` to opt out.
+- Shared texture usage is no longer marked experimental.
+- Fixed a crash when using `desktop_multi_window` on Windows with MicroProfile GPU init.
+
+[Flutter v0.14.9 on pub.dev](https://pub.dev/packages/rive/versions/0.14.9)
+
+</Update>
+
+<Update label="Unity v0.4.3" description="May 26, 2026" tags={["Unity"]}>
+
+The current Unity release, included here to set a starting point for this changelog.
+
+- Fixed a crash when assigning `null` to string properties.
+- Fixed a crash when updating the package on Windows.
+- Fixed an issue with library enums during import.
+- Added missing libpng symbol renames for Unity 6.4+ WebGL builds.
+
+[Unity v0.4.3 release notes](https://github.com/rive-app/rive-unity/releases/tag/v0.4.3)
+
+</Update>

--- a/runtimes/changelog-per-runtime.mdx
+++ b/runtimes/changelog-per-runtime.mdx
@@ -7,7 +7,7 @@ rss: true
 <Note>
   Temporary page for comparing changelog shapes. Same release data as
   [Changelog](/runtimes/changelog), but emitted as one `<Update>` per runtime instead of
-  one per fortnight. Try the runtime filters in the right sidebar on both pages.
+  one per date. Try the runtime filters in the right sidebar on both pages.
 </Note>
 
 {/* RUNTIME_UPDATE_INSERTION_POINT — new entries are added directly below this line, newest first. Do not remove. */}

--- a/runtimes/changelog.mdx
+++ b/runtimes/changelog.mdx
@@ -4,8 +4,8 @@ description: "Release updates across the Rive runtimes"
 rss: true
 ---
 
-Updates to the Rive runtimes, published roughly every two weeks. Each entry covers
-every version released since the previous entry.
+Updates to the Rive runtimes. Each entry covers every version released since the
+previous entry, so nothing is missed regardless of how often we post.
 
 For the complete history of any single runtime, see its own release notes: [Web](https://github.com/rive-app/rive-wasm/blob/master/CHANGELOG.md),
 [React](https://github.com/rive-app/rive-react/blob/main/CHANGELOG.md),

--- a/runtimes/changelog.mdx
+++ b/runtimes/changelog.mdx
@@ -1,0 +1,114 @@
+---
+title: "Changelog"
+description: "Release updates across the Rive runtimes"
+rss: true
+---
+
+Updates to the Rive runtimes, published roughly every two weeks. Each entry covers
+every version released since the previous entry.
+
+For the complete history of any single runtime, see its own release notes: [Web](https://github.com/rive-app/rive-wasm/blob/master/CHANGELOG.md),
+[React](https://github.com/rive-app/rive-react/blob/main/CHANGELOG.md),
+[React Native](https://github.com/rive-app/rive-nitro-react-native/releases),
+[Flutter](https://pub.dev/packages/rive/changelog),
+[Apple](https://github.com/rive-app/rive-ios/releases),
+[Android](https://github.com/rive-app/rive-android/releases),
+[Unity](https://github.com/rive-app/rive-unity/releases), and
+[Unreal](https://github.com/rive-app/rive-unreal/releases).
+
+{/* RUNTIME_UPDATE_INSERTION_POINT — new entries are added directly below this line, newest first. Do not remove. */}
+
+<Update label="July 16, 2026" description="Apple, Android, Web, React, React Native, Flutter, Unity, Unreal" tags={["Apple", "Android", "Web", "React", "React Native", "Flutter", "Unity", "Unreal"]}>
+
+## Core runtime
+
+Changes to the shared runtime that Rive is built on. These ship inside the runtime releases listed below, so no separate upgrade is needed.
+
+- Added 3D vector operations, `Mat4.lookAt` and `Mat4.ortho`, vector buffer writes, and a `GPUBuffer` write source range to scripting.
+- Added data binding support for fonts.
+- Added `requestArtboardSize`, artboard volume, and a semantics API to the command queue.
+- Added the enum name to `getProperties`.
+- Updated Luau to 0.728.
+- Layout fit is now composed as a separate scale on images, so a scale you set stays independent of it.
+- Fixed the Lua `Data` global not being initialized, which left view model constructors such as `Data.MyViewModel.new()` unavailable to scripts.
+- Fixed detached view model instances not advancing until the end of the frame.
+- Fixed Lua colors being decoded as signed rather than unsigned integers.
+- Fixed `bindablePropertyInstance` being used without validation.
+- Fixed direct focus resolving to a container rather than the first leaf node.
+- Fixed a per-frame update race on the ore buffer, and fixed texture compression.
+
+Shipped in the Apple, Android, and Web releases below.
+
+[Core runtime](https://github.com/rive-app/rive-runtime)
+
+{/* Core has no releases of its own yet. Once rive-runtime publishes official releases, this should link the specific core version the runtimes below vendored. */}
+
+## Apple v6.21.1
+
+- Improved time-to-first-frame by drawing the first frame synchronously when resuming from a paused state, rather than waiting on the display link.
+
+[Apple v6.21.1 release notes](https://github.com/rive-app/rive-ios/releases/tag/6.21.1)
+
+## Android v11.7.2
+
+- Added locking around the mutation APIs.
+- View model instance triggers now mark their bindings dirty, so a fired trigger propagates to bound properties.
+
+[Android v11.7.2 release notes](https://github.com/rive-app/rive-android/releases/tag/11.7.2)
+
+## Web v2.38.5
+
+- Fixed an audio clash between Rive runtimes sharing a page by adding miniaudio to the Closure externs.
+
+[Web v2.38.5 changes](https://github.com/rive-app/rive-wasm/compare/2.38.4...2.38.5)
+
+## React v4.29.5
+
+- Updated to the Rive JS runtime 2.38.5 — see Web above for what that includes.
+
+[React v4.29.5 changes](https://github.com/rive-app/rive-react/compare/v4.29.4...v4.29.5)
+
+## React Native v0.4.14–v0.4.18
+
+- Added asynchronous view model instance creation via `useViewModelInstance({ async: true })`.
+- Fixed a disposed Rive file being re-acquired when a view re-attached.
+- Fixed stale property setter calls after dispose, which now no-op instead.
+- Fixed data binding `HybridObject` native resources not being released on Android.
+- Updated the underlying native runtimes to rive-android 11.7.1 and rive-ios 6.21.0.
+
+Releases: [v0.4.14](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.14) · [v0.4.15](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.15) · [v0.4.16](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.16) · [v0.4.17](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.17) · [v0.4.18](https://github.com/rive-app/rive-nitro-react-native/releases/tag/v0.4.18)
+
+## Flutter v0.14.9
+
+The current Flutter release, included here to set a starting point for this changelog.
+
+- Touch and stylus pointer up and cancel now also dispatch a pointer exit, so listeners receive a Pointer Exit when a finger or pen lifts. This keeps enter and exit symmetric on mobile and matches the other Rive runtimes. Mouse and trackpad pointers are unaffected.
+- `RiveWidgetController` now advances and applies the state machine with zero elapsed time after pointer down and up events, so intermediate state — such as a view model property set on pointer down — is processed even when both occur in the same frame. Set it to `false` to opt out.
+- Shared texture usage is no longer marked experimental.
+- Fixed a crash when using `desktop_multi_window` on Windows with MicroProfile GPU init.
+
+[Flutter v0.14.9 on pub.dev](https://pub.dev/packages/rive/versions/0.14.9)
+
+## Unity v0.4.3
+
+The current Unity release, included here to set a starting point for this changelog.
+
+- Fixed a crash when assigning `null` to string properties.
+- Fixed a crash when updating the package on Windows.
+- Fixed an issue with library enums during import.
+- Added missing libpng symbol renames for Unity 6.4+ WebGL builds.
+
+[Unity v0.4.3 release notes](https://github.com/rive-app/rive-unity/releases/tag/v0.4.3)
+
+## Unreal v0.4.25
+
+- **Breaking:** `OnRiveReady` has been removed.
+- Added RHI GPU Canvas support, and fixed a crash where mouse sync events caused the GPU canvas to draw on the game thread.
+- Mouse down and up now respond immediately, and layout fit mode mouse events are fixed.
+- Exposed triggers to C++, and Blueprint nodes now produce useful errors when used incorrectly.
+- `SetRiveDescriptor` now re-creates artboards, and `SetOwningArtboard` now sets the owned artboard for all nested view models.
+- View model defaults now use referenced values instead of creating new ones, and nested artboards default correctly for instances.
+
+[Unreal v0.4.25 release notes](https://github.com/rive-app/rive-unreal/releases/tag/0.4.25)
+
+</Update>

--- a/runtimes/flutter/flutter.mdx
+++ b/runtimes/flutter/flutter.mdx
@@ -12,14 +12,6 @@ import { Demos } from "/snippets/demos.jsx";
 
 This guide documents how to use the Rive Flutter runtime to easily integrate Rive graphics in your Flutter apps.
 
-<Note>
-  The latest version of Rive Flutter is currently published as a dev release
-  `0.14.0-dev.x`. This means that while the package is stable and ready for
-  production use, we are still actively developing new features and
-  improvements. We recommend using the latest dev version to take advantage of
-  the newest features and fixes.
-</Note>
-
 <Info>
   Already using Rive Flutter? See our [Migration
   Guide](/runtimes/flutter/migration-guide) for information on adopting the
@@ -43,7 +35,7 @@ Follow the steps below to integrate Rive into your Flutter apps.
     ```yaml
     # pubspec.yaml
     dependencies:
-      rive: ^0.14.0-dev.6 # or latest dev version
+      rive: ^{{versionFlutter}}
     ```
 
   </Step>

--- a/runtimes/react-native/native-version-customization.mdx
+++ b/runtimes/react-native/native-version-customization.mdx
@@ -13,16 +13,17 @@ This section is for advanced users who need to use specific versions of the Rive
 
 ### Default Behavior
 
-By default, Rive React Native uses the native SDK versions specified in `package.json`:
+By default, Rive React Native pins the native SDK versions in the library's own
+`package.json` under `runtimeVersions`. The current release uses:
 
 ```json
 "runtimeVersions": {
-  "ios": "6.12.0",
-  "android": "10.4.5"
+  "ios": "{{versionApple}}",
+  "android": "{{versionAndroid}}"
 }
 ```
 
-These versions are tested and known to work well with this version of Rive React Native.
+These are tested and known to work with this version of Rive React Native. To confirm the exact versions your installed release bundles, check `runtimeVersions` in `node_modules/@rive-app/react-native/package.json`.
 
 ### Customizing Versions
 
@@ -36,7 +37,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.13.0"
+  "RiveRuntimeIOSVersion": "{{versionApple}}"
 }
 ```
 
@@ -51,7 +52,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=10.5.0
+Rive_RiveRuntimeAndroidVersion={{versionAndroid}}
 ```
 
 #### Expo Projects
@@ -69,13 +70,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: "6.13.0",
+        RiveRuntimeIOSVersion: "{{versionApple}}",
       },
     ],
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: "10.5.0",
+        Rive_RiveRuntimeAndroidVersion: "{{versionAndroid}}",
       },
     ],
   ],

--- a/runtimes/web/inputs.mdx
+++ b/runtimes/web/inputs.mdx
@@ -24,7 +24,7 @@ The web runtime provides an `onLoad` callback that's run when the Rive file is l
 <div id="button">
     <canvas id="canvas" width="1000" height="500"></canvas>
 </div>
-<script src="https://unpkg.com/@rive-app/canvas@2.10.3"></script>
+<script src="https://unpkg.com/@rive-app/canvas@{{versionWeb}}"></script>
 <script>
     const button = document.getElementById('button');
 

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -43,10 +43,10 @@ The first step to setting up the low-level Rive APIs is to load in the Rive WASM
 
 You can load the Rive WASM file via [unpkg](https://unpkg.com/) (hosts our NPM modules for the JS runtimes), which will make a network call to the CDN, or you can choose to host the WASM file on your own servers. With `unpkg`, the URL will look something like this:
 
-https://unpkg.com/@rive-app/canvas-advanced@2.26.1/rive.wasm
+https://unpkg.com/@rive-app/canvas-advanced@{{versionWeb}}/rive.wasm
 
 <Note>
- You'll want to ensure that the version at the end of @rive-app/canvas-advanced@ or @rive-app/webgl2-advanced@ matches the version of the dependency you installed in your app. For example, if you installed @rive-app/canvas-advanced@2.26.1 in package.json, the Rive WASM file you request from unpkg would be https://unpkg.com/@rive-app/canvas-advanced@2.26.1/rive.wasm.
+ You'll want to ensure that the version at the end of @rive-app/canvas-advanced@ or @rive-app/webgl2-advanced@ matches the version of the dependency you installed in your app. For example, if you installed @rive-app/canvas-advanced@{{versionWeb}} in package.json, the Rive WASM file you request from unpkg would be https://unpkg.com/@rive-app/canvas-advanced@{{versionWeb}}/rive.wasm.
 <br/>
  See [Preloading WASM](/runtimes/web/preloading-wasm) to preload WASM.
 </Note>
@@ -58,7 +58,7 @@ import RiveCanvas from '@rive-app/canvas-advanced';
 
 async function main() {
   const rive = await RiveCanvas({
-    locateFile: (_) => '<https://unpkg.com/@rive-app/canvas-advanced@2.26.1/rive.wasm>'
+    locateFile: (_) => '<https://unpkg.com/@rive-app/canvas-advanced@{{versionWeb}}/rive.wasm>'
   });
 }
 main();

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -38,7 +38,7 @@ See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which pack
 
         Add the following script tag to your web page to load v2 of the web runtime, which will get the latest patches/minor updates on major version 2:
         ```html
-        <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWebGL2}}"></script>
+        <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWeb}}"></script>
         ```
         If you see a newer major version to upgrade to, ensure your code accounts for breaking changes in the migration guide
 
@@ -46,7 +46,7 @@ See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which pack
 
         Alternatively, pin to a specific version for more control over what is loaded in your app. As Rive's feature set grows, you'll want to manually update this version to a newer one to ensure best compatibility.
         ```html
-        <script src="https://unpkg.com/@rive-app/webgl2@{{versionWebGL2}}"></script>
+        <script src="https://unpkg.com/@rive-app/webgl2@{{versionWeb}}"></script>
         ```
 
         This will make a global `rive` object available, allowing you to access the Rive API via the `rive` entry point. Follow the next steps below.
@@ -154,7 +154,7 @@ Bringing it all together, here's how to load a Rive graphic in a single HTML fil
   <body>
     <canvas id="canvas" width="500" height="500"></canvas>
 
-    <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWebGL2}}"></script>
+    <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWeb}}"></script>
     <script>
       const r = new rive.Rive({
         src: "https://cdn.rive.app/animations/vehicles.riv",

--- a/scripts/runtime-changelog/README.md
+++ b/scripts/runtime-changelog/README.md
@@ -1,0 +1,132 @@
+# Runtime changelog tooling
+
+Generates the fortnightly [runtime changelog](../../runtimes/changelog.mdx) entry and a
+copy-paste community announcement, from the runtimes' own releases.
+
+Two responsibilities, kept apart on purpose:
+
+- **`collect.mjs`** — deterministic. Decides *what shipped* by reading the package
+  registries and GitHub, and owns every version, date and URL. No AI.
+- **the `runtime-announcement` skill** — editorial. Turns the collected notes into prose.
+  This is the only step that uses judgment, and every run is human-reviewed.
+- **`digest.mjs`** — deterministic. Reassembles the *committed changelog* into a shareable
+  post. It reformats reviewed prose; it never re-summarizes.
+
+`state.json` (committed) records the last version announced per runtime. It is the
+boundary for the next entry. `generated/` is throwaway and git-ignored.
+
+Requires Node 18+. No dependencies, no build, no `package.json`.
+
+---
+
+## The two-minute version
+
+```bash
+# 1. Drive the whole thing through Claude Code — this is the normal path:
+#    open the repo and run the slash command, or just ask.
+/runtime-announcement
+```
+
+Claude will collect releases, draft the entry into `runtimes/changelog.mdx`, show it to
+you alongside a preview of the community post, and wait. When you approve, it records
+state. You review the diff, run the link check, and commit. Then ask it for the share
+post. That's it — the sections below are for when you want to run a step by hand.
+
+---
+
+## Running it by hand
+
+### 1. Collect what shipped
+
+```bash
+node scripts/runtime-changelog/collect.mjs
+```
+
+Prints a per-runtime summary and writes `generated/release-data.json`. Safe to run any
+time: it never changes `state.json`, never commits. If nothing new shipped it says so and
+exits 0.
+
+### 2. Write the entry
+
+This is the editorial step — let the skill do it (`/runtime-announcement`), since it
+carries all the rules about which sources are noisy, how the shared "Core runtime"
+section is derived, and what to cut. Doing it fully by hand means re-deriving that.
+
+### 3. Preview before committing
+
+```bash
+mint dev                         # see it render, try the runtime filters
+node scripts/runtime-changelog/digest.mjs --since <YYYY-MM-DD>   # preview the share post
+git diff runtimes/changelog.mdx  # exactly what changed
+```
+
+### 4. Record what was announced
+
+```bash
+node scripts/runtime-changelog/collect.mjs --advance-state
+```
+
+Reads `generated/release-data.json` (no network) and does two things: advances
+`state.json` to the versions in it, and syncs the `docs.json` install-version variables
+(`versionApple`, `versionAndroid`, `versionFlutter`, `versionWeb`, `versionUnity`) to each runtime's
+latest version — so the install snippets across the docs never go stale. The collect step
+previews these bumps first. **Only run this once the entry is finalized** — it sets the
+starting point for the next entry, so running it early would skip those releases forever.
+
+The version variables live in `docs.json` under `variables`. To wire one into a docs page,
+reference it as `{{versionApple}}` in the snippet (as `runtimes/apple/apple.mdx` and the
+web `<script>` tag do). The collector only updates variables that already exist — adding a
+new one is a deliberate `docs.json` edit.
+
+### 5. Commit — the entry and the state together
+
+```bash
+mint broken-links
+git add runtimes/changelog.mdx scripts/runtime-changelog/state.json
+git commit -m "docs(runtimes): runtime changelog for <date>"
+```
+
+They are one logical change: the entry is what you announced, the state is the record of
+it. Committing one without the other either re-announces or skips.
+
+### 6. Generate the community share post
+
+```bash
+node scripts/runtime-changelog/digest.mjs --since <YYYY-MM-DD>
+```
+
+`--since` sets the window start (defaults to the last 14 days); `--until` optionally sets
+the end. It groups every changelog entry in the window into one markdown post by runtime,
+Core first, and inherits the deep per-release links.
+
+The post prints to your terminal **and** is saved to `generated/community-post.md`
+(git-ignored, next to `release-data.json`); the script prints that path when it finishes.
+Copy it into Discord, a forum post, or an email — it's a share artifact, never committed.
+Pass `--out <path>` to save somewhere else instead.
+
+---
+
+## Adding a runtime
+
+Edit the `RUNTIMES` array in `collect.mjs`. Each entry declares a `versions` source (the
+authoritative record of what published) and a `notes` source (where the prose lives) —
+they are separate because for several runtimes they genuinely are. Supported source
+types: `github-releases`, `pub`, `npm` for versions; `github-releases`,
+`github-changelog-md` (with a `headingLevel`), `pub-archive-changelog` for notes. A new
+runtime has no state, so its first run bootstraps from the 14-day window rather than
+dumping its whole history.
+
+Verify the source before trusting it — several Rive repos publish releases that lag their
+real versions (see the comments in `collect.mjs`).
+
+## First-ever entry
+
+Only when `state.json` does not yet exist:
+
+```bash
+node scripts/runtime-changelog/collect.mjs --baseline
+```
+
+`--baseline` makes runtimes that shipped nothing in the window still contribute their
+current version, so the inaugural entry represents every runtime. The script refuses the
+flag once any state is recorded.

--- a/scripts/runtime-changelog/README.md
+++ b/scripts/runtime-changelog/README.md
@@ -1,7 +1,11 @@
 # Runtime changelog tooling
 
-Generates the fortnightly [runtime changelog](../../runtimes/changelog.mdx) entry and a
+Generates a [runtime changelog](../../runtimes/changelog.mdx) entry and a
 copy-paste community announcement, from the runtimes' own releases.
+
+Run it on whatever cadence you like — weekly, biweekly, or ad hoc. Each entry covers every
+version released since the last one, so nothing is missed and nothing is double-counted no
+matter how much time passes between runs.
 
 Two responsibilities, kept apart on purpose:
 
@@ -95,8 +99,9 @@ it. Committing one without the other either re-announces or skips.
 node scripts/runtime-changelog/digest.mjs --since <YYYY-MM-DD>
 ```
 
-`--since` sets the window start (defaults to the last 14 days); `--until` optionally sets
-the end. It groups every changelog entry in the window into one markdown post by runtime,
+`--since` sets the window start (defaults to the most recent changelog entry, so you get a
+post for whatever you just published); `--until` optionally sets the end. It groups every
+changelog entry in the window into one markdown post by runtime,
 Core first, and inherits the deep per-release links.
 
 The post prints to your terminal **and** is saved to `generated/community-post.md`
@@ -113,8 +118,8 @@ authoritative record of what published) and a `notes` source (where the prose li
 they are separate because for several runtimes they genuinely are. Supported source
 types: `github-releases`, `pub`, `npm` for versions; `github-releases`,
 `github-changelog-md` (with a `headingLevel`), `pub-archive-changelog` for notes. A new
-runtime has no state, so its first run bootstraps from the 14-day window rather than
-dumping its whole history.
+runtime has no state, so its first run bootstraps from a lookback window (14 days by
+default; `--bootstrap-days N` to change) rather than dumping its whole history.
 
 Verify the source before trusting it — several Rive repos publish releases that lag their
 real versions (see the comments in `collect.mjs`).

--- a/scripts/runtime-changelog/collect.mjs
+++ b/scripts/runtime-changelog/collect.mjs
@@ -6,7 +6,9 @@
 // collected notes into prose. Nothing here calls an AI.
 //
 //   node scripts/runtime-changelog/collect.mjs                  # collect; never writes state
-//   node scripts/runtime-changelog/collect.mjs --advance-state  # record what was announced
+//   node scripts/runtime-changelog/collect.mjs --advance-state  # record + sync docs.json versions
+//   node scripts/runtime-changelog/collect.mjs --baseline       # first-ever run (no state yet)
+//   node scripts/runtime-changelog/collect.mjs --bootstrap-days 30   # widen first-run lookback
 //
 // Collecting is always safe: it only writes generated/release-data.json. State moves
 // only on the explicit second step, which re-reads that same file and makes no network
@@ -25,8 +27,12 @@ const STATE_PATH = join(HERE, 'state.json');
 const OUT_DIR = join(HERE, 'generated');
 const OUT_PATH = join(OUT_DIR, 'release-data.json');
 
-// When a runtime has no recorded state, announce whatever shipped in this window.
-const BOOTSTRAP_DAYS = 14;
+// First-run lookback only: when a runtime has no recorded state yet, its first entry
+// covers whatever shipped in this many days. Used exclusively on the very first run for a
+// runtime — after that the range is a pure version comparison against state, so it does
+// not matter whether you run this weekly, biweekly, or ad hoc. Override with
+// --bootstrap-days N.
+const DEFAULT_BOOTSTRAP_DAYS = 14;
 
 // ---------------------------------------------------------------------------
 // Runtime configuration
@@ -119,7 +125,7 @@ const RUNTIMES = [
     // The Nitro runtime, published to npm as @rive-app/react-native. Distinct from
     // the legacy rive-app/rive-react-native repo (npm: rive-react-native, v9.x).
     // semantic-release cuts a GitHub release per publish, so releases keep pace and
-    // carry the notes — but it ships often (5 releases in a typical fortnight).
+    // carry the notes — but it ships often (frequently several releases per entry).
     versions: { type: 'github-releases', repo: 'rive-app/rive-nitro-react-native' },
     notes: { type: 'github-releases' },
     links: {
@@ -676,9 +682,9 @@ async function collectRuntime(runtime, state, cutoffIso, baseline) {
 // touched — adding one is a deliberate docs edit, not something this script guesses.
 // ---------------------------------------------------------------------------
 
-// Only runtimes whose docs pin a version get a variable. React, React Native and Unreal
-// install via "latest" (npm default) or a marketplace, so there is nothing to keep
-// current and they are deliberately absent.
+// Only runtimes whose docs pin a version get a variable. React and React Native install
+// via npm "latest" with no pin, so there is nothing to keep current and they are
+// deliberately absent.
 const DOCS_VERSION_VARS = {
   apple: { full: 'versionApple' },
   android: { full: 'versionAndroid' },
@@ -687,6 +693,7 @@ const DOCS_VERSION_VARS = {
   // webgl2, …); the docs expose it as the generalized {{versionWeb}}.
   web: { full: 'versionWeb', major: 'versionMajorWeb' },
   unity: { full: 'versionUnity' },
+  unreal: { full: 'versionUnreal' },
 };
 
 // Compares docs.json's current variable values against each runtime's latest version and
@@ -783,12 +790,22 @@ function advanceState() {
   console.log('\nNothing was committed or pushed. Review with: git diff');
 }
 
+// Reads `--flag N` as a positive integer, or returns the fallback when absent.
+function readIntArg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return fallback;
+  const v = Number(process.argv[i + 1]);
+  if (!Number.isInteger(v) || v <= 0) throw new Error(`${name} needs a positive integer`);
+  return v;
+}
+
 async function main() {
   if (process.argv.includes('--advance-state')) return advanceState();
 
   const baseline = process.argv.includes('--baseline');
+  const bootstrapDays = readIntArg('--bootstrap-days', DEFAULT_BOOTSTRAP_DAYS);
   const now = new Date();
-  const cutoff = new Date(now.getTime() - BOOTSTRAP_DAYS * 86_400_000);
+  const cutoff = new Date(now.getTime() - bootstrapDays * 86_400_000);
   const cutoffIso = cutoff.toISOString();
   const state = loadState();
 
@@ -801,7 +818,7 @@ async function main() {
 
   console.log('Rive runtime release collector');
   console.log(`  today:     ${localDate(now)}`);
-  console.log(`  bootstrap: releases published after ${localDate(cutoff)} (${BOOTSTRAP_DAYS}d)`);
+  console.log(`  first-run lookback: releases after ${localDate(cutoff)} (${bootstrapDays}d, first entry only)`);
   if (baseline) {
     console.log('  baseline:  quiet runtimes contribute their current version (first entry only)');
   }

--- a/scripts/runtime-changelog/collect.mjs
+++ b/scripts/runtime-changelog/collect.mjs
@@ -1,0 +1,888 @@
+#!/usr/bin/env node
+// Collects new stable Rive runtime releases and writes generated/release-data.json.
+//
+// Deterministic on purpose: this script decides *which versions shipped* and owns
+// every version number, date and URL. The runtime-announcement skill only turns the
+// collected notes into prose. Nothing here calls an AI.
+//
+//   node scripts/runtime-changelog/collect.mjs                  # collect; never writes state
+//   node scripts/runtime-changelog/collect.mjs --advance-state  # record what was announced
+//
+// Collecting is always safe: it only writes generated/release-data.json. State moves
+// only on the explicit second step, which re-reads that same file and makes no network
+// calls — so state can never advance past the versions the changelog entry describes.
+//
+// Zero dependencies, stdlib only: Node 18+ (global fetch, zlib).
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+const STATE_PATH = join(HERE, 'state.json');
+const OUT_DIR = join(HERE, 'generated');
+const OUT_PATH = join(OUT_DIR, 'release-data.json');
+
+// When a runtime has no recorded state, announce whatever shipped in this window.
+const BOOTSTRAP_DAYS = 14;
+
+// ---------------------------------------------------------------------------
+// Runtime configuration
+//
+// `versions` is the authoritative record that an artifact was actually published
+// (and when). `notes` is where the prose lives. They are separate because for
+// several runtimes they genuinely are different systems — see the comments.
+// ---------------------------------------------------------------------------
+
+const RUNTIMES = [
+  {
+    id: 'apple',
+    displayName: 'Apple',
+    versions: { type: 'github-releases', repo: 'rive-app/rive-ios' },
+    // Curated `## Fixed` / `## Changed` prose, followed by a `## Commits` dump of the
+    // upstream monorepo commits the release vendored.
+    notes: { type: 'github-releases' },
+    carriesCoreCommits: true,
+    links: { releases: 'https://github.com/rive-app/rive-ios/releases' },
+  },
+  {
+    id: 'android',
+    displayName: 'Android',
+    versions: { type: 'github-releases', repo: 'rive-app/rive-android' },
+    // No curated section at all — the whole body is the vendored monorepo commit dump.
+    notes: { type: 'github-releases' },
+    carriesCoreCommits: true,
+    links: { releases: 'https://github.com/rive-app/rive-android/releases' },
+  },
+  {
+    id: 'flutter',
+    displayName: 'Flutter',
+    // rive-flutter publishes no GitHub releases or tags past 0.8.4 (2022), so
+    // GitHub cannot tie notes to a version at all. pub.dev is the only record of
+    // what shipped, and the CHANGELOG.md inside the published archive is the only
+    // copy that is correctly headed per version. master's CHANGELOG.md keeps
+    // released notes under "## Upcoming" and appends unreleased work to the same
+    // block — parsing it would announce changes nobody can install.
+    versions: { type: 'pub', package: 'rive' },
+    notes: { type: 'pub-archive-changelog' },
+    links: {
+      releases: 'https://pub.dev/packages/rive/changelog',
+      package: 'https://pub.dev/packages/rive',
+    },
+  },
+  {
+    id: 'web',
+    displayName: 'Web',
+    // @rive-app/canvas, /webgl2 and /canvas-lite version in lockstep off rive-wasm.
+    // That shared version is what the docs expose as {{versionWeb}}.
+    versions: { type: 'npm', package: '@rive-app/webgl2' },
+    // rive-wasm's CHANGELOG.md is a raw dump of the whole monorepo's commits, so it
+    // carries Apple/Unreal/editor work that never touched the web runtime, and its
+    // newest heading is often undated. Dates come from npm above; the skill is told
+    // to filter the cross-platform noise.
+    notes: {
+      type: 'github-changelog-md',
+      repo: 'rive-app/rive-wasm',
+      branch: 'master',
+      headingLevel: 2,
+    },
+    carriesCoreCommits: true,
+    links: {
+      releases: 'https://github.com/rive-app/rive-wasm/blob/master/CHANGELOG.md',
+      package: 'https://www.npmjs.com/package/@rive-app/webgl2',
+    },
+  },
+  {
+    id: 'react',
+    displayName: 'React',
+    // Same failure as Flutter: rive-react's GitHub releases stop at v4.21.3 (June
+    // 2025) while npm has shipped up to 4.29.5. Tags do keep pace, but the releases
+    // API would silently report year-old versions as current.
+    versions: { type: 'npm', package: '@rive-app/react-canvas' },
+    // auto-changelog writes version headings at h4 (`#### [v4.29.5](...)`), not h2.
+    notes: {
+      type: 'github-changelog-md',
+      repo: 'rive-app/rive-react',
+      branch: 'main',
+      headingLevel: 4,
+    },
+    links: {
+      releases: 'https://github.com/rive-app/rive-react/blob/main/CHANGELOG.md',
+      package: 'https://www.npmjs.com/package/@rive-app/react-canvas',
+    },
+  },
+  {
+    id: 'react-native',
+    displayName: 'React Native',
+    // The Nitro runtime, published to npm as @rive-app/react-native. Distinct from
+    // the legacy rive-app/rive-react-native repo (npm: rive-react-native, v9.x).
+    // semantic-release cuts a GitHub release per publish, so releases keep pace and
+    // carry the notes — but it ships often (5 releases in a typical fortnight).
+    versions: { type: 'github-releases', repo: 'rive-app/rive-nitro-react-native' },
+    notes: { type: 'github-releases' },
+    links: {
+      releases: 'https://github.com/rive-app/rive-nitro-react-native/releases',
+      package: 'https://www.npmjs.com/package/@rive-app/react-native',
+    },
+  },
+  {
+    id: 'unity',
+    displayName: 'Unity',
+    // Distributed via UPM, so there is no registry to cross-check against; GitHub
+    // releases are the only record. Canary builds (v0.4.4-canary.87) exist as tags
+    // but are not published as releases — the prerelease filter covers them anyway.
+    versions: { type: 'github-releases', repo: 'rive-app/rive-unity' },
+    notes: { type: 'github-releases' },
+    links: { releases: 'https://github.com/rive-app/rive-unity/releases' },
+  },
+  {
+    id: 'unreal',
+    displayName: 'Unreal',
+    // Tags carry no `v` prefix (0.4.25). Notes are hand-written prose.
+    versions: { type: 'github-releases', repo: 'rive-app/rive-unreal' },
+    notes: { type: 'github-releases' },
+    links: { releases: 'https://github.com/rive-app/rive-unreal/releases' },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Semantic versions
+// ---------------------------------------------------------------------------
+
+// Local calendar date, not UTC. Publish timestamps are compared in UTC (correct — they
+// come from the registries that way), but the announcement date becomes the entry's
+// label, which is its permanent anchor. Someone generating an entry on the evening of
+// the 16th in the Americas should not get a permalink dated the 17th.
+function localDate(d) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function parseVersion(raw) {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+    String(raw).trim(),
+  );
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ?? null,
+    raw: String(raw).trim(),
+  };
+}
+
+function compareVersions(a, b) {
+  for (const k of ['major', 'minor', 'patch']) {
+    if (a[k] !== b[k]) return a[k] - b[k];
+  }
+  // A prerelease sorts before its own release: 1.0.0-rc.1 < 1.0.0
+  if (a.prerelease && !b.prerelease) return -1;
+  if (!a.prerelease && b.prerelease) return 1;
+  if (!a.prerelease && !b.prerelease) return 0;
+  const ap = a.prerelease.split('.');
+  const bp = b.prerelease.split('.');
+  for (let i = 0; i < Math.max(ap.length, bp.length); i++) {
+    const x = ap[i];
+    const y = bp[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      if (Number(x) !== Number(y)) return Number(x) - Number(y);
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Fetching
+// ---------------------------------------------------------------------------
+
+const TIMEOUT_MS = 30_000;
+
+async function getJson(url, headers = {}) {
+  const res = await fetch(url, {
+    headers: { accept: 'application/json', 'user-agent': 'rive-docs-changelog', ...headers },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.json();
+}
+
+async function getText(url) {
+  const res = await fetch(url, {
+    headers: { 'user-agent': 'rive-docs-changelog' },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.text();
+}
+
+function githubHeaders() {
+  // Optional: lifts the unauthenticated 60 req/hour limit. Not required.
+  const token = process.env.GITHUB_TOKEN;
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+// ---------------------------------------------------------------------------
+// Version sources -> [{ version, publishedAt, url, prerelease, notes? }]
+// ---------------------------------------------------------------------------
+
+async function fetchGithubReleases(repo) {
+  const json = await getJson(
+    `https://api.github.com/repos/${repo}/releases?per_page=100`,
+    githubHeaders(),
+  );
+  return json
+    .filter((r) => !r.draft)
+    .map((r) => ({
+      version: String(r.tag_name).replace(/^v/, ''),
+      publishedAt: r.published_at,
+      url: r.html_url,
+      prerelease: Boolean(r.prerelease),
+      notes: (r.body || '').trim(),
+    }));
+}
+
+async function fetchPubVersions(pkg) {
+  const d = await getJson(`https://pub.dev/api/packages/${pkg}`);
+  return d.versions.map((v) => ({
+    version: v.version,
+    publishedAt: v.published,
+    url: `https://pub.dev/packages/${pkg}/versions/${v.version}`,
+    archiveUrl: v.archive_url,
+    prerelease: false, // refined by parseVersion below
+  }));
+}
+
+async function fetchNpmVersions(pkg) {
+  const d = await getJson(`https://registry.npmjs.org/${pkg}`);
+  const time = d.time || {};
+  return Object.keys(d.versions).map((v) => ({
+    version: v,
+    publishedAt: time[v],
+    url: `https://www.npmjs.com/package/${pkg}/v/${v}`,
+    prerelease: false,
+  }));
+}
+
+async function fetchVersions(runtime) {
+  const cfg = runtime.versions;
+  switch (cfg.type) {
+    case 'github-releases':
+      return fetchGithubReleases(cfg.repo);
+    case 'pub':
+      return fetchPubVersions(cfg.package);
+    case 'npm':
+      return fetchNpmVersions(cfg.package);
+    default:
+      throw new Error(`${runtime.id}: unknown version source "${cfg.type}"`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Changelog parsing
+//
+// Handles every heading shape in use across the Rive repos:
+//   "## 0.14.8"                                   (rive-flutter, h2)
+//   "## [2.38.5](.../compare/2.38.4...2.38.5)"    (rive-wasm, h2, undated)
+//   "## [2.38.4](...) - 2026-07-01"               (rive-wasm, h2, dated)
+//   "#### [v4.29.5](.../compare/v4.29.4...v4.29.5)" (rive-react, h4)
+//   "## Upcoming"                                 -> no version, content dropped
+//
+// headingLevel must match the source exactly and is not worth guessing: too shallow
+// and a version's subsections ("### Fixes") get eaten as headings, dropping their
+// content; too deep and no version is ever found, yielding a silently empty section.
+// ---------------------------------------------------------------------------
+
+function versionFromHeading(heading) {
+  const m = /^\[?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\]?/.exec(heading.trim());
+  return m ? m[1] : null;
+}
+
+// Version headings on the wasm and react changelogs link to the GitHub compare view
+// for that release: `## [2.38.5](https://github.com/.../compare/2.38.4...2.38.5)`. That
+// is a better outbound link than the npm version page, so capture it when present.
+function urlFromHeading(heading) {
+  const m = /\]\((https?:\/\/[^)\s]+)\)/.exec(heading);
+  return m ? m[1] : null;
+}
+
+// Returns Map<version, { notes, url }>. `url` is the changelog heading's link when it
+// has one (Web, React), else null.
+function parseChangelog(md, headingLevel) {
+  const marker = '#'.repeat(headingLevel);
+  const headingRe = new RegExp(`^${marker}(?!#)\\s+(.+?)\\s*$`);
+  const sections = new Map();
+  let current = null;
+  let url = null;
+  let buffer = [];
+  const flush = () => {
+    if (current) sections.set(current, { notes: buffer.join('\n').trim(), url });
+  };
+  for (const line of md.split(/\r?\n/)) {
+    const m = headingRe.exec(line);
+    if (m) {
+      flush();
+      // A heading with no parseable version (e.g. "Upcoming") sets current to
+      // null, so its body is dropped rather than attributed to a real release.
+      current = versionFromHeading(m[1]);
+      url = urlFromHeading(m[1]);
+      buffer = [];
+      continue;
+    }
+    if (current) buffer.push(line);
+  }
+  flush();
+  return sections;
+}
+
+// Minimal tar reader: pulls a single file out of an archive without shelling out
+// to `tar` or taking a dependency. Entries are 512-byte header blocks; we only
+// need the name (offset 0) and the octal size (offset 124) to walk them.
+function readFileFromTar(tar, wanted) {
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const name = tar.toString('utf8', offset, offset + 100).replace(/\0.*$/, '');
+    if (!name) {
+      offset += 512; // padding or end-of-archive block
+      continue;
+    }
+    const rawSize = tar.toString('utf8', offset + 124, offset + 136).replace(/\0.*$/, '').trim();
+    const size = parseInt(rawSize || '0', 8);
+    if (Number.isNaN(size)) throw new Error(`corrupt tar header for "${name}"`);
+    const body = offset + 512;
+    if (name === wanted || name === `./${wanted}`) return tar.toString('utf8', body, body + size);
+    offset = body + Math.ceil(size / 512) * 512;
+  }
+  return null;
+}
+
+// Returns Map<version, { notes, url }>. `url` is a version-specific notes link when the
+// notes source provides one (the release page for GitHub releases, the compare link for
+// changelog sources); null when it does not (Flutter's plain `## 0.14.9` headings).
+async function fetchNotes(runtime, selected, allVersions) {
+  const cfg = runtime.notes;
+  switch (cfg.type) {
+    case 'github-releases': {
+      // Notes and the release-page URL both rode along with the version fetch.
+      return new Map(selected.map((r) => [r.version, { notes: r.notes || '', url: r.url }]));
+    }
+    case 'github-changelog-md': {
+      const md = await getText(
+        `https://raw.githubusercontent.com/${cfg.repo}/${cfg.branch}/CHANGELOG.md`,
+      );
+      return parseChangelog(md, cfg.headingLevel);
+    }
+    case 'pub-archive-changelog': {
+      // The newest published archive's CHANGELOG.md already contains every prior
+      // version's section, correctly headed — so one download covers the lot.
+      const newest = allVersions[allVersions.length - 1];
+      if (!newest?.archiveUrl) throw new Error(`${runtime.id}: no archive_url on ${newest?.version}`);
+      const res = await fetch(newest.archiveUrl, {
+        headers: { 'user-agent': 'rive-docs-changelog' },
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (!res.ok) throw new Error(`GET ${newest.archiveUrl} -> HTTP ${res.status}`);
+      const tar = gunzipSync(Buffer.from(await res.arrayBuffer()));
+      const md = readFileFromTar(tar, 'CHANGELOG.md');
+      if (md === null) throw new Error(`${runtime.id}: no CHANGELOG.md inside ${newest.archiveUrl}`);
+      return parseChangelog(md, cfg.headingLevel ?? 2);
+    }
+    default:
+      throw new Error(`${runtime.id}: unknown notes source "${cfg.type}"`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core runtime changes
+//
+// rive-app/rive-runtime is the shared C++ runtime. It publishes no releases, so there
+// is nothing to collect from it directly — and its `main` carries work that has not
+// shipped in any runtime yet, so announcing from it would describe changes nobody can
+// install (the same trap as Flutter's `## Upcoming` block).
+//
+// Instead we reconstruct core changes from the runtimes that vendor it: Apple, Android
+// and Web each embed the upstream monorepo commits they shipped. Anything found there
+// has, by construction, actually reached users. Roughly 25 of every 35 such commits are
+// common to more than one runtime, which is why they belong in one section rather than
+// being repeated three times.
+// ---------------------------------------------------------------------------
+
+const CORE = {
+  id: 'core',
+  displayName: 'Core runtime',
+  links: { releases: 'https://github.com/rive-app/rive-runtime' },
+};
+
+// Conventional-commit scopes owned by a specific runtime. These stay in that runtime's
+// own section rather than being promoted to core.
+const PLATFORM_SCOPES = new Map([
+  ['apple', 'apple'],
+  ['ios', 'apple'],
+  ['android', 'android'],
+  ['unreal', 'unreal'],
+  ['unity', 'unity'],
+  ['js', 'web'],
+  ['wasm', 'web'],
+  ['web', 'web'],
+  ['flutter', 'flutter'],
+  ['react', 'react'],
+]);
+
+// A vendored monorepo commit always carries `(#1234) <sha>`. Curated prose never does —
+// Apple writes issue references as markdown links, `([#454](url))`, which this will not
+// match. That difference is what separates real commits from hand-written notes without
+// needing to know which heading they sit under.
+const COMMIT_REF = /\(#(\d+)\)\s+([0-9a-f]{8,12})\b/;
+
+function parseCommitLine(raw) {
+  const line = raw.trim().replace(/^[-*]\s+/, '');
+  const ref = COMMIT_REF.exec(line);
+  if (!ref) return null;
+
+  const message = line.slice(0, ref.index).trim();
+  // Strict conventional commit: `fix(runtime): ...`, `chore: ...`
+  const strict = /^(\w+)\s*(?:\(([^)]*)\))?\s*:/.exec(message);
+  // Loose fallback for `feature (Unreal) Ore Support`, which has no colon and would
+  // otherwise be misread as unscoped and promoted into core.
+  const loose = strict ? null : /^(\w+)\s*\(([^)]+)\)/.exec(message);
+
+  const type = (strict?.[1] ?? loose?.[1] ?? '').toLowerCase() || null;
+  const scope = (strict?.[2] ?? loose?.[2] ?? '').toLowerCase().trim() || null;
+
+  return { message, type, scope, pr: ref[1], sha: ref[2] };
+}
+
+function classifyScope(scope) {
+  if (!scope) return { kind: 'core' };
+
+  const mentionsEditor = /\beditor\b/.test(scope);
+  const mentionsRuntime = /\bruntime\b/.test(scope);
+
+  // Editor-only work never ships in a runtime and is excluded outright.
+  if (mentionsEditor && !mentionsRuntime) return { kind: 'editor' };
+  // `fix(editor and runtime): ...` touches both. Dropping it would lose a real runtime
+  // fix, so keep it in core but mark it for the skill to judge rather than guessing.
+  if (mentionsEditor && mentionsRuntime) return { kind: 'core', ambiguous: true };
+
+  for (const [token, runtimeId] of PLATFORM_SCOPES) {
+    if (new RegExp(`\\b${token}\\b`).test(scope)) return { kind: 'platform', runtimeId };
+  }
+  return { kind: 'core' };
+}
+
+// Splits every vendored commit into core vs. platform-owned, deduping across runtimes by
+// upstream sha. Mutates each runtime to add `platformChanges`, and returns the core set.
+function deriveCore(results) {
+  const core = new Map();
+  let editorExcluded = 0;
+
+  for (const runtime of results) {
+    const cfg = RUNTIMES.find((r) => r.id === runtime.id);
+    runtime.platformChanges = [];
+    if (!cfg?.carriesCoreCommits || !runtime.hasUpdates) continue;
+
+    for (const release of runtime.releases) {
+      for (const raw of release.notes.split('\n')) {
+        const commit = parseCommitLine(raw);
+        if (!commit) continue;
+
+        const verdict = classifyScope(commit.scope);
+        if (verdict.kind === 'editor') {
+          editorExcluded++;
+          continue;
+        }
+        if (verdict.kind === 'platform') {
+          // Only claim it for the runtime it actually belongs to; an `apple`-scoped
+          // commit vendored into Android's dump is not an Android change.
+          if (verdict.runtimeId === runtime.id) {
+            runtime.platformChanges.push({ ...commit, version: release.version });
+          }
+          continue;
+        }
+
+        const existing = core.get(commit.sha);
+        if (existing) {
+          existing.shippedIn.add(runtime.id);
+        } else {
+          core.set(commit.sha, {
+            ...commit,
+            ambiguous: Boolean(verdict.ambiguous),
+            shippedIn: new Set([runtime.id]),
+          });
+        }
+      }
+    }
+  }
+
+  const changes = [...core.values()].map((c) => ({
+    message: c.message,
+    type: c.type,
+    scope: c.scope,
+    pr: c.pr,
+    sha: c.sha,
+    ambiguous: c.ambiguous,
+    shippedIn: [...c.shippedIn],
+  }));
+
+  return {
+    ...CORE,
+    hasUpdates: changes.length > 0,
+    // Core has no version of its own: rive-runtime publishes no releases, and the tags
+    // it does cut (runtime-v0.1.191) increment per commit and mean nothing to a user.
+    versionRange: null,
+    derivedFrom: results.filter((r) => r.hasUpdates && RUNTIMES.find((c) => c.id === r.id)?.carriesCoreCommits).map((r) => r.id),
+    editorCommitsExcluded: editorExcluded,
+    changes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+function loadState() {
+  if (!existsSync(STATE_PATH)) return {};
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+  } catch (err) {
+    throw new Error(`state.json is not valid JSON: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+async function collectRuntime(runtime, state, cutoffIso, baseline) {
+  const warnings = [];
+  const raw = await fetchVersions(runtime);
+
+  const stable = [];
+  for (const r of raw) {
+    // Drop source-flagged prereleases before parsing. Unreal's `0.4.17t` builds are
+    // all flagged prerelease upstream; parsing first would warn about 17 versions
+    // per run that we were always going to discard. A warning that always fires is
+    // one you learn to ignore, so only unparseable *stable* versions warn.
+    if (r.prerelease) continue;
+    const v = parseVersion(r.version);
+    if (!v) {
+      warnings.push(`Skipped unparseable stable version "${r.version}".`);
+      continue;
+    }
+    // Semver-marked prereleases from registries with no flag (rive's 0.14.0-dev.14).
+    if (v.prerelease !== null) continue;
+    if (!r.publishedAt) {
+      warnings.push(`Skipped ${r.version}: source reported no publish date.`);
+      continue;
+    }
+    stable.push({ ...r, parsed: v });
+  }
+  stable.sort((a, b) => compareVersions(a.parsed, b.parsed));
+
+  if (stable.length === 0) throw new Error(`${runtime.id}: no stable releases found`);
+
+  const recorded = state[runtime.id]?.lastAnnouncedVersion ?? null;
+  let selected = [];
+  let baselineOnly = false;
+
+  if (recorded) {
+    // Has a base: pure version comparison. The date window is never consulted again.
+    const base = parseVersion(recorded);
+    if (!base) throw new Error(`${runtime.id}: state has unparseable version "${recorded}"`);
+    selected = stable.filter((r) => compareVersions(r.parsed, base) > 0);
+  } else {
+    selected = stable.filter((r) => r.publishedAt > cutoffIso);
+    // Baseline mode, for the very first entry only: a runtime that shipped nothing
+    // inside the window still contributes its current version, so the inaugural entry
+    // represents every runtime. Without this, advancing state would mark those versions
+    // announced and they could never appear in any entry.
+    if (selected.length === 0 && baseline) {
+      selected = [stable[stable.length - 1]];
+      baselineOnly = true;
+    }
+  }
+
+  // Whatever selected the range, `previousVersion` is the stable release it follows on
+  // from — not the recorded state, which in baseline mode is the version being announced.
+  let previousVersion = recorded;
+  if (selected.length > 0) {
+    const firstIdx = stable.indexOf(selected[0]);
+    previousVersion = firstIdx > 0 ? stable[firstIdx - 1].version : null;
+  }
+
+  const latest = stable[stable.length - 1];
+  let releases = [];
+
+  if (selected.length > 0) {
+    const notes = await fetchNotes(runtime, selected, stable);
+    releases = selected.map((r) => {
+      const entry = notes.get(r.version) ?? { notes: '', url: null };
+      const body = (entry.notes ?? '').trim();
+      if (!body) {
+        warnings.push(`${r.version}: no release notes found in the configured notes source.`);
+      }
+      return {
+        version: r.version,
+        publishedAt: r.publishedAt.slice(0, 10),
+        // Best version-specific outbound link: the notes source's own link (a GitHub
+        // release page, or the changelog's compare link) when it has one, otherwise the
+        // registry version page. Always deep — never a repo's general releases index.
+        url: entry.url ?? r.url,
+        notes: body,
+      };
+    });
+  }
+
+  return {
+    id: runtime.id,
+    displayName: runtime.displayName,
+    previousVersion,
+    latestVersion: latest.version,
+    hasUpdates: releases.length > 0,
+    // True when this runtime shipped nothing in the window and is only present because
+    // the first entry establishes a baseline. Worth mentioning as "current version".
+    baselineOnly,
+    versionRange:
+      releases.length === 0
+        ? null
+        : releases.length === 1
+          ? `v${releases[0].version}`
+          : `v${releases[0].version}–v${releases[releases.length - 1].version}`,
+    links: runtime.links,
+    releases,
+    warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// docs.json runtime-version variables
+//
+// Install snippets across the docs hardcode a version (iOS `from: "6.13.0"`, Flutter
+// `rive: ^0.14.x`, the web `<script>` tag). Left alone they rot. Instead the docs expose
+// a `{{versionX}}` variable per runtime, and we sync each to the runtime's *latest
+// available* version whenever we advance state — so the install docs move in lockstep
+// with the changelog, in the same reviewed commit.
+//
+// `full` is the exact latest version; `major` (web only) is its major component, used by
+// the "load v2" unpkg snippet. Only variables that already exist in docs.json are
+// touched — adding one is a deliberate docs edit, not something this script guesses.
+// ---------------------------------------------------------------------------
+
+// Only runtimes whose docs pin a version get a variable. React, React Native and Unreal
+// install via "latest" (npm default) or a marketplace, so there is nothing to keep
+// current and they are deliberately absent.
+const DOCS_VERSION_VARS = {
+  apple: { full: 'versionApple' },
+  android: { full: 'versionAndroid' },
+  flutter: { full: 'versionFlutter' },
+  // One version line covers every @rive-app web package (canvas, canvas-advanced,
+  // webgl2, …); the docs expose it as the generalized {{versionWeb}}.
+  web: { full: 'versionWeb', major: 'versionMajorWeb' },
+  unity: { full: 'versionUnity' },
+};
+
+// Compares docs.json's current variable values against each runtime's latest version and
+// returns the list of variables that would change: [{ variable, from, to }].
+function computeDocsVersionUpdates(runtimes, docsText) {
+  const updates = [];
+  const read = (name) => {
+    const m = new RegExp(`"${name}"\\s*:\\s*"([^"]*)"`).exec(docsText);
+    return m ? m[1] : null;
+  };
+  for (const r of runtimes) {
+    const vars = DOCS_VERSION_VARS[r.id];
+    if (!vars) continue;
+    const targets = [
+      [vars.full, r.latestVersion],
+      vars.major ? [vars.major, r.latestVersion.split('.')[0]] : null,
+    ].filter(Boolean);
+    for (const [variable, to] of targets) {
+      const from = read(variable);
+      if (from === null) continue; // variable not declared in docs.json — don't invent it
+      if (from !== to) updates.push({ variable, from, to });
+    }
+  }
+  return updates;
+}
+
+// Applies the updates with a surgical per-variable replacement so the rest of docs.json —
+// formatting, key order, trailing-newline state — is untouched.
+function applyDocsVersionUpdates(updates) {
+  const path = join(REPO_ROOT, 'docs.json');
+  let text = readFileSync(path, 'utf8');
+  for (const { variable, to } of updates) {
+    text = text.replace(new RegExp(`("${variable}"\\s*:\\s*")[^"]*(")`), `$1${to}$2`);
+  }
+  writeFileSync(path, text);
+}
+
+function readDocsText() {
+  try {
+    return readFileSync(join(REPO_ROOT, 'docs.json'), 'utf8');
+  } catch {
+    return null; // docs.json is not required for collection to succeed
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+// Second step, run once the changelog entry is written and reviewed. Reads the same
+// release-data.json the entry was built from, so the recorded versions are exactly the
+// announced ones — no network, no chance of drifting onto a newer release.
+function advanceState() {
+  if (!existsSync(OUT_PATH)) {
+    console.error(`No ${OUT_PATH} found. Run the collector first.`);
+    process.exit(1);
+  }
+  const data = JSON.parse(readFileSync(OUT_PATH, 'utf8'));
+  const state = loadState();
+  const next = { ...state };
+  const announcedAt = data.announcementDate;
+
+  for (const r of data.runtimes) {
+    next[r.id] = {
+      lastAnnouncedVersion: r.latestVersion,
+      // Runtimes with nothing new keep their original announcement date; only the
+      // baseline moves, recording that we considered and skipped them.
+      announcedAt: r.hasUpdates ? announcedAt : (state[r.id]?.announcedAt ?? announcedAt),
+    };
+  }
+
+  writeFileSync(STATE_PATH, JSON.stringify(next, null, 2) + '\n');
+  console.log(`Recorded announcement state for ${data.runtimes.length} runtimes:`);
+  for (const r of data.runtimes) {
+    const note = r.hasUpdates ? `announced ${r.versionRange}` : 'no updates; baseline only';
+    console.log(`  ${r.displayName.padEnd(13)} -> ${r.latestVersion}  (${note})`);
+  }
+  console.log(`\nWrote ${STATE_PATH.replace(REPO_ROOT + '/', '')}`);
+
+  // Sync the docs install-version variables to the latest available versions, so the docs
+  // move with the changelog in one commit. Uses latestVersion (what a reader should
+  // install) for every runtime, not only the ones with a changelog entry this cycle.
+  const docsText = readDocsText();
+  const docsUpdates = docsText ? computeDocsVersionUpdates(data.runtimes, docsText) : [];
+  if (docsUpdates.length > 0) {
+    applyDocsVersionUpdates(docsUpdates);
+    console.log('\nUpdated docs.json runtime versions:');
+    for (const u of docsUpdates) console.log(`  ${u.variable.padEnd(20)} ${u.from} -> ${u.to}`);
+    console.log(`Wrote docs.json`);
+  } else {
+    console.log('\ndocs.json runtime versions already current.');
+  }
+
+  console.log('\nNothing was committed or pushed. Review with: git diff');
+}
+
+async function main() {
+  if (process.argv.includes('--advance-state')) return advanceState();
+
+  const baseline = process.argv.includes('--baseline');
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - BOOTSTRAP_DAYS * 86_400_000);
+  const cutoffIso = cutoff.toISOString();
+  const state = loadState();
+
+  if (baseline && Object.keys(state).length > 0) {
+    console.error('--baseline is only for the very first entry, but state.json already');
+    console.error('has entries. Once a runtime has a base, its range is decided by version');
+    console.error('comparison and this flag would re-announce a shipped version.');
+    process.exit(1);
+  }
+
+  console.log('Rive runtime release collector');
+  console.log(`  today:     ${localDate(now)}`);
+  console.log(`  bootstrap: releases published after ${localDate(cutoff)} (${BOOTSTRAP_DAYS}d)`);
+  if (baseline) {
+    console.log('  baseline:  quiet runtimes contribute their current version (first entry only)');
+  }
+  console.log('');
+
+  // All-or-nothing: a half-collected announcement is worse than none.
+  const results = [];
+  const failures = [];
+  for (const runtime of RUNTIMES) {
+    try {
+      results.push(await collectRuntime(runtime, state, cutoffIso, baseline));
+    } catch (err) {
+      failures.push(`${runtime.id}: ${err.message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('Collection failed:');
+    for (const f of failures) console.error(`  ${f}`);
+    console.error('\nNo files were written.');
+    process.exit(1);
+  }
+
+  for (const r of results) {
+    if (!r.hasUpdates) {
+      console.log(`  ${r.displayName.padEnd(8)} no new stable releases (latest ${r.latestVersion})`);
+    } else {
+      const from = r.previousVersion ?? 'none';
+      const tag = r.baselineOnly ? '  (baseline: current version, nothing new in window)' : '';
+      console.log(`  ${r.displayName.padEnd(13)} ${from} -> ${r.latestVersion}${tag}`);
+      for (const rel of r.releases) console.log(`           ${rel.version}  ${rel.publishedAt}`);
+    }
+    for (const w of r.warnings) console.log(`           ! ${w}`);
+  }
+  console.log('');
+
+  // Read-only preview of the docs.json version bumps that --advance-state will apply, so
+  // the reviewer sees them before approving. Nothing is written here.
+  const docsText = readDocsText();
+  const docsUpdates = docsText ? computeDocsVersionUpdates(results, docsText) : [];
+  if (docsUpdates.length > 0) {
+    console.log('  docs.json version variables that --advance-state will update:');
+    for (const u of docsUpdates) console.log(`    ${u.variable.padEnd(20)} ${u.from} -> ${u.to}`);
+    console.log('');
+  }
+
+  const updated = results.filter((r) => r.hasUpdates);
+  if (updated.length === 0) {
+    console.log('No new stable runtime releases were found. No files were modified.');
+    return;
+  }
+
+  const core = deriveCore(results);
+  if (core.hasUpdates) {
+    const shared = core.changes.filter((c) => c.shippedIn.length > 1).length;
+    console.log(
+      `  Core     ${core.changes.length} shared change(s) from ${core.derivedFrom.join(', ')}` +
+        ` (${shared} in more than one runtime; ${core.editorCommitsExcluded} editor commit(s) excluded)`,
+    );
+    console.log('');
+  }
+
+  const data = {
+    generatedAt: now.toISOString(),
+    // The date the entry should carry, in the author's local calendar. Use this for
+    // the <Update> label, not generatedAt.
+    announcementDate: localDate(now),
+    window: { from: localDate(cutoff), to: localDate(now) },
+    docsVersionUpdates: docsUpdates,
+    core,
+    runtimes: results,
+  };
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(OUT_PATH, JSON.stringify(data, null, 2) + '\n');
+  console.log(`Wrote ${OUT_PATH.replace(REPO_ROOT + '/', '')}`);
+  console.log(`\n${updated.length} runtime(s) have updates. State was not changed.`);
+  console.log('Write the changelog entry, then record it with: --advance-state');
+}
+
+main().catch((err) => {
+  console.error(`\nUnexpected failure: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/runtime-changelog/digest.mjs
+++ b/scripts/runtime-changelog/digest.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+// Produces a copy-paste runtime-update announcement (Discord, forum, email) from the
+// committed changelog. It reads the changelog rather than the collected JSON on purpose:
+// the changelog is the reviewed, hand-edited source of truth, so the digest can never
+// say something the published page doesn't.
+//
+//   node scripts/runtime-changelog/digest.mjs                       # last 14 days
+//   node scripts/runtime-changelog/digest.mjs --since 2026-07-01    # explicit window
+//   node scripts/runtime-changelog/digest.mjs --since 2026-06-01 --until 2026-06-30
+//   node scripts/runtime-changelog/digest.mjs --out /tmp/post.md    # custom save path
+//
+// It parses <Update> blocks, keeps those whose date falls in the window, and reassembles
+// their runtime sections into one post — so a period spanning several changelog entries
+// collapses into a single "here's what shipped" narrative. Deterministic; no AI.
+//
+// The post prints to stdout AND is saved to scripts/runtime-changelog/generated/
+// community-post.md (git-ignored) by default; --out overrides the save path.
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+const DEFAULT_SOURCE = join(REPO_ROOT, 'runtimes', 'changelog.mdx');
+// The post is saved here by default — alongside the collector's release-data.json, and
+// git-ignored like it. It's a share artifact, never committed.
+const DEFAULT_OUT = join(HERE, 'generated', 'community-post.md');
+const WINDOW_DAYS = 14;
+
+// Section ordering, matching the changelog. Core leads; unknown runtimes fall to the end.
+const RUNTIME_ORDER = [
+  'Core runtime',
+  'Apple',
+  'Android',
+  'Web',
+  'React',
+  'React Native',
+  'Flutter',
+  'Unity',
+  'Unreal',
+];
+
+const MONTHS = {
+  january: 1, february: 2, march: 3, april: 4, may: 5, june: 6,
+  july: 7, august: 8, september: 9, october: 10, november: 11, december: 12,
+};
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { source: DEFAULT_SOURCE, since: null, until: null, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--since') args.since = argv[++i];
+    else if (a === '--until') args.until = argv[++i];
+    else if (a === '--source') args.source = resolve(argv[++i]);
+    else if (a === '--out') args.out = resolve(argv[++i]);
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Dates — parse "July 16, 2026" and ISO "2026-07-16" without Date parsing quirks
+// ---------------------------------------------------------------------------
+
+// Returns a YYYY-MM-DD string, comparable lexicographically, or null.
+function toIso(text) {
+  if (!text) return null;
+  const iso = /(\d{4})-(\d{2})-(\d{2})/.exec(text);
+  if (iso) return `${iso[1]}-${iso[2]}-${iso[3]}`;
+  const long = /([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})/.exec(text);
+  if (long) {
+    const month = MONTHS[long[1].toLowerCase()];
+    if (month) return `${long[3]}-${String(month).padStart(2, '0')}-${long[2].padStart(2, '0')}`;
+  }
+  return null;
+}
+
+function isoDaysAgo(days) {
+  const d = new Date(Date.now() - days * 86_400_000);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function isoToday() {
+  return isoDaysAgo(0);
+}
+
+function prettyDate(iso) {
+  const [y, m, d] = iso.split('-').map(Number);
+  const name = Object.keys(MONTHS).find((k) => MONTHS[k] === m);
+  const month = name[0].toUpperCase() + name.slice(1);
+  return `${month} ${d}, ${y}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parse <Update> blocks
+// ---------------------------------------------------------------------------
+
+function attr(openTag, name) {
+  const m = new RegExp(`${name}="([^"]*)"`).exec(openTag);
+  return m ? m[1] : null;
+}
+
+function parseUpdates(mdx) {
+  const updates = [];
+  // Require whitespace + attributes after the tag name. A real <Update> always has at
+  // least a `label`; this skips a bare `<Update>` written inline in prose (e.g. a Note
+  // that mentions the component), which would otherwise be matched as an empty block and
+  // swallow the following real entry as its body.
+  const re = /<Update\s+([^>]*?)>([\s\S]*?)<\/Update>/g;
+  let m;
+  while ((m = re.exec(mdx)) !== null) {
+    const openTag = m[1];
+    let body = m[2];
+    // Drop MDX expression comments like {/* ... */} before they reach the output.
+    body = body.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').trim();
+    const label = attr(openTag, 'label');
+    const description = attr(openTag, 'description');
+    // An entry's date is its label when that's a date (per-fortnight page), otherwise
+    // its description (per-runtime page, where the label is "Apple v6.21.1").
+    const date = toIso(label) ?? toIso(description);
+    updates.push({ label, description, date, body });
+  }
+  return updates;
+}
+
+// Splits an Update body into `## Heading` sections. Text before the first heading (an
+// intro line) is attached to the entry itself.
+function splitSections(body) {
+  const sections = [];
+  let intro = [];
+  let current = null;
+  for (const line of body.split(/\r?\n/)) {
+    const h = /^##\s+(.+?)\s*$/.exec(line);
+    if (h) {
+      if (current) sections.push(current);
+      current = { heading: h[1].trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    } else {
+      intro.push(line);
+    }
+  }
+  if (current) sections.push(current);
+  return { intro: intro.join('\n').trim(), sections };
+}
+
+// Drop a trailing " - July 16, 2026" that the per-runtime page appends to labels that
+// have no version of their own (e.g. "Core runtime - July 16, 2026").
+function stripTrailingDate(text) {
+  return text.replace(/\s*[-–—,]\s*[A-Za-z]+\s+\d{1,2},?\s+\d{4}\s*$/, '').trim();
+}
+
+// "Apple v6.21.1" -> { runtime: "Apple", version: "v6.21.1" }; "Core runtime" -> no version.
+function splitHeading(heading) {
+  const clean = stripTrailingDate(heading.trim());
+  const m = /^(.*?)(?:\s+(v?\d[\w.–-]*))?$/u.exec(clean);
+  return { runtime: (m[1] || clean).trim(), version: m[2] || null };
+}
+
+function orderIndex(runtime) {
+  const i = RUNTIME_ORDER.indexOf(runtime);
+  return i === -1 ? RUNTIME_ORDER.length : i;
+}
+
+// ---------------------------------------------------------------------------
+// Build the digest
+// ---------------------------------------------------------------------------
+
+function buildDigest(updates, sinceIso, untilIso) {
+  const inWindow = updates
+    .filter((u) => u.date && u.date >= sinceIso && u.date <= untilIso)
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  if (inWindow.length === 0) return null;
+
+  // Group every section from every in-window entry under its runtime, preserving the
+  // version + date so a multi-entry period keeps "what shipped when".
+  const byRuntime = new Map();
+  for (const update of inWindow) {
+    const { intro, sections } = splitSections(update.body);
+    // Per-fortnight page: one Update with `## Runtime` sections inside. Per-runtime page:
+    // one Update per runtime, the name in the label and no inner headings — treat the
+    // whole body as a single section keyed on the label.
+    const runtimeSections = sections.length
+      ? sections
+      : [{ heading: update.label ?? '', lines: intro.split(/\r?\n/) }];
+    for (const section of runtimeSections) {
+      const { runtime, version } = splitHeading(section.heading);
+      if (!runtime) continue;
+      if (!byRuntime.has(runtime)) byRuntime.set(runtime, []);
+      byRuntime.get(runtime).push({ version, date: update.date, lines: section.lines });
+    }
+  }
+
+  const runtimes = [...byRuntime.keys()].sort(
+    (a, b) => orderIndex(a) - orderIndex(b) || a.localeCompare(b),
+  );
+
+  const dates = inWindow.map((u) => u.date);
+  const newest = dates[0];
+  const oldest = dates[dates.length - 1];
+  const range = newest === oldest ? prettyDate(newest) : `${prettyDate(oldest)} – ${prettyDate(newest)}`;
+
+  const out = [];
+  out.push(`# Rive runtime updates — ${range}`);
+  out.push('');
+  out.push(
+    runtimes.filter((r) => r !== 'Core runtime').join(', ').replace(/, ([^,]*)$/, ' and $1') +
+      ' saw new releases.',
+  );
+  out.push('');
+
+  for (const runtime of runtimes) {
+    const entries = byRuntime.get(runtime);
+    const multi = entries.length > 1;
+
+    for (const entry of entries) {
+      const versionSuffix = entry.version ? ` ${entry.version}` : '';
+      // With multiple contributions in the window, date-stamp each so the reader can
+      // tell successive releases apart.
+      const dateSuffix = multi ? ` — ${prettyDate(entry.date)}` : '';
+      out.push(`## ${runtime}${versionSuffix}${dateSuffix}`);
+      out.push('');
+      const trimmed = entry.lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+      if (trimmed) {
+        out.push(trimmed);
+        out.push('');
+      }
+    }
+  }
+
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim() + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const sinceIso = args.since ? toIso(args.since) : isoDaysAgo(WINDOW_DAYS);
+  const untilIso = args.until ? toIso(args.until) : isoToday();
+  if (!sinceIso) throw new Error(`could not parse --since "${args.since}"`);
+  if (!untilIso) throw new Error(`could not parse --until "${args.until}"`);
+
+  const mdx = readFileSync(args.source, 'utf8');
+  const updates = parseUpdates(mdx);
+  if (updates.length === 0) {
+    console.error(`No <Update> blocks found in ${args.source}.`);
+    process.exit(1);
+  }
+
+  const digest = buildDigest(updates, sinceIso, untilIso);
+  if (!digest) {
+    console.error(`No changelog entries between ${sinceIso} and ${untilIso}.`);
+    console.error(`(Found ${updates.length} entr${updates.length === 1 ? 'y' : 'ies'} overall.)`);
+    process.exit(1);
+  }
+
+  // Always print the post (so it's ready to copy, and the agent sees it inline) and always
+  // save a copy. Status goes to stderr so `digest.mjs > file` still yields clean content.
+  process.stdout.write(digest);
+
+  const outPath = args.out ?? DEFAULT_OUT;
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, digest);
+
+  const rel = outPath.replace(REPO_ROOT + '/', '');
+  const ignored = args.out ? '' : ' (git-ignored — copy it out to share, don\'t commit it)';
+  console.error(`\n${'─'.repeat(60)}`);
+  console.error(`Saved community post to ${rel}${ignored}`);
+  console.error(`Window: ${sinceIso} → ${untilIso}`);
+}
+
+main();

--- a/scripts/runtime-changelog/digest.mjs
+++ b/scripts/runtime-changelog/digest.mjs
@@ -4,7 +4,7 @@
 // the changelog is the reviewed, hand-edited source of truth, so the digest can never
 // say something the published page doesn't.
 //
-//   node scripts/runtime-changelog/digest.mjs                       # last 14 days
+//   node scripts/runtime-changelog/digest.mjs                       # most recent entry
 //   node scripts/runtime-changelog/digest.mjs --since 2026-07-01    # explicit window
 //   node scripts/runtime-changelog/digest.mjs --since 2026-06-01 --until 2026-06-30
 //   node scripts/runtime-changelog/digest.mjs --out /tmp/post.md    # custom save path
@@ -26,7 +26,6 @@ const DEFAULT_SOURCE = join(REPO_ROOT, 'runtimes', 'changelog.mdx');
 // The post is saved here by default — alongside the collector's release-data.json, and
 // git-ignored like it. It's a share artifact, never committed.
 const DEFAULT_OUT = join(HERE, 'generated', 'community-post.md');
-const WINDOW_DAYS = 14;
 
 // Section ordering, matching the changelog. Core leads; unknown runtimes fall to the end.
 const RUNTIME_ORDER = [
@@ -121,7 +120,7 @@ function parseUpdates(mdx) {
     body = body.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').trim();
     const label = attr(openTag, 'label');
     const description = attr(openTag, 'description');
-    // An entry's date is its label when that's a date (per-fortnight page), otherwise
+    // An entry's date is its label when that's a date (date-grouped page), otherwise
     // its description (per-runtime page, where the label is "Apple v6.21.1").
     const date = toIso(label) ?? toIso(description);
     updates.push({ label, description, date, body });
@@ -184,7 +183,7 @@ function buildDigest(updates, sinceIso, untilIso) {
   const byRuntime = new Map();
   for (const update of inWindow) {
     const { intro, sections } = splitSections(update.body);
-    // Per-fortnight page: one Update with `## Runtime` sections inside. Per-runtime page:
+    // Date-grouped page: one Update with `## Runtime` sections inside. Per-runtime page:
     // one Update per runtime, the name in the label and no inner headings — treat the
     // whole body as a single section keyed on the label.
     const runtimeSections = sections.length
@@ -244,9 +243,7 @@ function buildDigest(updates, sinceIso, untilIso) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const sinceIso = args.since ? toIso(args.since) : isoDaysAgo(WINDOW_DAYS);
   const untilIso = args.until ? toIso(args.until) : isoToday();
-  if (!sinceIso) throw new Error(`could not parse --since "${args.since}"`);
   if (!untilIso) throw new Error(`could not parse --until "${args.until}"`);
 
   const mdx = readFileSync(args.source, 'utf8');
@@ -254,6 +251,18 @@ function main() {
   if (updates.length === 0) {
     console.error(`No <Update> blocks found in ${args.source}.`);
     process.exit(1);
+  }
+
+  // Default window is just the most recent entry, so running this any time produces a post
+  // for whatever was last published — no assumption about how often you run it. Pass
+  // --since to cover a wider span (e.g. several entries at once).
+  let sinceIso;
+  if (args.since) {
+    sinceIso = toIso(args.since);
+    if (!sinceIso) throw new Error(`could not parse --since "${args.since}"`);
+  } else {
+    const dates = updates.map((u) => u.date).filter(Boolean).sort();
+    sinceIso = dates.length ? dates[dates.length - 1] : untilIso;
   }
 
   const digest = buildDigest(updates, sinceIso, untilIso);

--- a/scripts/runtime-changelog/state.json
+++ b/scripts/runtime-changelog/state.json
@@ -1,0 +1,34 @@
+{
+  "apple": {
+    "lastAnnouncedVersion": "6.21.1",
+    "announcedAt": "2026-07-16"
+  },
+  "android": {
+    "lastAnnouncedVersion": "11.7.2",
+    "announcedAt": "2026-07-16"
+  },
+  "flutter": {
+    "lastAnnouncedVersion": "0.14.9",
+    "announcedAt": "2026-07-16"
+  },
+  "web": {
+    "lastAnnouncedVersion": "2.38.5",
+    "announcedAt": "2026-07-16"
+  },
+  "react": {
+    "lastAnnouncedVersion": "4.29.5",
+    "announcedAt": "2026-07-16"
+  },
+  "react-native": {
+    "lastAnnouncedVersion": "0.4.18",
+    "announcedAt": "2026-07-16"
+  },
+  "unity": {
+    "lastAnnouncedVersion": "0.4.3",
+    "announcedAt": "2026-07-16"
+  },
+  "unreal": {
+    "lastAnnouncedVersion": "0.4.25",
+    "announcedAt": "2026-07-16"
+  }
+}


### PR DESCRIPTION
Adds a **runtime changelog** at `/runtimes/changelog` and the tooling to produce it periodically - covering all 8 Rive runtimes (Apple, Android, Web, React, React Native, Flutter, Unity, Unreal) plus a derived **Core runtime** section for shared C++ changes. As a bonus, it keeps the docs' install-version snippets from going stale.

### How it works

The design splits **deterministic facts** from **one AI editorial step**:

| Piece | Role | AI? |
|---|---|---|
| `scripts/runtime-changelog/collect.mjs` | Reads package registries + GitHub, decides what shipped, owns every version/date/URL | No |
| `.claude/skills/runtime-announcement` | Turns collected notes into changelog prose; reviewed every run | Yes (prose only) |
| `scripts/runtime-changelog/digest.mjs` | Reassembles the committed changelog into a copy-paste community post | No |
| `scripts/runtime-changelog/state.json` | Committed record of last-announced version per runtime - the boundary for the next entry | No |

Versions, dates, and links are **never AI-authored** - the agent only writes wording. `--advance-state` also syncs `docs.json` version variables (`versionApple`, `versionWeb`, …) to each runtime's latest, so wired install snippets never rot.

### Usage

One command in Claude Code: **`/runtime-announcement`**. It collects releases → drafts the entry → shows you the entry + a preview of the community post → you approve → it records state and bumps docs versions → you review `git diff` and commit. The community post is saved to `generated/community-post.md` (git-ignored) for pasting into Discord/forum. Full runbook in `scripts/runtime-changelog/README.md`.

### What's in this PR

- **Changelog page** + baseline entry covering all 8 runtimes
- **Tooling**: `collect.mjs`, `digest.mjs`, `state.json`, `README.md`, the skill
- **`docs.json`**: nav entry + auto-synced runtime version variables
- **8 runtime docs pages**: install snippets wired to those variables, replacing stale hardcoded versions (e.g. iOS `6.13.0`→current, RN default block `6.12.0`→current)

Everything is **local and human-reviewed** - no commits, pushes, or PRs happen automatically.

### Still on the table

- [ ] **Pick a changelog shape.** Two pages are included for comparison: `changelog.mdx` (grouped by date) and `changelog-per-runtime.mdx` (grouped by runtime, filterable). **Delete the loser + its temp `docs.json` nav entry before merge.**
- [ ] **`CLAUDE.md` still says `mintlify`** - the CLI is now `mint`. Separate cleanup.
- [ ] **No automation yet** - scheduled runs / auto-PRs are intentionally out of scope; revisit once the manual flow is proven.
- [ ] **Core links the repo**, not a version - `rive-runtime` has no releases yet. When it does, Core can link a specific version.
- [ ] **RN default-version block tracks "latest"** - accurate today (RN bundles latest), with prose pointing at `package.json` if it ever lags.