### PR TITLE
Update Terms of Service: add Fees and Refunds (subscriptions + credits)

### DIFF
--- a/legal/terms-of-service.mdx
+++ b/legal/terms-of-service.mdx
@@ -50,23 +50,29 @@ If you accept an invitation to join a Team as a Team Member, then you acknowledg
 
 The Service is free for individual Accounts, subject to these Terms. Creation of a Team requires you to purchase a subscription to access and use the Service for such Team (a **“Subscription”**). Your rights and the features of the Service available to your Team may depend upon the type and level of Subscription purchased. When you purchase a Subscription, you may select to be billed monthly or annually, and you will be billed immediately for the applicable interval. Pricing, payment terms and other Subscription details are described at [Rive Pricing](/account-admin/pricing).
 
-### 2. Upgrades, Downgrades, and Changes
+### 2. Fees and Refunds
+
+a. **Subscriptions**. All fees are non-refundable, except where required by law. This applies whether or not you cancel, and includes any unused portion of a Subscription.
+
+b. **Credits**. Purchased credits are non-refundable and have no cash value except where required by law. Credits are non-transferable and may not be redeemed for cash. Promotional or granted credits carry no cash value and may expire or be revoked at any time. Any remaining credit balance is forfeited when an account is closed or terminated.
+
+### 3. Upgrades, Downgrades, and Changes
 
 You may add additional Team Members to a Team within the Service interface. You will be charged for any such additional Team Members at a prorated rate for the remaining portion of the then-current billing period.
 
 You may change the type of Subscription at any time by (i) emailing us at [support@rive.app](mailto:support@rive.app) and following any instructions, if any, we provide to you in response to your change request or (ii) initiating a change through your Account settings within the Service.
 
-### 3. Payment Methods
+### 4. Payment Methods
 
 a. **Credit Card Authorization.** By purchasing a Subscription, you give us permission to charge your credit card or other approved method of payment for all fees incurred by you for your Subscription. Rive does not store your credit card information itself but instead relies on its third-party credit card processor. By purchasing a Subscription, you give us permission to share the applicable payment information with our third-party credit card processor.
 
 b. **Invoicing.** Rive may, in its sole discretion, agree in writing to permit certain users to pay via invoice. Any such invoice will be due within 15 days of receipt thereof, payable in U.S. Dollars. If you fail to make payment on time, Rive reserves the right, in addition to taking any other action at law or equity, to (i) charge interest on past due amounts at 1.0% per month or the highest interest rate allowed by law, whichever is less, and to charge all expenses of recovery, and (ii) terminate the applicable Account. You are solely responsible for all taxes, fees, duties and governmental assessments (except for taxes based on Rive's net income) that are imposed or become due in connection with your Subscription.
 
-### 4. Cancellation of a Subscription
+### 5. Cancellation of a Subscription
 
 You may cancel a Subscription at any time, effective upon the end of the then-current billing period, provided that you will not be entitled to receive any refund of any fees in connection with a cancellation. You may cancel either within the settings interface of the Services or by emailing us at [support@rive.app](mailto:support@rive.app).
 
-### 5. Enterprise Accounts
+### 6. Enterprise Accounts
 
 If you (or your organization, including any parent or affiliate entities) have annual gross revenues exceeding USD \$10 million, you may only use the Services under our Enterprise plan. By using the Services, you represent and warrant that you are eligible for the plan under which you have registered.
 


### PR DESCRIPTION
Adds a **Fees and Refunds** section to the Terms of Service:

- **Subscriptions** — all fees non-refundable except where required by law, including any unused portion on cancellation.
- **Credits** — purchased AI credits are non-refundable, have no cash value, and are non-transferable; promotional/granted credits may expire or be revoked; any remaining balance is forfeited when an account is closed.

The following subsections (Upgrades/Downgrades, Payment Methods, Cancellation, Enterprise Accounts) are renumbered 3–6 to make room for the insertion.

Content-only: one file, one hunk.