### PR TITLE
docs(scripting): add VertexBuffer and TriangleBuffer reference pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -485,6 +485,13 @@
                 ]
               },
               {
+                "group": "Mesh",
+                "pages": [
+                  "scripting/api-reference/mesh/vertex-buffer",
+                  "scripting/api-reference/mesh/triangle-buffer"
+                ]
+              },
+              {
                 "group": "Paint",
                 "pages": [
                   "scripting/api-reference/paint/paint",
@@ -504,13 +511,6 @@
                   "scripting/api-reference/path/path-command",
                   "scripting/api-reference/path/path-data",
                   "scripting/api-reference/path/path-measure"
-                ]
-              },
-              {
-                "group": "Mesh",
-                "pages": [
-                  "scripting/api-reference/mesh/vertex-buffer",
-                  "scripting/api-reference/mesh/triangle-buffer"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -507,6 +507,13 @@
                 ]
               },
               {
+                "group": "Mesh",
+                "pages": [
+                  "scripting/api-reference/mesh/vertex-buffer",
+                  "scripting/api-reference/mesh/triangle-buffer"
+                ]
+              },
+              {
                 "group": "Promise",
                 "pages": [
                   "scripting/api-reference/promise/promise"

--- a/scripting/api-reference/mesh/triangle-buffer.mdx
+++ b/scripting/api-reference/mesh/triangle-buffer.mdx
@@ -1,0 +1,42 @@
+---
+title: TriangleBuffer
+---
+
+Stores triangle index data for use with image meshes.
+
+Create one by calling `TriangleBuffer()`.
+
+```lua
+local tb = TriangleBuffer()
+```
+
+## Fields
+
+### `add`
+
+<div class="signature">
+```lua
+add(v1: number, v2: number, v3: number) -> ()
+```
+</div>
+
+Adds a triangle defined by the three vertex indices `v1`, `v2`, and `v3`.
+```lua
+local tb = TriangleBuffer()
+tb:add(1, 2, 3)
+```
+
+
+### `reset`
+
+<div class="signature">
+```lua
+reset() -> ()
+```
+</div>
+
+Clears all triangle indices from the buffer.
+```lua
+local tb = TriangleBuffer()
+tb:reset()
+```

--- a/scripting/api-reference/mesh/triangle-buffer.mdx
+++ b/scripting/api-reference/mesh/triangle-buffer.mdx
@@ -3,17 +3,16 @@ title: TriangleBuffer
 ---
 
 Stores triangle index data for use with image meshes.
-
-Create one by calling `TriangleBuffer()`.
-
 ```lua
 local tb = TriangleBuffer()
 ```
 
-## Fields
+
+## Methods
 
 ### `add`
 
+{/* function add(self, v1: number, v2: number, v3: number): () */}
 <div class="signature">
 ```lua
 add(v1: number, v2: number, v3: number) -> ()
@@ -29,6 +28,7 @@ tb:add(1, 2, 3)
 
 ### `reset`
 
+{/* function reset(self): () */}
 <div class="signature">
 ```lua
 reset() -> ()

--- a/scripting/api-reference/mesh/vertex-buffer.mdx
+++ b/scripting/api-reference/mesh/vertex-buffer.mdx
@@ -3,17 +3,16 @@ title: VertexBuffer
 ---
 
 Stores a list of 2D vertex positions for use with image meshes.
-
-Create one by calling `VertexBuffer()`.
-
 ```lua
 local vb = VertexBuffer()
 ```
 
-## Fields
+
+## Methods
 
 ### `add`
 
+{/* function add(self, ...Vector): () */}
 <div class="signature">
 ```lua
 add(...Vector) -> ()
@@ -29,6 +28,7 @@ vb:add(Vector.xy(0, 0), Vector.xy(1, 0), Vector.xy(1, 1))
 
 ### `reset`
 
+{/* function reset(self): () */}
 <div class="signature">
 ```lua
 reset() -> ()

--- a/scripting/api-reference/mesh/vertex-buffer.mdx
+++ b/scripting/api-reference/mesh/vertex-buffer.mdx
@@ -1,0 +1,42 @@
+---
+title: VertexBuffer
+---
+
+Stores a list of 2D vertex positions for use with image meshes.
+
+Create one by calling `VertexBuffer()`.
+
+```lua
+local vb = VertexBuffer()
+```
+
+## Fields
+
+### `add`
+
+<div class="signature">
+```lua
+add(...Vector) -> ()
+```
+</div>
+
+Adds one or more vertices to the buffer.
+```lua
+local vb = VertexBuffer()
+vb:add(Vector.xy(0, 0), Vector.xy(1, 0), Vector.xy(1, 1))
+```
+
+
+### `reset`
+
+<div class="signature">
+```lua
+reset() -> ()
+```
+</div>
+
+Clears all vertices from the buffer.
+```lua
+local vb = VertexBuffer()
+vb:reset()
+```

--- a/scripting/api-reference/renderer/renderer.mdx
+++ b/scripting/api-reference/renderer/renderer.mdx
@@ -80,7 +80,7 @@ drawImageMesh(image: Image, sampler: ImageSampler, vertices: VertexBuffer, uvs: 
 </div>
 
 Draws an image using mesh data defined by [VertexBuffer](/scripting/api-reference/mesh/vertex-buffer) vertices and texture
-coordinates, and [TriangleBuffer](/scripting/api-reference/mesh/triangle-buffer) triangle indices.
+coordinates, and [TriangleBuffer](/scripting/api-reference/mesh/triangle-buffer) indices.
 
 Check out [Scripting demos](https://rive.app/docs/scripting/demos) to see a working example.
 ```lua

--- a/scripting/api-reference/renderer/renderer.mdx
+++ b/scripting/api-reference/renderer/renderer.mdx
@@ -79,8 +79,8 @@ drawImageMesh(image: Image, sampler: ImageSampler, vertices: VertexBuffer, uvs: 
 ```
 </div>
 
-Draws an image using mesh data defined by vertices, texture
-coordinates, and triangle indices.
+Draws an image using mesh data defined by [VertexBuffer](/scripting/api-reference/mesh/vertex-buffer) vertices and texture
+coordinates, and [TriangleBuffer](/scripting/api-reference/mesh/triangle-buffer) triangle indices.
 
 Check out [Scripting demos](https://rive.app/docs/scripting/demos) to see a working example.
 ```lua


### PR DESCRIPTION
`Renderer.drawImageMesh` takes `VertexBuffer` and `TriangleBuffer`:

```lua
drawImageMesh(image: Image, sampler: ImageSampler, vertices: VertexBuffer, uvs: VertexBuffer, triangles: TriangleBuffer, blendMode: BlendMode, opacity: number) -> ()
```

Neither type had a page, so the signature named types you couldn't look up. Every other Renderer method links its parameter types: `drawPath` links Path and Paint, `drawImage` links Image, ImageSampler, and BlendMode.

Adds a page for each with their `add` and `reset` methods, a Mesh group in the sidebar, and links from the `drawImageMesh` description.

Content comes from the Luau declarations in `scripting_workspace` builtins. Page structure follows the existing reference pages: `## Methods`, the `{/* */}` signature comment above each signature block, and a code block rather than constructor prose, matching ImageSampler, which is constructed the same way.

`mint broken-links` passes.