### PR TITLE
docs(scripting): match protocol names to the Editor and list the missing ones

### DIFF
--- a/scripting/debugging/unit-testing.mdx
+++ b/scripting/debugging/unit-testing.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Unit Testing"
-description: "Write and run unit tests for your Blank Scripts using Test scripts."
+description: "Write and run unit tests for your helper functions using Test scripts."
 ---
 import { Demos } from '/snippets/demos.jsx'
 
-Test scripts let you write unit tests for your [Blank Scripts](/scripting/protocols/util-scripts) and run them directly in the Rive editor.
+Test scripts let you write unit tests for your helper functions (see [Blank Scripts](/scripting/protocols/util-scripts)) and run them directly in the Rive editor.
 Use them to verify math helpers, string utilities, or any other pure logic your scripts depend on.
 
 Beyond validating your code, tests also serve as precise instructions for the [AI Agent](/editor/ai-agent), helping it produce code that behaves exactly as you intend.

--- a/scripting/debugging/unit-testing.mdx
+++ b/scripting/debugging/unit-testing.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Unit Testing"
-description: "Write and run unit tests for your Util Scripts using Test scripts."
+description: "Write and run unit tests for your Blank Scripts using Test scripts."
 ---
 import { Demos } from '/snippets/demos.jsx'
 
-Test scripts let you write unit tests for your [Util Scripts](/scripting/protocols/util-scripts) and run them directly in the Rive editor.
+Test scripts let you write unit tests for your [Blank Scripts](/scripting/protocols/util-scripts) and run them directly in the Rive editor.
 Use them to verify math helpers, string utilities, or any other pure logic your scripts depend on.
 
 Beyond validating your code, tests also serve as precise instructions for the [AI Agent](/editor/ai-agent), helping it produce code that behaves exactly as you intend.
@@ -32,7 +32,7 @@ Inside a case, the `expect` function is passed as an argument to your test callb
 ### Example
 
 ```lua
--- Load the Util that you want to create tests for
+-- Load the script that you want to create tests for
 local MyUtil = require('MyUtil')
 
 function setup(test: Tester)

--- a/scripting/protocols/listener-action-scripts.mdx
+++ b/scripting/protocols/listener-action-scripts.mdx
@@ -10,7 +10,7 @@ Use Listener Action Scripts when you need to perform side effects—such as upda
 
 ## Creating a Listener Action Script
 
-[Create a new script](/scripting/creating-scripts) and select **Listener Action Script** as the type.
+[Create a new script](/scripting/creating-scripts) and select **Listener Action** as the type.
 
 ## Anatomy of a Listener Action
 

--- a/scripting/protocols/listener-action-scripts.mdx
+++ b/scripting/protocols/listener-action-scripts.mdx
@@ -10,7 +10,7 @@ Use Listener Action Scripts when you need to perform side effects—such as upda
 
 ## Creating a Listener Action Script
 
-[Create a new script](/scripting/creating-scripts) and select **Listener Action** as the type.
+[Create a new script](/scripting/creating-scripts) and select **Listener Action Script** as the type.
 
 ## Anatomy of a Listener Action
 

--- a/scripting/protocols/overview.mdx
+++ b/scripting/protocols/overview.mdx
@@ -14,10 +14,10 @@ Rive currently ships with the following protocols, with more to come:
 - [Path Effect](/scripting/protocols/path-effect-scripts) - Create custom path effects.
 - [Transition Conditions](/scripting/protocols/transition-condition-scripts) - Create custom state machine transition conditions.
 - [Listener Actions](/scripting/protocols/listener-action-scripts) - React to state machine listeners.
-- [Blank](/scripting/protocols/util-scripts) - Share helper logic across your other scripts.
+- [Blank](/scripting/protocols/util-scripts) - Share helper logic across scripts.
 - [Test](/scripting/protocols/test-scripts) - Unit test your functions.
-- **File Format** - Read and write your own binary file format inside the Editor.
-- **Text File Format** - Read and write a text-based format, and drive the Editor's text intelligence for it.
+- **File Format** - Read and write a binary file format.
+- **Text File Format** - Read and write a text file format.
 
 Each protocol represents a different kind of script the Editor can generate: a converter that shapes data, a custom drawing function, a layout helper, a testing harness, a path effect you can attach to strokes, and so on.
 

--- a/scripting/protocols/overview.mdx
+++ b/scripting/protocols/overview.mdx
@@ -14,7 +14,10 @@ Rive currently ships with the following protocols, with more to come:
 - [Path Effect](/scripting/protocols/path-effect-scripts) - Create custom path effects.
 - [Transition Conditions](/scripting/protocols/transition-condition-scripts) - Create custom state machine transition conditions.
 - [Listener Actions](/scripting/protocols/listener-action-scripts) - React to state machine listeners.
+- [Blank](/scripting/protocols/util-scripts) - Share helper logic across your other scripts.
 - [Test](/scripting/protocols/test-scripts) - Unit test your functions.
+- **File Format** - Read and write your own binary file format inside the Editor.
+- **Text File Format** - Read and write a text-based format, and drive the Editor's text intelligence for it.
 
 Each protocol represents a different kind of script the Editor can generate: a converter that shapes data, a custom drawing function, a layout helper, a testing harness, a path effect you can attach to strokes, and so on.
 

--- a/scripting/protocols/transition-condition-scripts.mdx
+++ b/scripting/protocols/transition-condition-scripts.mdx
@@ -7,7 +7,7 @@ description: "Create custom state machine transitions using scripts"
 
 ## Creating a Transition Condition Script
 
-[Create a new script](/scripting/creating-scripts) and select **Transition Condition Script** as the type.
+[Create a new script](/scripting/creating-scripts) and select **Transition Condition** as the type.
 
 ## Anatomy of a Transition Condition
 

--- a/scripting/protocols/util-scripts.mdx
+++ b/scripting/protocols/util-scripts.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Util Scripts"
+title: "Blank Scripts"
 description: "Create helper modules to organize shared logic across your scripts."
 ---
 
-Util scripts let you organize your code into small, focused modules that can be reused across multiple scripts.
+Blank scripts let you organize your code into small, focused modules that can be reused across multiple scripts.
 They’re ideal for math helpers, geometry utilities, color functions, or any logic that should be broken out into its own script.
 
-## Creating a Util Script
+## Creating a Blank Script
 
 [Create a new script](/scripting/creating-scripts) and select **Blank** as the type.
 
@@ -33,9 +33,9 @@ print(result) -- 5
 
 ```
 
-## Utils with Custom Types
+## Blank Scripts with Custom Types
 
-Custom types defined in your Util scripts will automatically be accessible
+Custom types defined in your Blank scripts will automatically be accessible
 in the parent script.
 
 ```lua

--- a/scripting/protocols/util-scripts.mdx
+++ b/scripting/protocols/util-scripts.mdx
@@ -8,7 +8,7 @@ They’re ideal for math helpers, geometry utilities, color functions, or any lo
 
 ## Creating a Util Script
 
-[Create a new script](/scripting/creating-scripts) and select **Util** as the type.
+[Create a new script](/scripting/creating-scripts) and select **Blank** as the type.
 
 ```lua
 --- Example helper function.


### PR DESCRIPTION
Checked the protocols overview and each protocol page against `ScriptProtocol` and the labels the type picker renders.

### Names that don't match the picker

| Docs say | Picker shows |
|---|---|
| **Util** | **Blank** |
| **Listener Action Script** | **Listener Action** |
| **Transition Condition Script** | **Transition Condition** |

"Util" doesn't appear anywhere in the editor. The label comes from `ScriptProtocol.utility.label`, which is `'Blank'`, so someone following the page looks for a menu entry that isn't there.

### Missing from the overview list

The list had 7 of the 10 protocols available today:

- **Blank** — already has a page and a sidebar entry, just not in this list
- **File Format** — undocumented
- **Text File Format** — undocumented

Both file format protocols get a one-line entry rather than a page, since neither has one yet. Verified user-reachable: the create menu renders every `availableProtocols()` entry by `type.label`.

Interpolator is excluded, still behind `ENABLE_SCRIPTED_INTERPOLATORS` (`prod: enabledForEveryone: false`). `availableProtocols()` filters exactly that one flag and nothing else.

`mint broken-links` passes.