### PR TITLE
docs: new web editor link

### DIFF
--- a/editor/get-rive.mdx
+++ b/editor/get-rive.mdx
@@ -18,7 +18,7 @@ You can use the Rive editor as a **desktop app** or directly in your **browser**
 
   <Card
     title="Web Editor"
-    href="https://editor.rive.app?utm_source=docs&utm_medium=content"
+    href="https://editor.rive.app"
   >
     Use Rive instantly in your browser.
   </Card>


### PR DESCRIPTION
resolves: #848

Adding params breaks the link. 