### PR TITLE
docs(scripting): document Context.log

### DIFF
--- a/scripting/api-reference/interfaces/context.mdx
+++ b/scripting/api-reference/interfaces/context.mdx
@@ -11,6 +11,24 @@ It serves as a bridge between your script and the Rive runtime, giving you acces
 
 ## Methods
 
+### `log`
+
+{/* function log(message: string): () */}
+<div class="signature">
+```lua
+log(message: string) -> ()
+```
+</div>
+
+Logs a message through the host: the CLI watch log and problems surface, the editor console. Available on both script backends.
+```lua
+function init(self: MyNode, context: Context): boolean
+    context.log('hello')
+    return true
+end
+```
+
+
 ### `markNeedsUpdate`
 
 {/* function markNeedsUpdate(self): () */}


### PR DESCRIPTION
The Context page documents 14 methods but not `log`, which is how a script produces output: the CLI watch log and problems surface, and the editor console.

It comes first in the `Context` declaration, so it's added in that position, with the description and example taken from the source doc comment.

`mint broken-links` passes.