### PR TITLE
docs(editor): add descriptive alt text in freeze-and-origin and groups

### DIFF
--- a/editor/fundamentals/freeze-and-origin.mdx
+++ b/editor/fundamentals/freeze-and-origin.mdx
@@ -16,11 +16,11 @@ You need to reposition the parent group to change the point of origin for these 
 
 Procedural objects (like artboards and procedural paths) have an origin property. The origin of a procedural path determines where its properties originate from. For example, changing the width of a rectangle with its origin in the middle (50% X and 50% Y) causes it to grow from its center.
 
-![Origin in the center](/images/editor/fundamentals/freeze-origin-center.gif)
+![Changing the width of a rectangle with the origin centered at 50% X and 50% Y, so it grows outward from the center](/images/editor/fundamentals/freeze-origin-center.gif)
 
 Changing the width on a rectangle with its origin on the left side (0% X) causes it to grow from its left.
 
-![Origin on the left](/images/editor/fundamentals/freeze-origin-left.gif)
+![Changing the width of a rectangle with the origin on the left at 0% X, so it grows from the left](/images/editor/fundamentals/freeze-origin-left.gif)
 
 This is particularly useful when animating paths that have other procedural properties enabled, such as rounded corners.
 

--- a/editor/fundamentals/groups.mdx
+++ b/editor/fundamentals/groups.mdx
@@ -27,14 +27,14 @@ The Target option draws an icon on the stage that is visible regardless of wheth
 
 Targets are directly selectable on the stage. You don't need to use [Deep Select](/editor/interface-overview/selection-and-navigation#deep-select) to select them.
 
-![Groups change Target](/images/editor/fundamentals/groups-targets.gif)
+![Setting the Style of a group to Target in the Inspector, which adds a selectable target icon on the stage](/images/editor/fundamentals/groups-targets.gif)
 
 The Target option is particularly useful when working with Constraints.
 
 <Tip>
   If targets aren't visible on the stage, open the **View Options** menu and make sure **Targets** is enabled.
 
-  ![targets bone visibility](/images/editor/interface/toggle-show-targets.gif)
+  ![Enabling Targets in the View Options menu so target icons appear on the stage](/images/editor/interface/toggle-show-targets.gif)
 </Tip>
 
 <Card title="Constraints" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>} iconType="solid" href="/editor/constraints/">


### PR DESCRIPTION
Continues the alt-text accessibility pass from #805 on two more editor pages.

## Changes

**`editor/fundamentals/freeze-and-origin.mdx`** — replaced the two origin GIF alt texts ("Origin in the center", "Origin on the left") with descriptions of what the animation actually shows: the rectangle growing outward from its center at 50% X / 50% Y, and growing from the left at 0% X.

**`editor/fundamentals/groups.mdx`** — replaced "Groups change Target" and "targets bone visibility" with descriptions of the actions demonstrated: setting a group's Style to Target in the Inspector, and enabling Targets in the View Options menu.

## Notes

Alt text follows the same W3C guidance used in #805 — describing the information the image conveys rather than restating nearby body copy.

Verified with `mintlify dev`. `mintlify broken-links` reports 33 pre-existing hits across 17 unrelated files, all of them the `{{supportForm}}` / `{{supportFormEducational}}` globals from `docs.json` that the checker doesn't expand — none in the files touched here.