### PR TITLE
docs(js): reference canvas over webgl2 for getting started. add caveats about choosing one over the other

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -27,7 +27,9 @@
     "pricingVoyagerYearly": "$304",
     "pricingEnterpriseYearly": "$1,440",
     "versionMajorWebGL2": "2",
-    "versionWebGL2": "2.38.3",
+    "versionWebGL2": "2.39.2",
+    "versionMajorCanvas": "2",
+    "versionCanvas": "2.39.2",
     "supportForm": "https://forms.rive.app/support?utm_medium=support_page",
     "supportFormEducational": "https://forms.rive.app/education?utm_medium=support_page"
   },

--- a/feature-support.mdx
+++ b/feature-support.mdx
@@ -23,14 +23,18 @@ When a feature requires API changes, migration notes will be included below.
 
 ### Runtimes
 
-<FeatureSupportGroup runtime="webWebGL2">
-    Choose between @rive-app/webgl2 and @rive-app/canvas, with guidance on performance, package size, and when to use canvas-lite.
-</FeatureSupportGroup>
 <FeatureSupportGroup runtime="webCanvas">
-    For better performance and the latest features, like vector feathering, we recommend using the WebGL2 runtime, which uses the Rive Renderer.
+    The recommended package for most web projects. Uses the browser's Canvas2D renderer, but does not support vector feathering at this time. See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl).
 </FeatureSupportGroup>
-<FeatureSupportGroup runtime="reactWebGL2" />
-<FeatureSupportGroup runtime="reactCanvas" />
+<FeatureSupportGroup runtime="webWebGL2">
+    Uses the Rive Renderer. Choose `@rive-app/webgl2` when your content uses vector feathering. See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl).
+</FeatureSupportGroup>
+<FeatureSupportGroup runtime="reactCanvas">
+    The recommended package for most React projects. Uses the browser's Canvas2D renderer, but does not support vector feathering at this time. See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl).
+</FeatureSupportGroup>
+<FeatureSupportGroup runtime="reactWebGL2">
+    Uses the Rive Renderer. Choose `@rive-app/react-webgl2` when your content uses vector feathering. See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl).
+</FeatureSupportGroup>
 
 <FeatureSupportGroup runtime="reactNative" />
 <FeatureSupportGroup runtime="flutter" />
@@ -53,12 +57,12 @@ When a feature requires API changes, migration notes will be included below.
 
 <FeatureSupportGroup runtime="webWebGL">
     <Warning>
-        The `@rive-app/webgl` runtime is deprecated. For better performance and the latest features, use `@rive-app/webgl2`.
+        The `@rive-app/webgl` runtime is deprecated as of `v2.37.0`. Use `@rive-app/canvas` (recommended for most content), or `@rive-app/webgl2` if you need vector feathering.
     </Warning>
 </FeatureSupportGroup>
 <FeatureSupportGroup runtime="reactWebGL" >
     <Warning>
-        The `@rive-app/react-webgl` runtime is deprecated. For better performance and the latest features, use `@rive-app/react-webgl2`.
+        The `@rive-app/react-webgl` runtime is deprecated as of `v4.30.0`. Use `@rive-app/react-canvas` (recommended for most content), or `@rive-app/react-webgl2` if you need vector feathering.
     </Warning>
 </FeatureSupportGroup>
 <FeatureSupportGroup runtime="reactNativeLegacy" >

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -39,21 +39,25 @@ If a runtime is not listed here, there is no renderer setup to configure. It use
 
         | Package | Renderer | Use when |
         | --- | --- | --- |
-        | `@rive-app/webgl2` | Rive  | You want the best support for Rive Renderer features and rendering fidelity. |
-        | `@rive-app/canvas` | Canvas2D | You have several Rive instances on screen, want a slightly smaller package, or do not need Rive Renderer-only features. |
+        | `@rive-app/canvas` (recommended) | Canvas2D | Most content. Most consistent performance and support across devices, with no limit on concurrent Rive instances. |
+        | `@rive-app/webgl2` | Rive Renderer | Your content uses Vector Feathering. |
         | `@rive-app/canvas-lite` | Canvas2D | You want the smallest Canvas2D package and do not need the full Canvas2D runtime feature set. |
+
+        See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for a full comparison.
     </Tab>
     <Tab title="Web (React)">
         The Web runtime provides multiple packages with the same core API. Choose the package based on the renderer you want to use.
 
         | Package | Renderer | Use when |
         | --- | --- | --- |
-        | `@rive-app/react-webgl2` | Rive Renderer | You want the best support for Rive Renderer features and rendering fidelity. |
-        | `@rive-app/react-canvas` | Canvas2D | You have several Rive instances on screen, want a slightly smaller package, or do not need Rive Renderer-only features. |
+        | `@rive-app/react-canvas` (recommended) | Canvas2D | Most content. Most consistent performance and support across devices, with no limit on concurrent Rive instances. |
+        | `@rive-app/react-webgl2` | Rive Renderer | Your content uses Vector Feathering. |
         | `@rive-app/react-canvas-lite` | Canvas2D | You want the smallest Canvas2D package and do not need the full Canvas2D runtime feature set. |
 
+        See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for a full comparison.
+
         <Note>
-            These packages provide the Rive React component and hooks. If you want to use the imperative JavaScript runtime in a React app, install one of the Web JavaScript packages instead, such as `@rive-app/webgl2`, `@rive-app/canvas`, or `@rive-app/canvas-lite`.
+            These packages provide the Rive React component and hooks. If you want to use the imperative JavaScript runtime in a React app, install one of the Web JavaScript packages instead, such as `@rive-app/canvas`, `@rive-app/canvas-lite`, or `@rive-app/webgl2`.
         </Note>
     </Tab>
     <Tab title="Android (Legacy)">

--- a/runtimes/getting-started.mdx
+++ b/runtimes/getting-started.mdx
@@ -53,7 +53,7 @@ You'll also find pages dedicated to controlling your Rive graphics at runtime. F
 
 <CardGroup cols={2}>
   <Card title="Choose a Renderer" href="/runtimes/choose-a-renderer" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
-    Specify the desired renderer to use at runtime. Each runtime provides different options. We recommend using the Rive Renderer.
+    Specify the desired renderer to use at runtime. Each runtime provides different options, and the best choice depends on your platform.
   </Card>
   <Card title="Format" href="/runtimes/advanced-topic/format" icon={<svg xmlns="http://www.w3.org/2000/svg" height="100%" fill="none" viewBox="0 0 16 16" class="size-4 text-gray-500/80 dark:text-gray-400" aria-hidden="true"><path fill="currentColor" d="M7.31 7.111 2.406 5.15l4.61-1.844.328-.126a2.3 2.3 0 0 1 1.647 0l.33.126L13.93 5.15 9.024 7.112c-.55.22-1.163.22-1.712 0"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m2.405 10.911 4.906 1.963c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 8.031 7.31 9.992c.55.22 1.162.22 1.712 0l4.906-1.963M2.405 5.15 7.31 7.111c.55.22 1.162.22 1.712 0l4.906-1.962-4.61-1.844-.329-.126a2.3 2.3 0 0 0-1.647 0l-.329.126z"></path></svg>}>
     The Rive File format.
@@ -81,18 +81,18 @@ Check out the runtime subpages for steps on how to get started!
   All web runtimes are distributed via npm:
 
   - [GitHub](https://github.com/rive-app/rive-wasm)
-  - [canvas](https://www.npmjs.com/package/@rive-app/canvas)
-  - [webgl2](https://www.npmjs.com/package/@rive-app/webgl2)
+  - [canvas](https://www.npmjs.com/package/@rive-app/canvas) (recommended)
   - [canvas-lite](https://www.npmjs.com/package/@rive-app/canvas-lite)
+  - [webgl2](https://www.npmjs.com/package/@rive-app/webgl2)
 
-  **See [Canvas vs WebGL](/runtimes/web/canvas-vs-webgl) for package guidance and sizing tradeoffs.**
+  **See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for package guidance, performance considerations, and sizing tradeoffs.**
 </Accordion>
 
 <Accordion title="React">
   All React runtimes are distributed via npm:
 
   - [GitHub](https://github.com/rive-app/rive-react)
-  - [canvas](https://www.npmjs.com/package/@rive-app/react-canvas)
+  - [canvas](https://www.npmjs.com/package/@rive-app/react-canvas) (recommended)
   - [canvas-lite](https://www.npmjs.com/package/@rive-app/react-canvas-lite)
   - [webgl2](https://www.npmjs.com/package/@rive-app/react-webgl2)
 

--- a/runtimes/react/data-binding.mdx
+++ b/runtimes/react/data-binding.mdx
@@ -31,7 +31,7 @@ import { Demos } from "/snippets/demos.jsx";
 Use the `useViewModel` hook to get a reference to a view model. You need to pass the `rive` object obtained from `useRive`.
 
 ```typescript
-import { useRive, useViewModel } from '@rive-app/react-webgl2';
+import { useRive, useViewModel } from '@rive-app/react-canvas';
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',
@@ -53,7 +53,7 @@ const namedViewModel = useViewModel(rive, { name: 'MyViewModelName' });
 Use the `useViewModelInstance` hook to create a view model instance from a view model returned by the `useViewModel` hook.
 
 ```typescript
-import { useRive, useViewModel, useViewModelInstance } from '@rive-app/react-webgl2';
+import { useRive, useViewModel, useViewModelInstance } from '@rive-app/react-canvas';
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',
@@ -78,7 +78,7 @@ const newUnbound = useViewModelInstance(viewModel, { useNew: true });
 You can also bind the view model instance directly to the Rive instance by passing the `rive` object to the `useViewModelInstance` hook.
 
 ```typescript
-import { useRive, useViewModel, useViewModelInstance } from '@rive-app/react-webgl2';
+import { useRive, useViewModel, useViewModelInstance } from '@rive-app/react-canvas';
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',
@@ -129,7 +129,7 @@ For React, no additional steps are needed to bind the view model instance to the
 The view model hooks run after Rive has loaded, which means the first frame has already advanced and rendered before they bind, even with `autoplay: false`. If you want to set data before the first render, do the data binding setup in the `onRiveReady` callback of `useRive` instead. It receives the `Rive` instance synchronously as soon as the file loads, and before the state machine advances, so you can stage instances and set property values that the very first frame renders with.
 
 ```tsx
-import { useRive, ViewModel, ViewModelInstance } from '@rive-app/react-webgl2';
+import { useRive, ViewModel, ViewModelInstance } from '@rive-app/react-canvas';
 
 const { RiveComponent } = useRive({
     src: 'your_file.riv',
@@ -179,7 +179,7 @@ import {
     useViewModel,
     useGlobalViewModelInstance,
     useViewModelInstanceColor,
-} from '@rive-app/react-webgl2';
+} from '@rive-app/react-canvas';
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',
@@ -254,7 +254,7 @@ import {
     useViewModelInstanceEnum,
     useViewModelInstanceColor,
     useViewModelInstanceTrigger
-} from '@rive-app/react-webgl2';
+} from '@rive-app/react-canvas';
 
 // Assuming viewModelInstance is obtained via useViewModelInstance or rive.viewModelInstance
 
@@ -326,7 +326,7 @@ The `value` returned by each hook will update automatically when the property ch
 Access nested properties by providing the full path (separated by `/`) as the first argument to the property hooks.
 
 ```typescript
-import { useViewModelInstanceString, useViewModelInstanceNumber } from '@rive-app/react-webgl2';
+import { useViewModelInstanceString, useViewModelInstanceNumber } from '@rive-app/react-canvas';
 
 // Accessing 'settings/theme/name' (String)
 const { value: themeName, setValue: setThemeName } = useViewModelInstanceString(
@@ -352,7 +352,7 @@ The React hooks handle observability automatically. When a property's value chan
 For Triggers, you can provide an `onTrigger` callback directly to the `useViewModelInstanceTrigger` hook, which fires when the trigger is activated in the Rive instance.
 
 ```typescript
-import { useViewModelInstanceTrigger } from '@rive-app/react-webgl2';
+import { useViewModelInstanceTrigger } from '@rive-app/react-canvas';
 
 // Assuming viewModelInstance is available
 const { trigger } = useViewModelInstanceTrigger(
@@ -372,7 +372,7 @@ const { trigger } = useViewModelInstanceTrigger(
 Use the `useViewModelInstanceImage` hook to set image properties on view model instances.
 
     ```typescript
-    import { useRive, useViewModel, useViewModelInstance, useViewModelInstanceImage } from '@rive-app/react-webgl2';
+    import { useRive, useViewModel, useViewModelInstance, useViewModelInstanceImage } from '@rive-app/react-canvas';
 
     const { rive, RiveComponent } = useRive({
         src: 'your_file.riv',
@@ -426,7 +426,7 @@ Use the `useViewModelInstanceImage` hook to set image properties on view model i
 Use the `useViewModelInstanceList` hook to manage list properties on view model instances.
 
 ```typescript
-import { useRive, useViewModel, useViewModelInstance, useViewModelInstanceList } from '@rive-app/react-webgl2';
+import { useRive, useViewModel, useViewModelInstance, useViewModelInstanceList } from '@rive-app/react-canvas';
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',
@@ -506,7 +506,7 @@ console.log(`List has ${length} items`);
 Use the `useViewModelInstanceArtboard` hook to set artboard properties on view model instances.
 
 ```typescript
-import { useRive, useViewModel, useViewModelInstance, useViewModelInstanceArtboard } from '@rive-app/react-webgl2';
+import { useRive, useViewModel, useViewModelInstance, useViewModelInstanceArtboard } from '@rive-app/react-canvas';
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',

--- a/runtimes/react/fonts.mdx
+++ b/runtimes/react/fonts.mdx
@@ -22,7 +22,7 @@ To start, import `RiveFont` and `decodeFont` from the React package and call `Ri
 
 ```tsx
 import { useEffect } from "react";
-import { useRive, RiveFont, decodeFont } from "@rive-app/react-webgl2";
+import { useRive, RiveFont, decodeFont } from "@rive-app/react-canvas";
 
 const THAI_FONT_URL =
   "https://raw.githubusercontent.com/google/fonts/main/ofl/notoserifthai/NotoSerifThai%5Bwdth%2Cwght%5D.ttf";

--- a/runtimes/react/migration-guides.mdx
+++ b/runtimes/react/migration-guides.mdx
@@ -4,10 +4,12 @@ description: 'Migrating between major versions of the Apple runtime'
 ---
 
 <AccordionGroup>
-    <Accordion title={`Migrating from @rive-app/react-webgl to @rive-app/react-webgl2`}>
-        We highly recommend migrating to `@rive-app/react-webgl2` for the best rendering quality and performance in most cases. The `@rive-app/react-webgl` package is deprecated and no longer receives updates after `v4.27.3`.
+    <Accordion title={`Migrating from @rive-app/react-webgl`}>
+        The `@rive-app/react-webgl` package is deprecated and no longer receives updates after `v4.27.3`, so you should migrate off it.
 
-        No changes to the API are necessary, simply update your package installation and import statements to use `@rive-app/react-webgl2`. This change will allow you to take advantage of the improved rendering capabilities of the [Rive renderer](https://rive.app/renderer) while maintaining compatibility with your existing codebase.
+        For most content, migrate to `@rive-app/react-canvas`. Choose `@rive-app/react-webgl2` if your content uses [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering). See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for the full comparison.
+
+        No changes to the API are necessary. Update your package installation and import statements to use the new package, and your existing code will keep working.
     </Accordion>
     <Accordion title="Migrating from 3.x.x to 4.x.x">
         Starting in v4 of our React runtimes, Rive will support Rive Text at runtime, which includes the following packages:

--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -22,11 +22,11 @@ There are three main ways to use Rive in a React app:
 <Steps>
   <Step title="Install the dependency">
     ```bash
-    npm i --save @rive-app/react-webgl2
+    npm i --save @rive-app/react-canvas
     ```
 
     <Info>
-      This guide uses `@rive-app/react-webgl2`. Rive also provides other React packages for different renderers. See [Choosing a Renderer](/runtimes/choose-a-renderer/overview#web-react) to choose the package that fits your project.
+      This guide uses `@rive-app/react-canvas`, the recommended package for most React projects. Rive also provides other React packages for different renderers — for example, content that uses [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering) requires `@rive-app/react-webgl2`. See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) to choose the package that fits your project.
     </Info>
   </Step>
   <Step title="Render the Rive component">
@@ -36,7 +36,7 @@ There are three main ways to use Rive in a React app:
 
         ```jsx
         import React, { useEffect } from "react";
-        import { useRive, useViewModelInstanceNumber } from "@rive-app/react-webgl2";
+        import { useRive, useViewModelInstanceNumber } from "@rive-app/react-canvas";
 
         export default function App() {
           const { rive, RiveComponent } = useRive({
@@ -84,7 +84,7 @@ There are three main ways to use Rive in a React app:
         This approach is best for simple embeds. Use hooks if you need to control state machines, access the Rive instance, listen for events, or control data at runtime.
 
         ```tsx
-        import Rive from '@rive-app/react-webgl2';
+        import Rive from '@rive-app/react-canvas';
 
         export const Simple = () => (
           <Rive
@@ -98,12 +98,12 @@ There are three main ways to use Rive in a React app:
         Use the imperative runtime when you want to create and manage the Rive instance yourself. In React, this is usually done with `useEffect` and a canvas ref.
 
         <Note>
-          Imperative usage uses the Web JavaScript runtime package, such as `@rive-app/webgl2`, instead of a React package.
+          Imperative usage uses the Web JavaScript runtime package, such as `@rive-app/canvas`, instead of a React package.
         </Note>
 
         ```jsx
         import React, { useEffect, useRef } from "react";
-        import { Rive, Fit, Layout } from "@rive-app/webgl2";
+        import { Rive, Fit, Layout } from "@rive-app/canvas";
         import "./styles.css";
 
         export default function App() {

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -1,73 +1,107 @@
 ---
 title: "Canvas vs WebGL2"
-description: "Choose between `@rive-app/webgl2` and `@rive-app/canvas`, with guidance on performance, package size, and when to use canvas-lite."
+description: "Choose between the @rive-app/canvas and @rive-app/webgl2 runtime packages."
 ---
 
-### Choose a runtime
+Rive's web runtime comes in two main packages: [`@rive-app/canvas`](https://www.npmjs.com/package/@rive-app/canvas) and [`@rive-app/webgl2`](https://www.npmjs.com/package/@rive-app/webgl2). They expose the same API. The only difference is how they draw.
 
-For web, start by choosing one of these two packages:
+**Start with `@rive-app/canvas`.** It performs consistently across devices and is the right choice for most files. Reach for `@rive-app/webgl2` when your file uses [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering), which the canvas renderer does not draw.
 
-- [`@rive-app/webgl2`](https://www.npmjs.com/package/@rive-app/webgl2)
-- [`@rive-app/canvas`](https://www.npmjs.com/package/@rive-app/canvas)
+Switching is a one-line import change, so you can try both and measure against your own content.
 
-They share the same high-level API, so switching packages does not require changing how you create a `new Rive({...})` instance. The key differences are the renderer and package size; read the sections below to decide what is best for your use case, and compare package sizes on [Runtime Sizes](/runtimes/runtime-sizes/).
+## Comparison
 
-### `@rive-app/webgl2` (recommended)
+| | `@rive-app/canvas` | `@rive-app/webgl2` |
+| --- | --- | --- |
+| Draws with | The browser's [Canvas2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) API | The [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content) on WebGL2 |
+| [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering) | ❌ Not yet supported; planned for a future release | ✅ Supported |
+| Blend modes | ✅ All blend modes, at no extra cost | 🟡 All blend modes, but anything other than **Normal** is expensive (see [Performance](#performance)) |
+| Graphics per page | ✅ No practical limit | 🟡 Bound by the browser's WebGL context limit (see [WebGL Context Limits](#webgl-context-limits)) |
+| Editor fidelity | 🟡 Matches for nearly all content (see [Fill Rules](#fill-rules)) | ✅ The same renderer the Rive Editor uses |
 
-Use `@rive-app/webgl2` if you want the best rendering quality and performance in most cases.
-
-```bash
-npm install @rive-app/webgl2
-```
-
-- Uses the [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content) for the best rendering performance
-- Supports Rive Renderer-only features (for example, vector feathering)
-
-<Note>
- WebGL has browser limits on concurrent contexts, which can limit how many `new Rive({...})` instances you can run at once. If you display many graphics on the same page, set `useOffscreenRenderer: true` for each Rive object.
- This moves rendering work to a shared offscreen WebGL context instead of creating as many separate contexts on visible canvases, which helps avoid context-limit issues and improves stability when many Rive instances are active.
-</Note>
-
-<Note>
-  Enabling the draft
-  [WEBGL_shader_pixel_local_storage](https://www.wikihow.tech/Enable-WebGL-Draft-Extensions-in-Google-Chrome)
-  extension in Chrome improves rendering performance. Without it, Rive falls
-  back to an MSAA-based WebGL2 path. We are actively working with browser
-  vendors to make this enabled by default.
-</Note>
-
-### `@rive-app/canvas`
-
-Use `@rive-app/canvas` when your graphics are less complex and you want a smaller runtime package.
+## `@rive-app/canvas`
 
 ```bash
 npm install @rive-app/canvas
 ```
 
-- Uses the browser's built-in [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) renderer
-- Smaller package size than the WebGL2 renderer option
-- Good for simpler vector/raster graphics
+Draws with [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API), the browser's built-in 2D API. Because browsers implement it natively, performance is predictable across desktop and mobile, and blend modes cost nothing extra.
 
-### More options after your runtime choice
+Use it when:
 
-For the canvas-based runtime option, you can alternatively use these variants based on packaging needs.
+- Your Rive graphics do not use Vector Feathering
+- You render many Rive graphics on one page
+- You want the smaller package
+- Consistent performance across a wide array of devices/browsers
 
-#### `@rive-app/canvas-lite` variant
+<Warning>
+  `@rive-app/canvas` does not draw [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering). Outer feathers draw with a hard edge, and inner feathers can draw as a solid fill. Use `@rive-app/webgl2` for files that use feathering.
+</Warning>
 
-The canvas version of our runtime supports a `-lite` variant for smaller package size.
+### Fill Rules
 
-- Example: [`@rive-app/canvas-lite`](https://www.npmjs.com/package/@rive-app/canvas-lite)
-- Use this package when you want the smallest runtime footprint
-- This package variant removes some features (for example, text, layout, audio, and scripting engines)
+Canvas2D offers the non-zero and even-odd [fill rules](/editor/fundamentals/fill-and-stroke#fill-rule), so Rive's clockwise fill rule draws as non-zero. The result is identical unless a path has self-intersecting, reversed, or overlapping contours. This applies to both fills and clipping paths.
 
-#### `@rive-app/canvas-single` variant
+## `@rive-app/webgl2`
 
-The canvas version of our runtime supports a `-single` variant, which bundles `rive.wasm` directly into the JavaScript file.
+```bash
+npm install @rive-app/webgl2
+```
 
-- Example: [`@rive-app/canvas-single`](https://www.npmjs.com/package/@rive-app/canvas-single)
-- Use this package if you want to avoid a separate WASM network request
-- Expect a larger JS bundle compared to the standard package
+Draws with the [Rive Renderer](https://rive.app/renderer?utm_source=docs&utm_medium=content) on WebGL2. This is the same renderer the Rive Editor uses, so what you see at edit time is what you get at runtime.
 
-### Deprecated package
+Use it when:
 
-`@rive-app/webgl` is deprecated and will no longer receive updates after `v2.37.0`. Prefer `@rive-app/webgl2`.
+- Your file uses [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering)
+- You need an exact match with the Editor for paths that self-intersect or overlap
+
+<Note>
+  If your file uses blend modes, measure on your target devices before committing to `@rive-app/webgl2`. See [Performance](#performance).
+</Note>
+
+### WebGL Context Limits
+
+Browsers cap how many WebGL contexts a page can hold at once. The exact number varies by browser and device, and the oldest context is typically dropped once the cap is reached — which limits how many `new Rive({...})` instances you can run.
+
+If you show several graphics on one page, set `useOffscreenRenderer: true` on each Rive object. Every instance then shares a single offscreen context instead of creating its own, which keeps you under the cap:
+
+```javascript
+const r = new rive.Rive({
+  src: "https://cdn.rive.app/animations/vehicles.riv",
+  canvas: document.getElementById("canvas"),
+  useOffscreenRenderer: true,
+});
+```
+
+This limit does not apply to `@rive-app/canvas`.
+
+## Performance
+
+The Rive Renderer gets its speed from GPU features that native graphics APIs like Metal and Vulkan expose today. For Rive on the web, those capabilities come from a WebGL extension, [`WEBGL_shader_pixel_local_storage`](https://www.khronos.org/registry/webgl/extensions/WEBGL_shader_pixel_local_storage/), which is still in draft. Rive is involved in the effort to standardize it across browsers, and we will update this guidance as support lands.
+
+Without it, `@rive-app/webgl2` falls back to a slower path (MSAA). Blend modes are where you may notice performance hits: anything other than **Normal** forces the renderer to re-read the frame as it draws, which adds up quickly on mobile. `@rive-app/canvas` has no equivalent cost, because Canvas2D blends natively.
+
+In practice:
+
+- If your file uses blend modes, and especially if you target mobile, use `@rive-app/canvas`.
+- Whichever you start with, measure on real devices. Swapping packages is a one-line change, so testing both is cheap.
+
+## Canvas Package Variants
+
+Two variants of the canvas package are available if you have specific bundling needs.
+
+### `@rive-app/canvas-lite`
+
+[`@rive-app/canvas-lite`](https://www.npmjs.com/package/@rive-app/canvas-lite) is the smallest Rive web package. It has the same API and renderer as `@rive-app/canvas`, but drops the text, layout, audio, and scripting engines to save space.
+
+Use it when your files do not rely on those features. If a file does use them, the affected content will not appear.
+
+### `@rive-app/canvas-single`
+
+[`@rive-app/canvas-single`](https://www.npmjs.com/package/@rive-app/canvas-single) bundles `rive.wasm` directly into the JavaScript file, so loading Rive takes one network request instead of two.
+
+Use it when you want to avoid a separate WASM request. The tradeoff is a larger JavaScript bundle.
+
+## Deprecated Package
+
+`@rive-app/webgl` is deprecated and receives no updates after `v2.37.0`. Move to `@rive-app/canvas`, or to `@rive-app/webgl2` if your file uses vector feathering. Neither move requires API changes — see the [migration guide](/runtimes/web/migration-guides).

--- a/runtimes/web/faq.mdx
+++ b/runtimes/web/faq.mdx
@@ -20,7 +20,7 @@ Read more on [what CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 
 Yes! You may notice that starting in `v2.0.0` of the web runtimes, the size of the `rive.wasm` file requested on the browser increased. This was due to including a new dependency in the WASM build for a text engine that supports the powerful and flexible [Rive Text](/editor/text/) feature.
 
-However, if you don't have a need to use the native Rive Text feature (or prefer to use imported SVG text), you can use the [@rive-app/canvas-lite](/runtimes/web/web-js#canvas-vs-webgl) which provides the same API and similar rendering capabilities as `@rive-app/canvas`, with a smaller package.
+However, if you don't have a need to use the native Rive Text feature (or prefer to use imported SVG text), audio, or scripting, you can use the [@rive-app/canvas-lite](/runtimes/web/canvas-vs-webgl#rive-app-canvas-lite) which provides the same API and similar rendering capabilities as `@rive-app/canvas`, with a smaller package.
 
 ### Why did the canvas width/height attribute values change?
 

--- a/runtimes/web/fonts.mdx
+++ b/runtimes/web/fonts.mdx
@@ -21,7 +21,7 @@ As of `v2.37.1`, the JS runtime provides an API for supplying fallback fonts. Wh
 To start, import the `RiveFont` named export from the JS package and call its static method `setFallbackFontCallback()`, passing in your callback. The callback receives the glyph that failed to render (as a Unicode code point) and the font weight, and should return a list of fallback fonts. It may be called multiple times if successive fallback fonts also lack support for the glyph.
 
 ```javascript
-import { RiveFont, decodeFont, Rive } from "@rive-app/webgl2";
+import { RiveFont, decodeFont, Rive } from "@rive-app/canvas";
 
 const THAI_FALLBACK_FONT_URL =
   "https://raw.githubusercontent.com/google/fonts/main/ofl/notoserifthai/NotoSerifThai%5Bwdth%2Cwght%5D.ttf";

--- a/runtimes/web/migration-guides.mdx
+++ b/runtimes/web/migration-guides.mdx
@@ -4,10 +4,12 @@ description: 'Migrating between major versions of the Apple runtime'
 ---
 
 <AccordionGroup>
-    <Accordion title={`Migrating from @rive-app/webgl to @rive-app/webgl2`}>
-        We highly recommend migrating to `@rive-app/webgl2` for the best rendering quality and performance in most cases. The `@rive-app/webgl` package is deprecated and no longer receives updates after `v2.37.0`.
+    <Accordion title={`Migrating from @rive-app/webgl`}>
+        The `@rive-app/webgl` package is deprecated and no longer receives updates after `v2.37.0`, so you should migrate off it.
 
-        The migration process involves updating your package installation and import statements to use `@rive-app/webgl2` instead of `@rive-app/webgl`. There are no breaking API changes, so your existing code should work with the new package without modification.
+        For most content, migrate to `@rive-app/canvas`. Choose `@rive-app/webgl2` if your content uses [Vector Feathering](/editor/fundamentals/fill-and-stroke#vector-feathering). See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for the full comparison.
+
+        Either way, the migration process is the same: update your package installation and import statements. There are no breaking API changes, so your existing code should work with the new package without modification.
 
         For example, if you were previously using:
 
@@ -22,14 +24,14 @@ description: 'Migrating between major versions of the Apple runtime'
         You can update this to:
 
         ```bash
-        npm install @rive-app/webgl2
+        npm install @rive-app/canvas
         ```
 
         ```typescript
-        import { Rive } from '@rive-app/webgl2';
+        import { Rive } from '@rive-app/canvas';
         ```
 
-        This change will allow you to take advantage of the improved rendering capabilities of the [Rive renderer](https://rive.app/renderer) while maintaining compatibility with your existing codebase.
+        Substitute `@rive-app/webgl2` in both places if your content uses Vector Feathering. Either package maintains compatibility with your existing codebase.
     </Accordion>
     <Accordion title="Migrating from v1 to v2">
         Starting in v2 of our Web (JS) runtimes, Rive will support Rive Text at runtime, which includes the following packages:
@@ -52,9 +54,9 @@ description: 'Migrating between major versions of the Apple runtime'
     <Accordion title="Migrating from rive.js">
        Previously, the web runtime would deploy to the [rive-js](https://www.npmjs.com/package/rive-js) package on npm. We have since moved away from this one-package model and into a place where you can import from several different packages based on your API/rendering-level needs.
 
-        - @rive-app/webgl2
         - @rive-app/canvas
         - @rive-app/canvas-advanced
+        - @rive-app/webgl2
 
         In addition to these new packages, there is a `@rive-app/canvas-single` package that has the WASM encoded in the JS. See [canvas vs webgl2](/runtimes/web/canvas-vs-webgl) for more details.
 
@@ -79,17 +81,17 @@ description: 'Migrating between major versions of the Apple runtime'
         You could replace this with:
 
         ```bash
-        npm i @rive-app/webgl2
+        npm i @rive-app/canvas
         ```
 
         ```typescript
-        import {Rive} from '@rive-app/webgl2';
+        import {Rive} from '@rive-app/canvas';
 
         const foo = new Rive({
         src: "https://cdn.rive.app/animations/vehicles.riv",
         });
         ```
 
-        Or, you can replace `@rive-app/webgl2` with any of the new package outputs for web runtime that suit your need.
+        Or, you can replace `@rive-app/canvas` with any of the new package outputs for web runtime that suit your need.
     </Accordion>
 </AccordionGroup>

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -14,23 +14,21 @@ import { Demos } from '/snippets/demos.jsx'
 
 This guide documents how to get started using the Rive web runtime library. The runtime is open source and available in this [GitHub repository](https://github.com/rive-app/rive-wasm). This library has a high-level JavaScript API (with TypeScript support) and a low-level API to load in Web Assembly (WASM) and control the rendering loop yourself. This runtime allows you to:
 
-- Quickly integrate Rive into all web applications (Webflow, WordPress, etc.)
-- Provides a base API to build other web-based Rive runtime wrappers (React, Svelte, etc.)
-- Support advanced use cases by controlling the render loop (web-based game engines)
+- Integrate Rive into any web application (Webflow, WordPress, etc.)
+- Build other web-based Rive runtime wrappers on top of a common base API (React, Svelte, etc.)
+- Support advanced use cases by controlling the render loop yourself (web-based game engines)
 
 ## Getting started
 
 Follow the steps below to integrate Rive into your web app.
 
-The following instructions describe using the `@rive-app/webgl2` package. Rive provides web-based packages like WebGL2, Canvas, and Lite versions.
-
-See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which package is the correct choice for your use case.
+These instructions use `@rive-app/canvas`, the package we recommend for most projects. Rive also publishes a WebGL2 package and smaller "lite" Canvas variants — see [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) to pick the right one. The packages share the same API surface, so you can switch to a different one easily if needed.
 
 <Steps>
   <Step title="Install the dependency">
     <Tip>
-      We recommend always using the [latest version](https://www.npmjs.com/package/@rive-app/webgl2) when possible. The versions listed below and in the examples may differ from the latest. You van find the latest
-      version on [npmjs](https://www.npmjs.com/package/@rive-app/webgl2?activeTab=versions).
+      We recommend always using the [latest version](https://www.npmjs.com/package/@rive-app/canvas) when possible. The versions listed below and in the examples may differ from the latest. You can find the latest
+      version on [npmjs](https://www.npmjs.com/package/@rive-app/canvas?activeTab=versions).
     </Tip>
     <Tabs>
       <Tab title="Script Tag">
@@ -38,7 +36,7 @@ See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which pack
 
         Add the following script tag to your web page to load v2 of the web runtime, which will get the latest patches/minor updates on major version 2:
         ```html
-        <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWebGL2}}"></script>
+        <script src="https://unpkg.com/@rive-app/canvas@{{versionMajorCanvas}}"></script>
         ```
         If you see a newer major version to upgrade to, ensure your code accounts for breaking changes in the migration guide
 
@@ -46,40 +44,40 @@ See [Canvas vs WebGL2](/runtimes/web/canvas-vs-webgl) for guidance on which pack
 
         Alternatively, pin to a specific version for more control over what is loaded in your app. As Rive's feature set grows, you'll want to manually update this version to a newer one to ensure best compatibility.
         ```html
-        <script src="https://unpkg.com/@rive-app/webgl2@{{versionWebGL2}}"></script>
+        <script src="https://unpkg.com/@rive-app/canvas@{{versionCanvas}}"></script>
         ```
 
         This will make a global `rive` object available, allowing you to access the Rive API via the `rive` entry point. Follow the next steps below.
       </Tab>
       <Tab title="Package Manager">
         ```bash npm
-        npm install @rive-app/webgl2
+        npm install @rive-app/canvas
         ```
 
         ```bash pnpm
-        pnpm add @rive-app/webgl2
+        pnpm add @rive-app/canvas
         ```
 
         ```bash yarn
-        yarn add @rive-app/webgl2
+        yarn add @rive-app/canvas
         ```
 
         ```bash bun
-        bun add @rive-app/webgl2
+        bun add @rive-app/canvas
         ```
 
         ```javascript Importing
         // Import the entire module under the global identifier `rive`
-        import * as rive from "@rive-app/webgl2";
+        import * as rive from "@rive-app/canvas";
 
         // Alternatively, import only the specific parts you need
-        import { Rive } from "@rive-app/webgl2";
+        import { Rive } from "@rive-app/canvas";
 
         ```
       </Tab>
     </Tabs>
     <Tip>
-      Not using [Rive Text](/editor/text/), [Rive Layouts](/editor/layouts/), [Rive Scripting](/scripting/), or [Rive Audio](/editor/events/audio-events)? Consider using [@rive-app/canvas-lite](/runtimes/web/canvas-vs-webgl#rive-app-webgl2-lite) instead, which is a smaller package variant of our canvas runtime.
+      Not using [Rive Text](/editor/text/), [Rive Layouts](/editor/layouts/), [Rive Scripting](/scripting/), or [Rive Audio](/editor/events/audio-events)? Consider using [@rive-app/canvas-lite](/runtimes/web/canvas-vs-webgl#rive-app-canvas-lite) instead, which is a smaller package variant of our canvas runtime.
     </Tip>
   </Step>
   <Step title="Create a Canvas">
@@ -154,14 +152,14 @@ Bringing it all together, here's how to load a Rive graphic in a single HTML fil
   <body>
     <canvas id="canvas" width="500" height="500"></canvas>
 
-    <script src="https://unpkg.com/@rive-app/webgl2@{{versionMajorWebGL2}}"></script>
+    <script src="https://unpkg.com/@rive-app/canvas@{{versionMajorCanvas}}"></script>
     <script>
       const r = new rive.Rive({
         src: "https://cdn.rive.app/animations/vehicles.riv",
         canvas: document.getElementById("canvas"),
         autoplay: true,
         autoBind: true,
-        // artboard: "Arboard", // Optional. If not supplied the default is selected
+        // artboard: "Artboard", // Optional. If not supplied the default is selected
         stateMachines: "bumpy",
         onLoad: () => {
           // Ensure the drawing surface matches the canvas size and device pixel ratio
@@ -195,10 +193,10 @@ Under the hood, Rive creates various low-level objects (such as artboard instanc
 
 Fortunately, the high-level JavaScript API simplifies this process. You don't need to track every object created during the Rive instance lifecycle. Instead, you can clean up all associated objects with a single method call.
 
-To clean up a Rive instance and free up resources, simply call the following method on your Rive instance:
+To clean up a Rive instance and free up resources, call the following method on your Rive instance:
 
 ```javascript
-const riveInstance = new Rive({...));
+const riveInstance = new Rive({...});
 ...
 // When ready to cleanup
 riveInstance.cleanup();

--- a/snippets/feature-support.jsx
+++ b/snippets/feature-support.jsx
@@ -28,11 +28,11 @@ export const FeatureSupportGroup = ({
 
     // Do not include legacy runtimes
     const runtimesInOrder = [
-        "webWebGL2",
         "webCanvas",
+        "webWebGL2",
         "webCanvasLite",
-        "reactWebGL2",
         "reactCanvas",
+        "reactWebGL2",
         "reactCanvasLite",
         "reactNative",
         "flutter",


### PR DESCRIPTION
- Move getting started guides to use canvas
- New pass at the canvas vs webgl page

TODO:
- Update codesandbox examples to use canvas