### PR TITLE
docs(editor): document interpolation shortcuts and Elastic easing

### DIFF
--- a/editor/animate-mode/interpolation-easing.mdx
+++ b/editor/animate-mode/interpolation-easing.mdx
@@ -21,21 +21,6 @@ The interpolation graph is a visual representation of how the value will change 
 
 You can choose which interpolation type to use by selecting any of the icons above the graph.
 
-Each type has a shortcut that applies it to the selected keys:
-
-| Interpolation | Shortcut |
-|---|---|
-| Hold | <kbd>F6</kbd> |
-| Linear | <kbd>F7</kbd> |
-| Ease In Out (Cubic) | <kbd>F8</kbd> |
-| Ease In (Cubic) | <kbd>Shift</kbd> + <kbd>F8</kbd> |
-| Ease Out (Cubic) | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> |
-| Ease In Out (Cubic Value) | <kbd>F9</kbd> |
-| Ease In (Cubic Value) | <kbd>Shift</kbd> + <kbd>F9</kbd> |
-| Ease Out (Cubic Value) | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> |
-| Elastic | <kbd>F10</kbd> |
-
-
 ### Linear
 
 ![Image](https://ucarecdn.com/992113a2-f03d-43be-9f22-d638fa48ba70/)

--- a/editor/animate-mode/interpolation-easing.mdx
+++ b/editor/animate-mode/interpolation-easing.mdx
@@ -21,6 +21,21 @@ The interpolation graph is a visual representation of how the value will change 
 
 You can choose which interpolation type to use by selecting any of the icons above the graph.
 
+Each type also has a shortcut that applies it to the selected keys:
+
+| Interpolation | Shortcut |
+|---|---|
+| Hold | <kbd>F6</kbd> |
+| Linear | <kbd>F7</kbd> |
+| Cubic — Ease In Out | <kbd>F8</kbd> |
+| Cubic — Ease In | <kbd>Shift</kbd> + <kbd>F8</kbd> |
+| Cubic — Ease Out | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> |
+| Cubic Value — Ease In Out | <kbd>F9</kbd> |
+| Cubic Value — Ease In | <kbd>Shift</kbd> + <kbd>F9</kbd> |
+| Cubic Value — Ease Out | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> |
+| Elastic | <kbd>F10</kbd> |
+
+
 ### Linear
 
 ![Image](https://ucarecdn.com/992113a2-f03d-43be-9f22-d638fa48ba70/)
@@ -42,6 +57,10 @@ The default cubic curve creates a gentle curve from the first key to the next, w
 ![Image](https://ucarecdn.com/39d5d86c-d390-4500-acdb-ad57d3e89539/)
 
 Hold doesn't interpolate values between keys. It simply holds the current value until the next key is reached, where the next value is set instantly.
+
+### Elastic
+
+Elastic easing overshoots the target value and oscillates before settling on it, for springy and bouncing motion. It exposes an easing curve alongside **Amplitude**, which controls how far the overshoot travels, and **Period**, which controls how quickly the oscillation settles.
 
 ### Interpolation field
 

--- a/editor/animate-mode/interpolation-easing.mdx
+++ b/editor/animate-mode/interpolation-easing.mdx
@@ -21,7 +21,7 @@ The interpolation graph is a visual representation of how the value will change 
 
 You can choose which interpolation type to use by selecting any of the icons above the graph.
 
-Each type also has a shortcut that applies it to the selected keys:
+Each type has a shortcut that applies it to the selected keys:
 
 | Interpolation | Shortcut |
 |---|---|
@@ -60,7 +60,7 @@ Hold doesn't interpolate values between keys. It simply holds the current value 
 
 ### Elastic
 
-Elastic easing overshoots the target value and oscillates before settling on it, for springy and bouncing motion. It exposes an easing curve alongside **Amplitude**, which controls how far the overshoot travels, and **Period**, which controls how quickly the oscillation settles.
+Elastic overshoots the value and oscillates before settling on it. **Amplitude** controls how far it overshoots, and **Period** controls how quickly it settles.
 
 ### Interpolation field
 

--- a/editor/animate-mode/interpolation-easing.mdx
+++ b/editor/animate-mode/interpolation-easing.mdx
@@ -27,12 +27,12 @@ Each type has a shortcut that applies it to the selected keys:
 |---|---|
 | Hold | <kbd>F6</kbd> |
 | Linear | <kbd>F7</kbd> |
-| Cubic — Ease In Out | <kbd>F8</kbd> |
-| Cubic — Ease In | <kbd>Shift</kbd> + <kbd>F8</kbd> |
-| Cubic — Ease Out | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> |
-| Cubic Value — Ease In Out | <kbd>F9</kbd> |
-| Cubic Value — Ease In | <kbd>Shift</kbd> + <kbd>F9</kbd> |
-| Cubic Value — Ease Out | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> |
+| Ease In Out (Cubic) | <kbd>F8</kbd> |
+| Ease In (Cubic) | <kbd>Shift</kbd> + <kbd>F8</kbd> |
+| Ease Out (Cubic) | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F8</kbd> |
+| Ease In Out (Cubic Value) | <kbd>F9</kbd> |
+| Ease In (Cubic Value) | <kbd>Shift</kbd> + <kbd>F9</kbd> |
+| Ease Out (Cubic Value) | macOS: <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> Windows: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F9</kbd> |
 | Elastic | <kbd>F10</kbd> |
 
 


### PR DESCRIPTION
Two things missing from this page, both shipping.

**Shortcuts.** Each interpolation type has an F-key that applies it to the selected keys (F6 Hold, F7 Linear, F8 family Cubic, F9 family Cubic Value, F10 Elastic). Not documented here or on the keyboard shortcuts page. Added as a table under the panel section.

**Elastic.** The panel ships five types — Hold, Linear, Cubic, Cubic Value, Elastic — and Elastic was the only one without a section. Added one covering the overshoot and the Amplitude and Period controls.

Handlers verified ungated in `keyframe_manager.dart`. Scripted interpolators are excluded, still behind `ENABLE_SCRIPTED_INTERPOLATORS` (`prod: enabledForEveryone: false`).

`mint broken-links` passes.