### PR TITLE
docs(editor): refactor url embed and sharing

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -231,9 +231,9 @@
                 "group": "Publishing",
                 "pages": [
                   "editor/exporting/exporting-for-runtime",
+                  "editor/embed-urls/overview",
                   "editor/exporting/exporting-for-video-and-static-design",
-                  "editor/exporting/exporting-for-backup",
-                  "editor/embed-urls/overview"
+                  "editor/exporting/exporting-for-backup"
                 ]
               },
               {

--- a/editor/embed-urls/overview.mdx
+++ b/editor/embed-urls/overview.mdx
@@ -1,61 +1,59 @@
 ---
-title: 'Embed URLs Overview'
-sidebarTitle: 'Embed URLs'
-description: 'Embed URLs are a fast, no-code way to share or embed your Rive files on the web.'
+title: 'Sharing & Embedding'
+description: "Share your Rive files with a hosted link or embed them in websites and other platforms."
 ---
 
 <Note>Generating embed URLs is available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
-Embed URLs let you quickly generate a public version of your file for embedding or sharing.
+Embed URLs let you quickly generate a shareable version of your file for embedding or sharing.
 
-Unlike [inviting someone to collaborate](/account-admin/workspaces/managing-workspace-members#inviting-members-to-a-workspace), an embed URL is a **snapshot** of your file at the moment it’s generated. If you make changes later, you’ll need to generate a new link to reflect those updates.
+An embed URL is a **snapshot** of your file at the moment it’s generated. If you make changes later, you’ll need to generate a new link to reflect those updates.
 
-## Creating an embed URL
+<Note>
+  Embeds use iframes and don't provide access to Rive's runtime APIs. If you need to control or interact with your Rive programmatically, use a [Rive runtime](/runtimes/getting-started) instead.
+</Note>
+
+## Creating an Embed URL
 
 <Steps>
   <Step title="Open the Embed Link dialog">
-    In the Rive editor, click the **hamburger menu** in the top-left corner and select **Generate Embed URL**.
+    In the Rive editor, click the **main menu** in the top-left corner and select **Generate Embed URL**.
 
     ![Generate embed URL](/images/integrations/html-embed/generate-share-link-1.png)
   </Step>
   <Step title="Generate your link">
-    In the dialog that appears, click **Generate Embed URL**.
+    In the dialog that appears, choose the artboard and state machine or timeline animation to display, and click **Generate Link**.
 
     ![Generate embed URL](/images/integrations/html-embed/generate-share-link-2.png)
   </Step>
-  <Step title="Choose an embed URL type">
-    Once the link is generated, select the option that best fits how you plan to use your file.
+  <Step title="Set your options">
+    - **Enable** — Turn the link on or off to control access.
+    - **Rive Renderer** — Use the Rive Renderer (recommended) or Canvas renderer.
+    - **Multi-touch** — Enable support for multi-touch interactions.
+
+    <Note>Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content), are only available using the Rive Renderer. See our [Feature Support](/feature-support) page for more information.</Note>
+
+    ![Generate embed URL](/images/integrations/html-embed/generate-share-link-3.png)
+  </Step>
+  <Step title="Choose a link type">
+    Select the option that best fits how you plan to use your file.
 
     <Note>
       For more information on using embed URLs with tools like Framer, Webflow, and Notion, see [Integrations](/integrations/overview).
     </Note>
 
-    ![Generate embed URL](/images/integrations/html-embed/generate-share-link-3.png)
+    - **Hosted link** — Opens your file on a dedicated Rive page with a framed viewer. Ideal for sharing with clients or stakeholders.
+    - **Embed link** — Displays your file without the surrounding Rive UI. Useful for platforms that automatically preview links, such as Notion and Telegram.
+    - **Embed code** — An iframe snippet for embedding your file into sites where you can edit HTML, such as WordPress.
+    - **Framer code (Deprecated)** — See the new official [Rive Framer Plugin](https://www.framer.com/marketplace/plugins/rive/).
   </Step>
 </Steps>
-
-### Embed URL types
-
-- **Hosted link** — Opens your file on a dedicated Rive page with a framed viewer. Ideal for sharing with clients or stakeholders.
-- **Embed link** — Displays your file without the surrounding Rive UI. Useful for platforms that automatically preview links (e.g. Notion, Telegram).
-- **Embed code** — An iframe snippet for embedding your file into sites where you can edit HTML (e.g. WordPress).
-- **Framer code (Deprecated)** — See the new official [Rive Framer Plugin](https://www.framer.com/marketplace/plugins/rive/).
-
-### Embed URL options
-
-- **Enable** — Turn the link on or off to control access.
-- **Rive Renderer** — Use the Rive Renderer (recommended) or Canvas renderer.
-- **Multi-touch** — Enable support for multi-touch interactions.
-
-<Note>Certain features, such as [Vector Feathering](https://rive.app/blog/introducing-vector-feathering?utm_source=docs&utm_medium=content), are only available using the Rive Renderer. See our [Feature Support](/feature-support) page for more information.</Note>
 
 
 ## Sharing on Social Media
 
-1. Copy the **Hosted Link**
-2. Paste it into your favorite platform
-3. See your Rive creation unfurl when you post
+Copy the **Hosted Link** and paste it into a supported social platform. The link includes metadata that allows supported platforms to display a preview of your Rive file.
 
-## Managing embed URLs
+## Managing Embed URLs
 
-Visit the [Embed URLs](https://rive.app/account/links?utm_source=docs&utm_medium=content) section of your settings to manage the links you've generated. You can disable an embed URL by setting its Active toggle to off.
+Visit the [Embed URLs](https://rive.app/account/links?utm_source=docs&utm_medium=content) section of your settings to manage the links you've generated. You can disable an embed URL by turning off **Active**.

--- a/editor/embed-urls/overview.mdx
+++ b/editor/embed-urls/overview.mdx
@@ -16,7 +16,7 @@ An embed URL is a **snapshot** of your file at the moment it’s generated. If y
 ## Creating an Embed URL
 
 <Steps>
-  <Step title="Open the Embed Link dialog">
+  <Step title="Open the Embed URL dialog">
     In the Rive editor, click the **main menu** in the top-left corner and select **Generate Embed URL**.
 
     ![Generate embed URL](/images/integrations/html-embed/generate-share-link-1.png)

--- a/editor/exporting/exporting-for-video-and-static-design.mdx
+++ b/editor/exporting/exporting-for-video-and-static-design.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Exporting for Video or Static Design'
+title: 'Exporting Videos & Images'
 description: ''
 ---
 


### PR DESCRIPTION
1. Sharing & Embedding is a more clear title.
2. These are just iFrames. If you want more control, use a runtime. 
3. Move options into the steps, rather than listing them after. 
4. Minor wording changes. 
5. Move the sidebar link up the list based on what the user is most likely to need

Unrelated: 
- Update sidebar title to `Exporting Videos & Images` so it doesn't wrap in the sidebar

<img width="588" height="261" alt="CleanShot 2026-08-18 at 15 31 55" src="https://github.com/user-attachments/assets/8518d10a-57a3-4dc2-b55f-5385d17fae5e" />
