### PR TITLE
fix(project): repair dead redirect destinations

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -956,7 +956,7 @@
     },
     {
       "source": "/editor/layouts/layouts-&-constraints",
-      "destination": "/editor/layouts"
+      "destination": "/editor/layouts/layouts-overview"
     },
     {
       "source": "/editor/fundamentals/nested-artboards",
@@ -968,23 +968,23 @@
     },
     {
       "source": "/runtimes/apple/migrating-from-1.x.x-to-2.x.x",
-      "destination": "/runtimes/apple/migrating"
+      "destination": "/runtimes/apple/migration-guides"
     },
     {
       "source": "/runtimes/apple/migrating-from-2.x.x-to-3.x.x",
-      "destination": "/runtimes/apple/migrating"
+      "destination": "/runtimes/apple/migration-guides"
     },
     {
       "source": "/runtimes/apple/migrating-from-3.x.x-to-4.x.x",
-      "destination": "/runtimes/apple/migrating"
+      "destination": "/runtimes/apple/migration-guides"
     },
     {
       "source": "/runtimes/apple/migrating-from-4.x.x-to-5.x.x",
-      "destination": "/runtimes/apple/migrating"
+      "destination": "/runtimes/apple/migration-guides"
     },
     {
       "source": "/runtimes/apple/migrating-from-5.x.x-to-6.x.x",
-      "destination": "/runtimes/apple/migrating"
+      "destination": "/runtimes/apple/migration-guides"
     },
     {
       "source": "/scripting/api-reference/animation",
@@ -1196,7 +1196,7 @@
     },
     {
       "source": "/scripting/api-reference/vector",
-      "destination": "/scripting/api-reference/vec2d/vector"
+      "destination": "/scripting/api-reference/vector/vector"
     },
     {
       "source": "/game-runtimes/unreal/using-events",
@@ -1207,7 +1207,7 @@
       "destination": "/runtimes/react/migration-guides#migrating-from-0-x-x-to-1-x-x"
     },
     {
-      "source": "runtimes/react/migrating-from-v1-to-v3",
+      "source": "/runtimes/react/migrating-from-v1-to-v3",
       "destination": "/runtimes/react/migration-guides#migrating-from-1-x-x-to-3-x-x"
     },
     {


### PR DESCRIPTION
Seven redirect rules in `docs.json` point at pages that don't exist, so they 404 instead of redirecting.

| source | was | now |
|---|---|---|
| `/editor/layouts/layouts-&-constraints` | `/editor/layouts` | `/editor/layouts/layouts-overview` |
| `/runtimes/apple/migrating-from-{1..5}.x.x` (5 rules) | `/runtimes/apple/migrating` | `/runtimes/apple/migration-guides` |
| `/scripting/api-reference/vector` | `/scripting/api-reference/vec2d/vector` | `/scripting/api-reference/vector/vector` |

`vec2d/vector` was itself only a redirect source, so that rule was a hop to a hop. Collapsed to the real page.

Also adds the missing leading slash on the `runtimes/react/migrating-from-v1-to-v3` source, the only rule in the file without one.

`mint broken-links` passes.