### PR TITLE
docs(editor): update advanced topics

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -185,29 +185,6 @@
                 ]
               },
               {
-                "group": "Rigging & Control",
-                "pages": [
-                  "editor/manipulating-shapes/manipulating-shapes",
-                  "editor/manipulating-shapes/meshes",
-                  "editor/manipulating-shapes/bones",
-                  "editor/manipulating-shapes/joysticks",
-                  {
-                    "group": "Constraints",
-                    "pages": [
-                      "editor/constraints/constraints-overview",
-                      "editor/constraints/ik-constraint",
-                      "editor/constraints/distance-constraint",
-                      "editor/constraints/scale-constraint",
-                      "editor/constraints/rotation-constraint",
-                      "editor/constraints/transform-constraint",
-                      "editor/constraints/translation-constraint",
-                      "editor/constraints/follow-path-constraint",
-                      "editor/constraints/scroll-constraint"
-                    ]
-                  }
-                ]
-              },
-              {
                 "group": "Data",
                 "pages": [
                   "editor/data-binding/overview",
@@ -236,19 +213,49 @@
                   "editor/exporting/exporting-for-backup",
                   "editor/embed-urls/overview"
                 ]
-              },
-              {
-                "group": "AI",
-                "pages": [
-                  "editor/ai-agent/ai-agent",
-                  "editor/ai/mcp"
-                ]
               }
             ]
           },
           {
             "group": "Advanced Topics",
             "pages": [
+              {
+                "group": "AI",
+                "pages": [
+                  "editor/ai-agent/ai-agent",
+                  "editor/ai/mcp"
+                ]
+              },
+              {
+                "group": "Rigging & Control",
+                "pages": [
+                  "editor/manipulating-shapes/manipulating-shapes",
+                  "editor/manipulating-shapes/meshes",
+                  "editor/manipulating-shapes/bones",
+                  "editor/manipulating-shapes/joysticks",
+                  {
+                    "group": "Constraints",
+                    "pages": [
+                      "editor/constraints/constraints-overview",
+                      "editor/constraints/ik-constraint",
+                      "editor/constraints/distance-constraint",
+                      "editor/constraints/scale-constraint",
+                      "editor/constraints/rotation-constraint",
+                      "editor/constraints/transform-constraint",
+                      "editor/constraints/translation-constraint",
+                      "editor/constraints/follow-path-constraint",
+                      "editor/constraints/scroll-constraint"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Accessibility",
+                "pages": [
+                  "editor/accessibility/semantics",
+                  "editor/accessibility/reduced-motion"
+                ]
+              },
               {
                 "group": "Admin & Workspaces",
                 "pages": [
@@ -261,13 +268,6 @@
                     ]
                   },
                   "account-admin/bring-your-own-bucket"
-                ]
-              },
-              {
-                "group": "Accessibility",
-                "pages": [
-                  "editor/accessibility/semantics",
-                  "editor/accessibility/reduced-motion"
                 ]
               },
               {


### PR DESCRIPTION
This moved **AI** and **Rigging & Control** back into **Advanced Topics**. For a second I moved them into **Fundamentals**, but that's for absolute essentials. You can still be proficient at rive without ever touching meshes or constraints. I also think **AI** was a little buried in **Fundamentals.**

<img width="441" height="727" alt="CleanShot 2026-08-13 at 17 20 56" src="https://github.com/user-attachments/assets/b01f88ca-633a-47c5-9c6f-dd5348d7bf28" />
