### PR TITLE
docs: add feature support line for global view models

### DIFF
--- a/feature-support.mdx
+++ b/feature-support.mdx
@@ -84,6 +84,7 @@ Differences may reflect:
 
 ### Features
 
+<FeatureSupportGroup feature="globalViewModels" />
 <FeatureSupportGroup feature="dataBindingFonts" />
 <FeatureSupportGroup feature="semantics">
   Accessibility voice over support with [Semantics](/editor/accessibility/semantics).

--- a/snippets/feature-support.jsx
+++ b/snippets/feature-support.jsx
@@ -53,6 +53,7 @@ export const FeatureSupportGroup = ({
     ]
 
     const featuresInOrder = [
+        "globalViewModels",
         "dataBindingFonts",
         "semantics",
         "scripting",
@@ -83,6 +84,27 @@ export const FeatureSupportGroup = ({
     ]
 
     const features = {
+        globalViewModels: {
+            title: "Global View Models",
+            runtimes: {
+                webCanvas: { supported: true, version: "2.39.2+" },
+                webCanvasLite: { supported: true, version: "2.39.2+" },
+                webWebGL: { supported: false, description: "Not supported" },
+                webWebGL2: { supported: true, version: "2.39.2+" },
+                reactCanvas: { supported: true, version: "4.31.0+" },
+                reactCanvasLite: { supported: true, version: "4.31.0+" },
+                reactWebGL: { supported: false, description: "Not supported" },
+                reactWebGL2: { supported: true, version: "4.31.0+" },
+                reactNative: { supported: false, description: "Coming soon" },
+                reactNativeLegacy: { supported: false, description: "Not supported" },
+                flutter: { supported: false, description: "Coming soon" },
+                apple: { supported: false, description: "Coming soon" },
+                android: { supported: false, description: "Coming soon" },
+                cpp: { supported: true, description: "Supported" },
+                unity: { supported: false, description: "Coming soon" },
+                unreal: { supported: false, description: "Coming soon" }
+            }
+        },
         dataBindingFonts: {
             title: "Data Binding Fonts",
             runtimes: {


### PR DESCRIPTION
Adding to our feature support page for global view models so it has its own line item.