### PR TITLE
project: make mint broken-links pass clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,23 +10,24 @@ This is the official documentation repository for Rive (https://rive.app/docs), 
 
 ### Setup
 ```bash
-npm i -g mintlify
+npm i -g mint
 ```
+The old `mintlify` package is deprecated — uninstall it if present.
 
 ### Local Preview
 ```bash
-mintlify dev
+mint dev
 ```
 Run this from the repository root (where docs.json is located). The preview will be available at http://localhost:3000.
 
 ### Link Validation
 ```bash
-mintlify broken-links
+mint broken-links
 ```
-Always run this before creating a pull request to verify there are no broken links.
+Always run this before creating a pull request; it must report zero broken links.
 
 ### Troubleshooting
-- If `mintlify dev` isn't running, run `mintlify install` to re-install dependencies
+- If `mint dev` isn't working, run `mint update`
 - Make sure you're running commands from the repository root directory
 
 ## Architecture
@@ -57,10 +58,12 @@ The documentation is organized into platform-specific sections:
 
 ## Content Guidelines
 
+Follow `STYLEGUIDE.md` for writing conventions: voice and tone, frontmatter, headings, UI labels, `<Steps>`, callouts, `UseCase` examples, and code blocks. The notes below cover repo mechanics only.
+
 ### Images
 
 - Store images in `/images/` with subdirectories matching the documentation structure
-- Use descriptive filenames relative to the functionality being documented
+- Use descriptive kebab-case filenames relative to the functionality being documented (`my-image.png`)
 - Always include descriptive alt-text when embedding images
 
 Example image paths:
@@ -74,6 +77,13 @@ Use absolute paths from root, not relative paths:
 ```markdown
 ✓ [Hierarchy](/editor/interface-overview/hierarchy)
 ✗ [Hierarchy](../editor/interface-overview/hierarchy)
+```
+
+For URLs stored in docs.json `variables`, use a JSX-expression href:
+```markdown
+✓ <a href={"{{supportForm}}"}>Contact support</a>
+✗ <a href="{{supportForm}}">Contact support</a>   (renders, but flagged by mint broken-links)
+✗ [Contact support]({{supportForm}})              (does not render — variable is not substituted)
 ```
 
 ### Commit Messages
@@ -101,13 +111,16 @@ project: update navigation structure
 
 ## Pull Request Workflow
 
+See `CONTRIBUTING.md` for the full external-contributor flow (finding and claiming issues, forking).
+
 1. Fork the repository and branch from `main`
 2. Make your changes following the content guidelines
-3. Preview locally with `mintlify dev`
-4. Run `mintlify broken-links` to verify no broken links
+3. Preview locally with `mint dev`
+4. Run `mint broken-links` — it must pass clean
 5. Create PR with:
-   - Title following Conventional Commits format
+   - Title following Conventional Commits format (PRs are squash-merged, so the title must summarize the full change)
    - Description summarizing all changes
+   - Links to related issues; screenshots or preview links when helpful
    - Base branch set to `main`
 6. Reviewers will be auto-assigned via CODEOWNERS
 7. Mintlify will create a staging deployment - use "View Deployment" to preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you start making any changes, check out the [STYLEGUIDE.md](./STYLEGUIDE.
 
 ### 1. Find something to work on
 
-Start with the [Contributing backlog](https://github.com/rive-app/rive-docs/issues/725) or browse issues labeled [good first issue]((https://github.com/rive-app/rive-docs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)).
+Start with the [Contributing backlog](https://github.com/rive-app/rive-docs/issues/725) or browse issues labeled [good first issue](<(https://github.com/rive-app/rive-docs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)>).
 
 Before starting, comment on the issue to claim it.
 
@@ -35,6 +35,8 @@ Make your updates in the relevant documentation files.
 ### 4. Preview your changes
 
 Rive uses [Mintlify](https://mintlify.com) for documentation. Follow Mintlify's [Local Development](https://www.mintlify.com/docs/quickstart#make-your-first-change) guide to set up your local environment for previewing your changes locally.
+
+Before committing, run `mint broken-links` from the repository root - it must report zero broken links.
 
 ### 5. Commit your changes
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview the do
 npm i -g mint
 ```
 
-Run the following command at the root of your documentation (where mint.json is)
+Run the following command at the root of your documentation (where docs.json is)
 
 ```
 mint dev
@@ -35,7 +35,7 @@ mint dev
 
 #### Troubleshooting
 
-- Page loads as a 404 - Make sure you are running in a folder with `mint.json` (i.e from this repository's root directory).
+- Page loads as a 404 - Make sure you are running in a folder with `docs.json` (i.e from this repository's root directory).
 
 ## Custom Rive Components
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -88,6 +88,7 @@ Use links to help readers move between related concepts without interrupting the
 - Use relative links for internal docs pages (`[my link](/editor/something)`).
 - Link the first meaningful mention of a concept. Don’t overlink repeated mentions of the same concept on a page.
 - Use descriptive link text that explains where the link goes. Avoid vague link text like “click here,” “read more,” or “this page.”
+- For URLs stored in docs.json `variables`, use a JSX-expression href: `<a href={"{{supportForm}}"}>Contact support</a>`. The plain form `href="{{supportForm}}"` renders but is flagged by `mint broken-links`, and the markdown form `[text]({{supportForm}})` does not substitute the variable at all.
 
 ## Callouts
 

--- a/account-admin/account-overview/account-management.mdx
+++ b/account-admin/account-overview/account-management.mdx
@@ -15,4 +15,4 @@ From here you can:
 
 Your workspaces are listed in the left sidebar. Click "Manage Workspace" next to any workspace to change its plan, update payment, or invite members.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/account-admin/account-overview/billing-changes.mdx
+++ b/account-admin/account-overview/billing-changes.mdx
@@ -3,7 +3,7 @@ title: "Billing Changes"
 description: "How to update your card, change your plan, or manage billing for your Rive workspace."
 ---
 
-⚠️ If you have a pending change (like a scheduled cancellation), you can't make other billing changes until it's resolved. <a href="{{supportForm}}">Contact support</a> if you're stuck.
+⚠️ If you have a pending change (like a scheduled cancellation), you can't make other billing changes until it's resolved. <a href={"{{supportForm}}"}>Contact support</a> if you're stuck.
 
 
 ## Where to Manage Billing
@@ -39,7 +39,7 @@ Access is typically restored within a few minutes.
 
 Click "Change Plan" from the Manage Workspace page to switch between Free and Voyager.
 
-**Have legacy/grandfathered pricing?** <a href="{{supportForm}}">Contact support</a> and we'll process the change for you. This includes switching between monthly and annual billing.
+**Have legacy/grandfathered pricing?** <a href={"{{supportForm}}"}>Contact support</a> and we'll process the change for you. This includes switching between monthly and annual billing.
 
 ---
 
@@ -50,7 +50,7 @@ Call your bank first. Common issues:
 - International transactions blocked (Rive uses Stripe)
 - Bank flagged the charge as suspicious
 
-After your bank clears it, wait 30 minutes and try again. Still not working? Try a different card or <a href="{{supportForm}}">contact support</a>.
+After your bank clears it, wait 30 minutes and try again. Still not working? Try a different card or <a href={"{{supportForm}}"}>contact support</a>.
 
 ---
 
@@ -64,4 +64,4 @@ Each workspace has its own billing. Make sure you're managing the right one—ch
 
 Only the workspace owner can update billing. If you're seeing access errors due to a payment issue, let the owner know.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/account-admin/account-overview/cancel-my-account.mdx
+++ b/account-admin/account-overview/cancel-my-account.mdx
@@ -18,7 +18,7 @@ Plans are managed per workspace. Cancelling a plan only affects the selected wor
     <Info>
       If you don't see the Cancel Plan button, the workspace may already be on the Free plan.
 
-      If not, please <a href="{{supportForm}}">contact support</a>.
+      If not, please <a href={"{{supportForm}}"}>contact support</a>.
     </Info>
   </Step>
   <Step>
@@ -36,11 +36,11 @@ You'll keep access until the end of your current billing period. After that, the
 
 <AccordionGroup>
 	<Accordion title="Can I undo a cancellation?">
-    If you change your mind or need to make changes, <a href="{{supportForm}}">contact support</a> to remove the pending cancellation first.
+    If you change your mind or need to make changes, <a href={"{{supportForm}}"}>contact support</a> to remove the pending cancellation first.
   </Accordion>
   <Accordion title="How do I permanently delete my workspace and all my files?">
     See [Deleting a Workspace](/home/account-admin/workspaces/delete-a-workspace).
   </Accordion>
 </AccordionGroup>
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/account-admin/account-overview/creating-an-account.mdx
+++ b/account-admin/account-overview/creating-an-account.mdx
@@ -14,7 +14,7 @@ After signing up, you can use Rive for free or upgrade a workspace later.
   </Accordion>
 
   <Accordion title="Can I create a new account with an email address I used before?">
-    If you previously deleted a Rive account with the same email address, you won't be able to create a new account with that email. <a href="{{supportForm}}">Contact support</a> to restore the old account instead.
+    If you previously deleted a Rive account with the same email address, you won't be able to create a new account with that email. <a href={"{{supportForm}}"}>Contact support</a> to restore the old account instead.
   </Accordion>
 
   <Accordion title="How do I collaborate with other people?">
@@ -22,6 +22,6 @@ After signing up, you can use Rive for free or upgrade a workspace later.
   </Accordion>
 
   <Accordion title="Do you offer student discounts?">
-    Yes. See <a href="{{supportFormEducational}}">Rive Student Plan Request</a> for details.
+    Yes. See <a href={"{{supportFormEducational}}"}>Rive Student Plan Request</a> for details.
   </Accordion>
 </AccordionGroup>

--- a/account-admin/account-overview/delete-my-account.mdx
+++ b/account-admin/account-overview/delete-my-account.mdx
@@ -24,4 +24,4 @@ You need to remove all workspaces from your account first:
 
 Deleting your account suspends access for everyone in your workspace. If you want the workspace to continue, transfer ownership to another admin before deleting your account. See [Transfer Workspace Ownership](/account-admin/workspaces/managing-workspaces#transferring-workspace-ownership).
 
-If you delete your account and later want to use the same email address, you won't be able to create a new account. <a href="{{supportForm}}">Contact support</a> to restore your account instead. Note: we cannot guarantee your files will still be available.
+If you delete your account and later want to use the same email address, you won't be able to create a new account. <a href={"{{supportForm}}"}>Contact support</a> to restore your account instead. Note: we cannot guarantee your files will still be available.

--- a/account-admin/account-overview/downloading-my-receipt-or-invoice.mdx
+++ b/account-admin/account-overview/downloading-my-receipt-or-invoice.mdx
@@ -14,4 +14,4 @@ Invoice links in email expire after about a week. If your link no longer works, 
 
 Check your spam folder if the Stripe email doesn't arrive within a few minutes.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/account-admin/account-overview/trouble-logging-in.mdx
+++ b/account-admin/account-overview/trouble-logging-in.mdx
@@ -10,4 +10,4 @@ Two common causes:
 
 **2. Wrong password** Click "Forgot password?" below the login button. We'll email you a reset link.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/account-admin/pricing.mdx
+++ b/account-admin/pricing.mdx
@@ -57,10 +57,10 @@ If you're on a legacy plan, your pricing is locked in as long as your plan stays
 
 ## Students
 
-Rive offers a discounted Student Plan for individual students with a valid student email or documentation. The Student Plan is for personal educational work only—not for commercial use or team collaboration. Complete <a href="{{supportFormEducational}}">this form</a> to request access to the Student Plan.
+Rive offers a discounted Student Plan for individual students with a valid student email or documentation. The Student Plan is for personal educational work only—not for commercial use or team collaboration. Complete <a href={"{{supportFormEducational}}"}>this form</a> to request access to the Student Plan.
 
 Schools, universities, and non-profits should use a standard Cadet or Voyager plan.
 
 ---
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/account-admin/workspaces/managing-workspace-members.mdx
+++ b/account-admin/workspaces/managing-workspace-members.mdx
@@ -89,7 +89,7 @@ Admins can remove members from a workspace at any time.
 </Steps>
 
 <Note>
-  The workspace owner can't be removed. If you need to change ownership, <a href="{{supportForm}}">contact support</a>.
+  The workspace owner can't be removed. If you need to change ownership, <a href={"{{supportForm}}"}>contact support</a>.
 </Note>
 
 ## FAQs

--- a/account-admin/workspaces/managing-workspaces.mdx
+++ b/account-admin/workspaces/managing-workspaces.mdx
@@ -75,7 +75,7 @@ For more information about plans and features, see [Pricing](https://rive.app/pr
     Make sure the new owner is already a member of the workspace and has the Admin role. See [Inviting Workspace Members](/account-admin/workspaces/managing-workspace-members#inviting-members-to-a-workspace) and [Changing Member Roles](/account-admin/workspaces/managing-workspace-members#changing-member-roles).
   </Step>
   <Step>
-    <a href="{{supportForm}}">Contact support</a> with:
+    <a href={"{{supportForm}}"}>Contact support</a> with:
 
     - The workspace name
     - The email address of the current owner

--- a/account-admin/workspaces/reactivating-a-canceled-workspace.mdx
+++ b/account-admin/workspaces/reactivating-a-canceled-workspace.mdx
@@ -18,6 +18,6 @@ Your workspace is now active again.
 
 "Create new Workspace" is **not** the same as reactivating. If you have multiple workspaces, double-check you're reactivating the right one—each workspace has a display name and a username.
 
-**If you accidentally created a new workspace instead of reactivating:** <a href="{{supportForm}}">Contact support</a>. We can cancel the incorrect workspace and refund you, but we can't transfer payments or files between workspaces. If you saved files in the wrong workspace, download your backups (.rev files) before we cancel it.
+**If you accidentally created a new workspace instead of reactivating:** <a href={"{{supportForm}}"}>Contact support</a>. We can cancel the incorrect workspace and refund you, but we can't transfer payments or files between workspaces. If you saved files in the wrong workspace, download your backups (.rev files) before we cancel it.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -14,7 +14,7 @@ Not sure where to start? Ask in the [community](https://community.rive.app/c/sup
 - [Voyager Support](https://community.rive.app/c/voyager-support?utm_source=docs&utm_medium=support_page&utm_content=voyager_support) — Priority support with direct help from the Rive team for production issues and blocking bugs (included with Voyager)
 - [Enterprise](https://rive.app/pricing?utm_source=docs&utm_medium=support_page&utm_content=enterprise_support) - For teams that need closer collaboration, Enterprise plans include a dedicated Slack channel with the Rive team
 - [Discord](https://discord.com/invite/FGjmaTr) — Chat with the community in real time for quick questions and discussion
-- <a href="{{supportForm}}">Account support</a> — Billing, account issues, or private inquiries
+- <a href={"{{supportForm}}"}>Account support</a> — Billing, account issues, or private inquiries
 
 <Tip>
   For faster, more accurate help, include a `.rev` file, a video, a code snippet, and a minimal example.
@@ -33,7 +33,7 @@ Not sure where to start? Ask in the [community](https://community.rive.app/c/sup
 
 <AccordionGroup>
 	<Accordion title="Do you offer student discounts?">
-		Yes. See <a href="{{supportFormEducational}}">Rive Student Plan Request</a> for details.
+		Yes. See <a href={"{{supportFormEducational}}"}>Rive Student Plan Request</a> for details.
 	</Accordion>
 	<Accordion title="Where should I ask technical questions?">
 		For most technical questions, the fastest way to get help is through the community.

--- a/home/account-admin/account-overview/add-vat-tax-id-to-your-invoice.mdx
+++ b/home/account-admin/account-overview/add-vat-tax-id-to-your-invoice.mdx
@@ -3,7 +3,7 @@ title: "Add VAT/Tax ID to Your Invoice"
 description: "Need a tax invoice with your VAT or Tax ID for your records? Use our form and we'll email you an updated invoice."
 ---
 
-<a href="{{supportForm}}">Request a Tax Invoice</a>
+<a href={"{{supportForm}}"}>Request a Tax Invoice</a>
 
 You'll need:
 
@@ -27,4 +27,4 @@ To have your tax info included automatically on all future receipts, update your
 
 All future invoices will include your tax details automatically.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
+++ b/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
@@ -23,7 +23,7 @@ If you need the files, you'll need to work that out directly with the former emp
 
 ## How to Request Cancellation
 
-<a href="{{supportForm}}">Contact support</a> with:
+<a href={"{{supportForm}}"}>Contact support</a> with:
 
 - Your company name
 - The employee's name and email (if known)
@@ -38,4 +38,4 @@ We'll verify you control the payment method, cancel the plan, and remove your ca
 
 Create a company-owned workspace and add employees as members. When someone leaves, you remove them—no plans to chase down, no files lost.
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/home/account-admin/account-overview/change-your-email-or-password.mdx
+++ b/home/account-admin/account-overview/change-your-email-or-password.mdx
@@ -17,4 +17,4 @@ title: "Change Your Email or Password"
 - Enter your new password
 - Click "Save Password"
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/home/account-admin/account-overview/refunds.mdx
+++ b/home/account-admin/account-overview/refunds.mdx
@@ -8,7 +8,7 @@ Per Rive's [Terms of Service](/legal/terms-of-service), fees are non-refundable.
 
 ## Billing Errors
 
-If you were charged incorrectly (duplicate charge, charged after cancellation, wrong amount), <a href="{{supportForm}}">contact support</a> with:
+If you were charged incorrectly (duplicate charge, charged after cancellation, wrong amount), <a href={"{{supportForm}}"}>contact support</a> with:
 
 - Your account email
 - Date and amount of the charge
@@ -24,4 +24,4 @@ If you're not sure Rive is right for you:
 - Start with monthly instead of annual if you want flexibility
 - Double-check you're upgrading the right workspace
 
-**Questions?** <a href="{{supportForm}}">Contact support</a>.
+**Questions?** <a href={"{{supportForm}}"}>Contact support</a>.

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -86,16 +86,16 @@ After confirming:
 		Only the owner can delete a workspace. Your options:
 		- Ask the owner to delete it
 		- Leave the workspace yourself (you can always remove yourself)
-		- <a href="{{supportForm}}">Contact support</a> if the owner is unreachable
+		- <a href={"{{supportForm}}"}>Contact support</a> if the owner is unreachable
 	</Accordion>
 	<Accordion title="I want to delete a workspace, but the owner is no longer with the company.">
-		<a href="{{supportForm}}">Contact support</a> with proof of company ownership. We can help transfer ownership first, then you can delete.
+		<a href={"{{supportForm}}"}>Contact support</a> with proof of company ownership. We can help transfer ownership first, then you can delete.
 	</Accordion>
   <Accordion title="Does deleting one workspace affect the others?">
 		Deleting one doesn't affect others—they're completely independent. Triple-check which one you're deleting using the workspace switcher.
 	</Accordion>
   <Accordion title="I deleted my workspace by mistake. How do I get it back?">
-		**Within 90 days:** <a href="{{supportForm}}">Contact support</a> immediately with the subject "Recover Deleted Workspace - URGENT." Include the workspace name, your account email, and when you deleted it. We can restore it.
+		**Within 90 days:** <a href={"{{supportForm}}"}>Contact support</a> immediately with the subject "Recover Deleted Workspace - URGENT." Include the workspace name, your account email, and when you deleted it. We can restore it.
 
     **After 90 days:** Unfortunately, the data is gone. This is why we really push the backup step.
 	</Accordion>
@@ -103,7 +103,7 @@ After confirming:
 		You're probably not the workspace owner. Check who owns it in workspace settings.
 	</Accordion>
   <Accordion title="The Delete button is grayed out.">
-		This is usually a billing issue. Resolve any outstanding payments first, or <a href="{{supportForm}}">contact support</a>.
+		This is usually a billing issue. Resolve any outstanding payments first, or <a href={"{{supportForm}}"}>contact support</a>.
 	</Accordion>
   <Accordion title="Some workspace members still see the deleted workspace.">
 		This is probably a caching issue. Have the members log out, clear browser cache, and log back in. It should resolve within 30 minutes.
@@ -119,4 +119,4 @@ After confirming:
 
 ---
 
-**Still not sure?** <a href="{{supportForm}}">Contact support</a> before doing anything permanent.
+**Still not sure?** <a href={"{{supportForm}}"}>Contact support</a> before doing anything permanent.

--- a/runtimes/apple/layouts.mdx
+++ b/runtimes/apple/layouts.mdx
@@ -3,8 +3,6 @@ title: "Layout"
 description: "Control how graphics are laid out within the canvas."
 ---
 
-import { Apple } from '/snippets/constants.mdx'
-
 import FitMode from '/snippets/runtimes/layouts/fit-mode.mdx'
 import Alignment from "/snippets/runtimes/layouts/alignment.mdx"
 import Bounds from "/snippets/runtimes/layouts/bounds.mdx"

--- a/runtimes/apple/logging.mdx
+++ b/runtimes/apple/logging.mdx
@@ -3,8 +3,6 @@ title: 'Logging'
 description: ''
 ---
 
-import { Apple } from '/snippets/constants.mdx'
-
 import Overview from '/snippets/runtimes/logging/overview.mdx'
 
 <Overview />

--- a/runtimes/apple/playing-audio.mdx
+++ b/runtimes/apple/playing-audio.mdx
@@ -8,8 +8,6 @@ import WebWarning from "/snippets/runtimes/playing-audio/web-warning.mdx"
 import EmbeddedAssets from "/snippets/runtimes/playing-audio/embedded-assets.mdx"
 import ReferencedAssets from "/snippets/runtimes/playing-audio/referenced-assets.mdx"
 
-import { Apple } from "/snippets/constants.mdx"
-
 <Overview />
 
 <EmbeddedAssets />

--- a/runtimes/apple/semantics.mdx
+++ b/runtimes/apple/semantics.mdx
@@ -3,8 +3,6 @@ title: "Semantics"
 description: "Make your Rive views accessible to VoiceOver by enabling semantics in the Apple runtime."
 ---
 
-import { Apple } from "/snippets/constants.mdx"
-
 <Note>
   Semantics is currently only available in [Early Access](https://rive.app/downloads?utm_source=docs&utm_medium=content). Runtime support is in development or released as experimental.
 


### PR DESCRIPTION
- convert 33 `<a href="{{supportForm}}">` anchors to JSX-expression hrefs (`href={"{{var}}"}`) - the checker doesn't substitute docs.json variables, so every one was a false positive; renders identically, URLs stay in docs.json variables
- remove 4 dead `constants.mdx` imports left by #765 (mint validate now passes)
- rename CLI `mintlify` -> `mint` in CLAUDE.md, fix mint.json -> docs.json in README, document the variable-link convention and the zero-broken-links gate in CLAUDE.md / STYLEGUIDE.md / CONTRIBUTING.md
- align CLAUDE.md with the newer CONTRIBUTING.md and STYLEGUIDE.md