### PR TITLE
Update scripting API documentation

### DIFF
--- a/scripting/api-reference/gpu/bind-group-layout-desc.mdx
+++ b/scripting/api-reference/gpu/bind-group-layout-desc.mdx
@@ -14,6 +14,13 @@ metadata / native slots so callers don't have to know any of them.
 Source shader. Layouts cannot be built without one.
 
 
+### `fragment`
+
+Fragment Shader, when the pipeline this layout serves takes its two
+stages from different files. Its bindings and slots live only in its
+own map, so a layout built without it cannot resolve them.
+
+
 ### `groupIndex`
 
 WGSL `@group(N)` this layout describes. Valid range [0, 4).

--- a/scripting/api-reference/gpu/pipeline-stage.mdx
+++ b/scripting/api-reference/gpu/pipeline-stage.mdx
@@ -5,6 +5,12 @@ title: PipelineStage
 A pipeline stage: a Shader, or WebGPU-style `{ module = Shader,
 entryPoint = name }`. The Shader's `@vertex`/`@fragment` functions are the
 selectable entry points; omit `entryPoint` to use the first one of that
-stage (like WebGPU). Vertex and fragment may come from different Shaders.
+stage (like WebGPU).
+
+Vertex and fragment may come from different Shaders. Each file's bindings
+are numbered on its own, so on Vulkan, D3D12 and GL — which share one slot
+namespace between the stages — two files that declare different bindings
+can collide; `GPUPipeline.new` rejects that case naming both bindings.
+Declaring the same bindings in both files always works.
 
 


### PR DESCRIPTION
This PR updates the scripting API documentation generated from the rive repository.

Generated from commit: a156d37294489f3de1d02abe07dafcef58b9b37c
Repository: rive-app/rive
Workflow run: https://github.com/rive-app/rive/actions/runs/32416530679