### PR TITLE
docs(scripting): list the permitted values on enum reference pages

### DIFF
--- a/scripting/api-reference/artboards/gamepad-mapping-kind.mdx
+++ b/scripting/api-reference/artboards/gamepad-mapping-kind.mdx
@@ -2,3 +2,5 @@
 title: GamepadMappingKind
 ---
 
+* `standard`
+* `unknown`

--- a/scripting/api-reference/gpu/blend-factor.mdx
+++ b/scripting/api-reference/gpu/blend-factor.mdx
@@ -4,4 +4,16 @@ title: BlendFactor
 
 Blend factor for src/dst color and alpha (WebGPU canonical strings).
 
-
+* `zero`
+* `one`
+* `src`
+* `one-minus-src`
+* `src-alpha`
+* `one-minus-src-alpha`
+* `dst`
+* `one-minus-dst`
+* `dst-alpha`
+* `one-minus-dst-alpha`
+* `src-alpha-saturated`
+* `constant`
+* `one-minus-constant`

--- a/scripting/api-reference/gpu/blend-op.mdx
+++ b/scripting/api-reference/gpu/blend-op.mdx
@@ -4,4 +4,8 @@ title: BlendOp
 
 Blend equation operator.
 
-
+* `add`
+* `subtract`
+* `reverse-subtract`
+* `min`
+* `max`

--- a/scripting/api-reference/gpu/buffer-usage.mdx
+++ b/scripting/api-reference/gpu/buffer-usage.mdx
@@ -4,4 +4,6 @@ title: BufferUsage
 
 How a GPU buffer will be used. Pass to `GPUBuffer.new`.
 
-
+* `vertex`
+* `index`
+* `uniform`

--- a/scripting/api-reference/gpu/compare-function.mdx
+++ b/scripting/api-reference/gpu/compare-function.mdx
@@ -4,4 +4,11 @@ title: CompareFunction
 
 Depth comparison function for pipeline depth-stencil state and shadow samplers.
 
-
+* `never`
+* `less`
+* `equal`
+* `less-equal`
+* `greater`
+* `not-equal`
+* `greater-equal`
+* `always`

--- a/scripting/api-reference/gpu/cull-mode.mdx
+++ b/scripting/api-reference/gpu/cull-mode.mdx
@@ -4,4 +4,6 @@ title: CullMode
 
 Triangle face culling mode.
 
-
+* `none`
+* `front`
+* `back`

--- a/scripting/api-reference/gpu/filter.mdx
+++ b/scripting/api-reference/gpu/filter.mdx
@@ -4,4 +4,5 @@ title: Filter
 
 Texture filtering mode.
 
-
+* `nearest`
+* `linear`

--- a/scripting/api-reference/gpu/primitive-topology.mdx
+++ b/scripting/api-reference/gpu/primitive-topology.mdx
@@ -4,4 +4,8 @@ title: PrimitiveTopology
 
 GPU primitive assembly topology.
 
-
+* `triangle-list`
+* `triangle-strip`
+* `line-list`
+* `line-strip`
+* `point-list`

--- a/scripting/api-reference/gpu/texture-aspect.mdx
+++ b/scripting/api-reference/gpu/texture-aspect.mdx
@@ -5,4 +5,6 @@ title: TextureAspect
 Which planes of a depth/stencil texture a view exposes.
 Use 'depth-only' for depth textures sampled as texture_depth_2d in WGSL.
 
-
+* `all`
+* `depth-only`
+* `stencil-only`

--- a/scripting/api-reference/gpu/texture-type.mdx
+++ b/scripting/api-reference/gpu/texture-type.mdx
@@ -4,4 +4,7 @@ title: TextureType
 
 Texture dimensionality (WebGPU canonical strings).
 
-
+* `2d`
+* `cube`
+* `3d`
+* `2d-array`

--- a/scripting/api-reference/gpu/vertex-format.mdx
+++ b/scripting/api-reference/gpu/vertex-format.mdx
@@ -4,4 +4,12 @@ title: VertexFormat
 
 Per-vertex attribute format (WebGPU canonical strings).
 
-
+* `float32`
+* `float32x2`
+* `float32x3`
+* `float32x4`
+* `uint8x4`
+* `unorm8x4`
+* `snorm8x4`
+* `float16x2`
+* `float16x4`

--- a/scripting/api-reference/gpu/wrap-mode.mdx
+++ b/scripting/api-reference/gpu/wrap-mode.mdx
@@ -4,4 +4,6 @@ title: WrapMode
 
 Texture address / wrap mode.
 
-
+* `repeat`
+* `mirror-repeat`
+* `clamp-to-edge`


### PR DESCRIPTION
Twelve string-union types have reference pages carrying the description but not the values. These types accept nothing except those exact strings, so the pages don't say what to pass.

`BlendFactor` is the clearest case. The whole page:

```
Blend factor for src/dst color and alpha (WebGPU canonical strings).
```

13 permitted values, none listed. Same for `BlendOp`, `BufferUsage`, `CompareFunction`, `CullMode`, `Filter`, `GamepadMappingKind`, `PrimitiveTopology`, `TextureType`, `VertexFormat`, and `WrapMode`. `TextureAspect` mentions `depth-only` in prose but never lists `all` or `stencil-only`.

Values and order come from the Luau declarations in `scripting_workspace` builtins, in the bullet style already used by `StrokeCap`, `StrokeJoin`, and `PaintStyle`.

Descriptions are untouched. `GamepadMappingKind` still has none, matching the absent doc comment upstream.

`mint broken-links` passes.