### PR TITLE
docs(js/react): add deprecation docs for various parameters in the high-level JS/React runtime and use new stateMachine param in examples

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -27,7 +27,7 @@
     "pricingVoyagerYearly": "$304",
     "pricingEnterpriseYearly": "$1,440",
     "versionMajorWebGL2": "2",
-    "versionWebGL2": "2.40.0",
+    "versionWebGL2": "2.41.0",
     "supportForm": "https://forms.rive.app/support?utm_medium=support_page",
     "supportFormEducational": "https://forms.rive.app/education?utm_medium=support_page"
   },

--- a/runtimes/react/artboards.mdx
+++ b/runtimes/react/artboards.mdx
@@ -12,7 +12,11 @@ import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboar
 
 ```javascript
 export const Simple = () => (
-  <Rive src="https://cdn.rive.app/animations/vehicles.riv" artboard="Truck" />
+  <Rive
+    src="https://cdn.rive.app/animations/vehicles.riv"
+    artboard="Truck"
+    stateMachine="bumpy"
+  />
 );
 
 // With `useRive` Hook:
@@ -20,6 +24,7 @@ export default function Simple() {
   const { RiveComponent } = useRive({
       src: 'https://cdn.rive.app/animations/vehicles.riv',
       artboard: 'Truck',
+      stateMachine: 'bumpy',
       autoplay: true,
   });
 

--- a/runtimes/react/best-practices.mdx
+++ b/runtimes/react/best-practices.mdx
@@ -21,7 +21,7 @@ Rive creates an instance when the component mounts, and that instance is tied to
 function RiveAnimation() {
   const { RiveComponent } = useRive({
     src: '/animation.riv',
-    stateMachines: 'State Machine 1',
+    stateMachine: 'State Machine 1',
   });
 
   return <RiveComponent />;

--- a/runtimes/react/data-binding.mdx
+++ b/runtimes/react/data-binding.mdx
@@ -134,7 +134,7 @@ import { useRive, ViewModel, ViewModelInstance } from '@rive-app/react-webgl2';
 
 const { RiveComponent } = useRive({
     src: 'your_file.riv',
-    stateMachines: 'MyStateMachine',
+    stateMachine: 'MyStateMachine',
     autoplay: true,
     autoBind: false, // Set up the instances yourself before the first frame
     onRiveReady: (rive) => {
@@ -184,7 +184,7 @@ import {
 
 const { rive, RiveComponent } = useRive({
     src: 'your_file.riv',
-    stateMachines: 'State Machine 1',
+    stateMachine: 'State Machine 1',
     autoBind: false,
 });
 

--- a/runtimes/react/fonts.mdx
+++ b/runtimes/react/fonts.mdx
@@ -52,7 +52,7 @@ export default function MyRiveComponent() {
   const { RiveComponent } = useRive({
     src: "my.riv",
     autoplay: true,
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
   });
 
   return <RiveComponent />;

--- a/runtimes/react/layouts.mdx
+++ b/runtimes/react/layouts.mdx
@@ -29,6 +29,8 @@ import Rive, { Layout, Fit, Alignment } from '@rive-app/react-canvas';
 export const Simple = () => (
   <Rive
     src="https://cdn.rive.app/animations/vehicles.riv"
+    artboard="Truck"
+    stateMachine="bumpy"
     layout={new Layout({ fit: Fit.Contain, alignment: Alignment.TopCenter })}
   />
 );
@@ -43,7 +45,7 @@ export default function Example() {
   const { RiveComponent } = useRive({
     src: 'my-file.riv',
     artboard: 'my-artboard',
-    animations: 'my-animation',
+    stateMachine: 'my-state-machine',
     layout: new Layout({
       fit: Fit.Cover,
       alignment: Alignment.TopCenter,
@@ -70,7 +72,7 @@ import { useRive, Layout, Fit } from "@rive-app/react-canvas";
 export const RiveComponent = () => {
   const { RiveComponent } = useRive({
     src: "your-rive-file.riv",
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     layout: new Layout({
       fit: Fit.Layout,
       // layoutScaleFactor: 2, // Optional: 2x scale of the layout

--- a/runtimes/react/parameters-and-return-values.mdx
+++ b/runtimes/react/parameters-and-return-values.mdx
@@ -57,9 +57,7 @@ The following parameters are specific to `useRive`:
 ### useStateMachineInput
 
 <Warning>
-**Deprecated**
-
-State machine inputs are deprecated. For new work, use [Data Binding](/runtimes/web/data-binding). This hook remains available for legacy projects.
+  **Deprecated in `v4.33.0`.** The hook still works and nothing has been removed, but state machine inputs will be removed in a future major version. Use [data binding](/runtimes/react/data-binding) for new work — see the [migration guide](/editor/data-binding/migration-guide#state-machine-inputs).
 </Warning>
 
 The `useStateMachineInput` hook can be used to grab references to Rive State Machine inputs, both for reading input values, and setting (or triggering) them. See below for parameters to pass in and the return value.
@@ -145,6 +143,41 @@ The main benefit of this hook is that it allows you to create a `RiveFile` insta
 ### `<RiveComponent />`
 
 The `RiveComponent` default export and the `RiveComponent` returned from the `useRive` hook are both to be rendered in the JSX of a component. As noted previously, all attributes and event handlers that can be passed to a `canvas` element can also be passed to the `Rive` component and used in the same manner.
+
+#### Props
+
+The default export accepts the props below in addition to any `canvas` attributes. It always plays with `autoplay: true`. For anything beyond a simple embed — controlling playback, reading the `Rive` instance, or data binding — use the [`useRive`](#userive) hook instead.
+
+```typescript
+interface RiveProps {
+  src: string; // required
+  artboard?: string;
+  stateMachine?: string;
+  layout?: Layout;
+  useOffscreenRenderer?: boolean;
+  shouldDisableRiveListeners?: boolean;
+  shouldResizeCanvasToContainer?: boolean;
+
+  // Deprecated props
+  animations?: string | string[];
+  stateMachines?: string | string[];
+  automaticallyHandleEvents?: boolean;
+}
+```
+
+- `src` - *(required)* URL of the Rive asset, or path to the public `.riv` asset.
+- `artboard` - *(optional)* Artboard to render. Defaults to the first artboard in the file.
+- `stateMachine` - *(strongly recommended)* Name of the state machine to play.
+- `layout` - *(optional)* A [`Layout`](/runtimes/react/layouts) instance setting fit and alignment for the drawing surface.
+- `useOffscreenRenderer` - *(optional)* Share a single WebGL context across canvases. Only relevant for `@rive-app/react-webgl2`. Defaults to `true`.
+- `shouldDisableRiveListeners` - *(optional)* Prevents Rive from attaching pointer event listeners to the canvas.
+- `shouldResizeCanvasToContainer` - *(optional)* Automatically resize the canvas to its container. Defaults to `true`.
+
+#### Deprecated props
+
+- `stateMachines` - Use `stateMachine` with a single state machine name instead.
+- `animations` - Use `stateMachine` to play a state machine instead.
+- `automaticallyHandleEvents` - Deprecated along with the rest of the [Rive Events](/runtimes/react/rive-events) surface. Use [data binding](/runtimes/react/data-binding) instead.
 
 One thing to note is that `style`/`className` props set on the component will be passed onto the containing `<div>` element, rather than the underlying `<canvas>` itself. The reason for this is that the containing `<div>` element handles resizing and layout for you, and thus, all styles should be passed onto this element.
 

--- a/runtimes/react/preloading-wasm.mdx
+++ b/runtimes/react/preloading-wasm.mdx
@@ -55,7 +55,7 @@ if (typeof window !== 'undefined') {
 export default function Hero() {
   const { RiveComponent } = useRive({
     src: '/assets/hero.riv',
-    stateMachines: 'State Machine 1',
+    stateMachine: 'State Machine 1',
     autoplay: true,
     autoBind: true,
   });

--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -42,8 +42,8 @@ There are three main ways to use Rive in a React app:
           const { rive, RiveComponent } = useRive({
             // Load a local .riv file or use a hosted URL.
             src: "quick_start_health_bar.riv",
-            // Be sure to specify the correct state machine (or animation) name
-            stateMachines: "State Machine 1",
+            // Be sure to specify the correct state machine name
+            stateMachine: "State Machine 1",
             // Autoplay the state machine
             autoplay: true,
             // This uses the view model instance defined in Rive
@@ -89,7 +89,7 @@ There are three main ways to use Rive in a React app:
         export const Simple = () => (
           <Rive
             src="https://cdn.rive.app/animations/vehicles.riv"
-            stateMachines="bumpy"
+            stateMachine="bumpy"
           />
         );
         ```
@@ -113,8 +113,8 @@ There are three main ways to use Rive in a React app:
             const riveInstance = new Rive({
               // Load a local .riv file or use a hosted URL.
               src: "quick_start_health_bar.riv",
-              // Be sure to specify the correct state machine (or animation) name
-              stateMachines: "State Machine 1", // Name of the State Machine to play
+              // Be sure to specify the correct state machine name
+              stateMachine: "State Machine 1", // Name of the State Machine to play
               canvas: canvasRef.current,
               autoplay: true,
               autoBind: true, // This uses the view model instance defined in Rive

--- a/runtimes/react/semantics.mdx
+++ b/runtimes/react/semantics.mdx
@@ -27,7 +27,7 @@ import { useRive, SemanticMode } from "@rive-app/react-canvas";
 export default function Login() {
   const { RiveComponent } = useRive({
     src: "/login.riv",
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     autoplay: true,
     autoBind: true,
     semanticsMode: SemanticMode.Enabled,
@@ -45,7 +45,7 @@ Use `semanticsOptions.riveCanvasLabel` to set an `aria-label` on the semantic ov
 export default function Login() {
   const { RiveComponent } = useRive({
     src: "/login.riv",
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     autoplay: true,
     autoBind: true,
     semanticsMode: SemanticMode.Enabled,
@@ -69,7 +69,7 @@ import { useRive } from "@rive-app/react-canvas";
 export default function Login({ accessibilityEnabled }) {
   const { RiveComponent, rive } = useRive({
     src: "/login.riv",
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     autoplay: true,
     autoBind: true,
   });

--- a/runtimes/react/state-machines.mdx
+++ b/runtimes/react/state-machines.mdx
@@ -13,6 +13,8 @@ import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-stat
 
 <PlayingStateMachines />
 
+Name the state machine you want to play with the `stateMachine` parameter on `useRive` (or the `stateMachine` prop on the default `<Rive />` component).
+
 #### Autoplay the State Machine
 
 To auto-play a state machine by default, simply set `autoplay` to `true`.
@@ -20,7 +22,7 @@ To auto-play a state machine by default, simply set `autoplay` to `true`.
 export default function Simple() {
   const { RiveComponent } = useRive({
     src: 'https://cdn.rive.app/animations/vehicles.riv',
-    stateMachines: "bumpy",
+    stateMachine: "bumpy",
     autoplay: true,
   });
 
@@ -36,7 +38,7 @@ You can manually play and pause the state machine using the `play`, `pause`, and
   export default function Simple() {
     const { rive, RiveComponent } = useRive({
       src: "https://cdn.rive.app/animations/vehicles.riv",
-      stateMachines: "bumpy",
+      stateMachine: "bumpy",
       autoplay: true,
     });
 

--- a/runtimes/web/artboards.mdx
+++ b/runtimes/web/artboards.mdx
@@ -15,6 +15,7 @@ import ChoosingAnArtboard from "/snippets/runtimes/artboards/choosing-an-artboar
       src: 'https://cdn.rive.app/animations/vehicles.riv',
       canvas: document.getElementById('canvas'),
       artboard: 'Truck',
+      stateMachine: 'bumpy',
       autoplay: true
   });
 ```

--- a/runtimes/web/caching-a-rive-file.mdx
+++ b/runtimes/web/caching-a-rive-file.mdx
@@ -36,7 +36,7 @@ if (!canvas) return;
 const riveInstance = new rive.Rive({
     riveFile: loadedRiveFile,
     // Be sure to specify the correct state machine (or animation) name
-    stateMachines: "Motion", // Name of the State Machine to play
+    stateMachine: "Motion", // Name of the State Machine to play
     canvas: canvas,
     layout: new rive.Layout({
     fit: rive.Fit.FitWidth,

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -31,6 +31,8 @@ If you show several graphics on one page, set `useOffscreenRenderer: true` on ea
 const r = new rive.Rive({
   src: "https://cdn.rive.app/animations/vehicles.riv",
   canvas: document.getElementById("canvas"),
+  artboard: "Truck",
+  stateMachine: "bumpy",
   useOffscreenRenderer: true,
 });
 ```

--- a/runtimes/web/data-binding.mdx
+++ b/runtimes/web/data-binding.mdx
@@ -151,7 +151,7 @@ Assign an instance to a global slot with `setGlobalViewModelInstance()`, then ap
 const r = new rive.Rive({
     src: "my_rive_file.riv",
     canvas: document.getElementById("canvas"),
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     autoBind: false,
     onLoad: () => {
         const themeVM = r.viewModelByName("Theme");
@@ -430,7 +430,7 @@ const r = new Rive({
         fit: Fit.Layout,
         layoutScaleFactor: 0.5,
     }),
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     onLoad: () => {
         r.resizeDrawingSurfaceToCanvas();
 

--- a/runtimes/web/faq.mdx
+++ b/runtimes/web/faq.mdx
@@ -45,6 +45,7 @@ const canvasElement = document.getElementById('some-canvas-element-id');
 const r = new Rive({
   src: 'some-file.riv',
   canvas: canvasElement,
+  stateMachine: 'State Machine 1',
   autoplay: true,
   onLoad: () => {
     r.resizeDrawingSurfaceToCanvas();
@@ -80,7 +81,7 @@ Ideally, you want to ensure that the width/height attributes on the canvas are a
 
 ### How come my state machine isn't playing?
 
-Make sure you've specified the `stateMachines` property when instantiating Rive with the name of your state machine. To autoplay the state machine, don't forget to set `autoplay: true` when instantiating the Rive object.
+Make sure you've specified the `stateMachine` property when instantiating Rive with the name of your state machine. To autoplay the state machine, don't forget to set `autoplay: true` when instantiating the Rive object.
 
 ### How do I get other web-frameworks to support Rive?
 

--- a/runtimes/web/fonts.mdx
+++ b/runtimes/web/fonts.mdx
@@ -50,7 +50,7 @@ const main = async () => {
   const r = new Rive({
     src: "my.riv",
     autoplay: true,
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     // ...
   });
 };

--- a/runtimes/web/layouts.mdx
+++ b/runtimes/web/layouts.mdx
@@ -74,7 +74,7 @@ riveInstance.layout = new rive.Layout({ fit: rive.Fit.Fill });
       fit: Fit.Layout,
       // layoutScaleFactor: 2, // 2x scale of the layout, when using `Fit.Layout`. This allows you to resize the layout as needed.
     }),
-    stateMachines: ["State Machine 1"],
+    stateMachine: "State Machine 1",
     onLoad: () => {
       computeSize();
     },

--- a/runtimes/web/loading-assets.mdx
+++ b/runtimes/web/loading-assets.mdx
@@ -92,7 +92,7 @@ fetch(urls[randomIndex]).then(
 
 const riveInstance = new Rive({
 src: "acqua_text.riv",
-stateMachines: "State Machine 1", // Name of the State Machine to play
+stateMachine: "State Machine 1", // Name of the State Machine to play
 canvas: document.getElementById("rive-canvas"),
 layout: new Layout({
     fit: Fit.Cover,

--- a/runtimes/web/preloading-wasm.mdx
+++ b/runtimes/web/preloading-wasm.mdx
@@ -60,7 +60,7 @@ async function mountHero(canvas) {
   const riveInstance = new Rive({
     canvas,
     buffer: await heroFetch,
-    stateMachines: "State Machine 1",
+    stateMachine: "State Machine 1",
     autoBind: true,
     autoplay: true,
     // ... other configuration

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -3,6 +3,8 @@ title: 'Rive Parameters'
 description: 'API docs for the Rive instance.'
 ---
 
+import DefaultPlayback from "/snippets/runtimes/state-machines/default-playback.mdx"
+
 This page is a **reference** for constructor options, types, and instance methods on the high-level **`Rive`** class, as well as a number of other exported classes. For walkthroughs and samples, use the guides below and link back here when you need exact signatures.
 
 **Related guides**
@@ -69,7 +71,7 @@ export interface RiveParameters {
 - `stateMachine` - *(strongly recommended)* Name of the state machine to play (i.e. `"State Machine 1"`) from the `.riv` file. Added in `v2.41.0` to replace the plural `stateMachines` parameter.
 
 <Note>
-  If you do not pass `stateMachine`, or the deprecated `stateMachines` or `animations` parameters, Rive will currently play the first linear animation it finds on the artboard. In the next major version of the JS runtime (v3), Rive will play the default state machine it finds on the artboard.
+  <DefaultPlayback />
 </Note>
 
 - `layout` - *(optional)* Provide a [`new Layout()`](/runtimes/web/layouts) instance. See that guide for fit modes, alignment, bounds, and responsive layout.

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -27,7 +27,7 @@ export interface RiveParameters {
   buffer?: ArrayBuffer; // one of src, buffer, or riveFile is required
   riveFile?: RiveFile; // one of src, buffer, or riveFile is required
   artboard?: string;
-  stateMachines?: string | string[]; // strongly recommended setting this property
+  stateMachine?: string; // strongly recommended setting this property
   layout?: Layout;
   autoplay?: boolean;
   autoBind?: boolean;
@@ -35,7 +35,6 @@ export interface RiveParameters {
   enableRiveAssetCDN?: boolean;
   shouldDisableRiveListeners?: boolean;
   isTouchScrollEnabled?: boolean;
-  automaticallyHandleEvents?: boolean;
   dispatchPointerExit?: boolean;
   enableMultiTouch?: boolean;
   drawingOptions?: DrawOptimizationOptions;
@@ -44,8 +43,6 @@ export interface RiveParameters {
   onPlay?: EventCallback;
   onPause?: EventCallback;
   onStop?: EventCallback;
-  onLoop?: EventCallback;
-  onStateChange?: EventCallback;
   onAdvance?: EventCallback;
   assetLoader?: AssetLoadCallback;
   enablePerfMarks?: boolean;
@@ -55,7 +52,11 @@ export interface RiveParameters {
   semanticsOptions?: RiveSemanticsOptions; // experimental
 
   // Deprecated parameters
-  animations?: string | string[]; // deprecated in favor of stateMachines
+  animations?: string | string[]; // deprecated in favor of stateMachine
+  stateMachines?: string | string[]; // deprecated in favor of stateMachine
+  automaticallyHandleEvents?: boolean; // deprecated along with Rive Events
+  onLoop?: EventCallback; // deprecated in favor of state machines and data binding
+  onStateChange?: EventCallback; // deprecated in favor of state machine actions and data binding
 }
 ```
 
@@ -65,10 +66,10 @@ export interface RiveParameters {
   - `buffer` - *(optional)* `ArrayBuffer` of `.riv` bytes.
   - `riveFile` - *(optional)* Provide a loaded **`RiveFile`** across instances. See [Caching a Rive file](/runtimes/web/caching-a-rive-file) for more details.
 - `artboard` - *(optional)* Name of the artboard to use. If not provided, it will pull the default artboard from the exported `.riv` file.
-- `stateMachines` - *(strongly recommended)* Name of a state machine to load (i.e. `"State Machine 1"`) from the `.riv` file. If not provided, currently Rive will pull the first linear animation it finds (deprecated behavior). In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
+- `stateMachine` - *(strongly recommended)* Name of the state machine to play (i.e. `"State Machine 1"`) from the `.riv` file. Added in `v2.41.0` to replace the plural `stateMachines` parameter.
 
 <Note>
- Note: You should only provide a single state machine string for `stateMachines`. Running multiple state machines of the same artboard at the same time may cause unintended consequences.
+  If you do not pass `stateMachine`, or the deprecated `stateMachines` or `animations` parameters, Rive will currently play the first linear animation it finds on the artboard. In the next major version of the JS runtime (v3), Rive will play the default state machine it finds on the artboard.
 </Note>
 
 - `layout` - *(optional)* Provide a [`new Layout()`](/runtimes/web/layouts) instance. See that guide for fit modes, alignment, bounds, and responsive layout.
@@ -79,7 +80,6 @@ export interface RiveParameters {
 - `shouldDisableRiveListeners` - *(optional)* Boolean flag to disable setting up Rive Listeners on the `<canvas>` element, thus preventing any event listeners from being set up on the element.
   - **Note:** Rive Listeners by default are not set up on a `<canvas>` element if there is no playing state machine, or a state machine without any Rive Listeners set up on the state machine
 - `isTouchScrollEnabled` - *(optional)* For Rive Listeners, allows scrolling behavior to still occur on canvas elements when a touch/drag action is performed on touch-enabled devices. Otherwise, scroll behavior may be prevented on touch/drag actions on the canvas by default.
-- `automaticallyHandleEvents` - *(optional)* Enable Rive Events to be handled by the runtime. This means any special Rive Event may have a side effect that takes place implicitly. For example, if during the render loop an `OpenUrlEvent` is detected, the browser may try to open the specified URL in the payload. This flag is `false` by default to prevent any unwanted behaviors from taking place. This means any special Rive Event will have to be handled manually by subscribing to `EventType.RiveEvent`
 - `dispatchPointerExit` - *(optional)* For Rive Listeners, dispatches a pointer exit event when the pointer exits the canvas. This can be useful for ensuring hover states are properly reset when the user's cursor leaves the canvas area. Defaults to true.
 - `enableMultiTouch` - *(optional)* Enables multi-touch support for Rive Listeners. When enabled, the runtime will track and respond to multiple simultaneous touch points on touch-enabled devices. Defaults to false.
 - `drawingOptions` - *(optional)* An enum (`DrawOptimizationOptions`) that provides drawing optimization options. This can be used to configure rendering performance optimizations. The default is `DrawOptimizationOptions.DrawOnChanged`, which will only submit a draw command if the artboard has visually updated.
@@ -90,8 +90,6 @@ export interface RiveParameters {
 - `onPlay` - *(optional)* Callback that gets fired when the animation starts playing.
 - `onPause` - *(optional)* Callback that gets fired when the animation pauses.
 - `onStop` - *(optional)* Callback that gets fired when the animation stops playing.
-- `onLoop` - *(optional)* Callback that gets fired when the animation completes a loop.
-- `onStateChange` - *(optional)* Callback that gets fired when a state change occurs.
 - `onAdvance` - *(optional)* Callback that gets fired every frame when the Artboard has advanced.
 - `assetLoader` - *(optional)* Callback to load assets. Full patterns and examples in the [loading assets](/runtimes/web/loading-assets) guide.
 - `enablePerfMarks` - *(optional)* Emits `performance.mark` / `performance.measure` entries for key Rive startup and render events for performance profiling purposes. False by default. Also available on `RuntimeLoader` and `RiveFile`.
@@ -107,7 +105,16 @@ export interface RiveParameters {
 </Warning>
 
 ### Deprecated parameters
-- `animations` - *(optional)* Deprecated in favor of `stateMachines`. Name of a singular timeline animation to load from the `.riv` file. If not provided, Rive will pull the first linear animation it finds. In the next major version of the runtime, Rive will default to pulling the default state machine on the artboard.
+
+<Warning>
+  As of `v2.41.0` the parameters below are deprecated. They still work, and nothing has been removed, but using one logs a one-time `[Rive]`-prefixed console warning, and each will eventually be removed in a future major version.
+</Warning>
+
+- `stateMachines` - Use `stateMachine` with a single state machine name instead. Support for playing multiple state machines at once is going away.
+- `animations` - Name of a timeline animation to load from the `.riv` file. Use `stateMachine` to play a state machine instead.
+- `automaticallyHandleEvents` - Enable Rive Events to be handled by the runtime. For example, if during the render loop an `OpenUrlEvent` is detected, the browser may try to open the specified URL in the payload. Defaults to `false`. Deprecated along with the rest of the [Rive Events](/runtimes/web/rive-events) surface — use [data binding](/runtimes/web/data-binding) instead.
+- `onLoop` - Callback that gets fired when the animation completes a loop. Loop events are only reported for linear animation playback, which is itself deprecated. Use a state machine to control playback and [data binding](/runtimes/web/data-binding) to react to changes.
+- `onStateChange` - Callback that gets fired when a state change occurs. Use [data binding](/runtimes/web/data-binding) (view model property observers) or [state machine actions](/editor/state-machine/states#actions) to react to changes from your graphic instead.
 
 
 ## APIs
@@ -177,16 +184,19 @@ Stops a specified state machine via the passed-in name. If no name is passed in,
 ```typescript
 interface RiveResetParameters {
   artboard?: string;
-  animations?: string | string[];
-  stateMachines?: string | string[];
+  stateMachine?: string;
   autoplay?: boolean;
   autoBind?: boolean;
+
+  // Deprecated parameters
+  animations?: string | string[];
+  stateMachines?: string | string[];
 }
 
 reset(params?: RiveResetParameters): void
 ```
 
-Resets the artboard, timeline animations, and/or state machines from the start (or entry state). Cleans up existing artboard/animation/state machine instances first. Playback after reset follows `autoplay` and `autoBind` (same meaning as constructor parameters). Example: [State machine playback](/runtimes/web/state-machines).
+Resets the artboard and state machine from the start (or entry state). Cleans up existing artboard/animation/state machine instances first. Playback after reset follows `autoplay` and `autoBind`, and `stateMachine` takes priority over the deprecated plural parameters exactly as it does on the constructor. Example: [State machine playback](/runtimes/web/state-machines).
 
 ---
 
@@ -258,6 +268,10 @@ In addition to the event callbacks you can set in the `Rive` constructor (i.e. `
 
 Subscribe to runtime events (similar to `addEventListener`).
 
+<Note>
+  `on()` itself is not deprecated, but subscribing with `EventType.RiveEvent`, `EventType.StateChange`, or `EventType.Loop` is, and each logs a one-time console warning. Every other `EventType` is unaffected, and `off()` never warns.
+</Note>
+
 #### off()
 
 `off(type: EventType, callback: EventCallback): void`
@@ -279,9 +293,12 @@ export enum EventType {
   Play = "play",
   Pause = "pause",
   Stop = "stop",
-  Loop = "loop", // Only applicable for timeline animations, not state machines
+  /** @deprecated Only reported for timeline animations. Use data binding instead. */
+  Loop = "loop",
   Advance = "advance", // Called each frame after state machine advance
+  /** @deprecated Use data binding or state machine actions instead. */
   StateChange = "statechange",
+  /** @deprecated Use data binding instead. */
   RiveEvent = "riveevent",
 }
 ```
@@ -291,10 +308,11 @@ The `Event` type is `{ type: EventType; data?: ... }`. The shape of `data` depen
 - **Load** — `RiveFile`  (the loaded file handle) or the string "buffer" indicating a load from an ArrayBuffer
 - **LoadError** — `string` (error message)
 - **Play**, **Pause**, **Stop** — `string[]` (names of the animations or state machines affected)
-- **Loop** — `LoopEvent` (`{ animation: string; type: LoopType }`). `LoopType` is `OneShot`, `Loop`, or `PingPong`.
 - **Advance** — `number` (elapsed seconds for that frame)
-- **StateChange** — `string[]` (state names that changed)
-- **RiveEvent** — custom or built-in Rive event payload (for example open-URL events)
+- **Loop** — *(deprecated in `v2.41.0`)* `LoopEvent` (`{ animation: string; type: LoopType }`). `LoopType` is `OneShot`, `Loop`, or `PingPong`. Both the `LoopEvent` interface and the `LoopType` enum are deprecated alongside the event.
+- **StateChange** — *(deprecated in `v2.41.0`)* `string[]` (state names that changed)
+- **RiveEvent** — *(deprecated in `v2.41.0`)* custom or built-in Rive event payload (for example open-URL events)
+
 
 For **`EventType.RiveEvent`** listener examples, see [Rive Events](/runtimes/web/rive-events). Prefer [Data binding](/runtimes/web/data-binding) for new work where it applies.
 
@@ -314,11 +332,16 @@ interface RiveLoadParameters {
   autoplay?: boolean;
   autoBind?: boolean;
   artboard?: string;
-  animations?: string | string[];
-  stateMachines?: string | string[];
+  stateMachine?: string;
   useOffscreenRenderer?: boolean;
   shouldDisableRiveListeners?: boolean;
   tabIndex?: number;
+  semanticsMode?: SemanticMode;
+  semanticsOptions?: RiveSemanticsOptions;
+
+  // Deprecated parameters
+  animations?: string | string[];
+  stateMachines?: string | string[];
 }
 
 load(params: RiveLoadParameters): void
@@ -422,7 +445,7 @@ class StateMachineInput {
 
 ---
 
-#### Nested artboard paths (deprecated)
+#### Nested artboard paths
 
 For inputs and text runs on **nested artboards**, use a path string (for example `"parentArtboard"` or `"group/nested"`) to set input and text run values.
 
@@ -445,6 +468,14 @@ Prefer data binding with [Nested Property Paths](/runtimes/web/data-binding#nest
 These target named text runs on the **currently active** artboard. Console warnings are emitted when the run cannot be resolved.
 
 Prefer data binding with [Text data binding](/runtimes/web/data-binding#reading-and-writing-properties) for new work where possible.
+
+---
+
+#### scrub()
+
+`scrub(animationNames?: string | string[], value?: number): void`
+
+Scrubs the specified timeline animations to the given time; if none are specified, scrubs all of them. Deprecated in `v2.41.0` — use a state machine to control playback instead.
 
 ---
 

--- a/runtimes/web/semantics.mdx
+++ b/runtimes/web/semantics.mdx
@@ -44,7 +44,7 @@ import { Rive, SemanticMode } from "@rive-app/webgl2";
 const rive = new Rive({
   canvas: document.getElementById("rive-canvas"),
   src: "login.riv",
-  stateMachines: "State Machine 1",
+  stateMachine: "State Machine 1",
   autoplay: true,
   autoBind: true,
   semanticsMode: SemanticMode.Enabled,
@@ -59,7 +59,7 @@ If you want to programmatically control when semantics are enabled, construct `R
 const rive = new Rive({
   canvas: document.getElementById("rive-canvas"),
   src: "login.riv",
-  stateMachines: "State Machine 1",
+  stateMachine: "State Machine 1",
   semanticsMode: SemanticMode.Disabled,
   autoplay: true,
   autoBind: true,
@@ -80,7 +80,7 @@ The semantic overlay's container element is a `role="region"` landmark. Use the 
 const rive = new Rive({
   canvas: document.getElementById("rive-canvas"),
   src: "login.riv",
-  stateMachines: "State Machine 1",
+  stateMachine: "State Machine 1",
   autoplay: true,
   autoBind: true,
   semanticsMode: SemanticMode.Enabled,

--- a/runtimes/web/state-machines.mdx
+++ b/runtimes/web/state-machines.mdx
@@ -6,6 +6,7 @@ description: "Playing a state machine"
 import Overview from "/snippets/runtimes/state-machines/overview.mdx"
 import ControllingPlayback from "/snippets/runtimes/state-machines/controlling-playback.mdx"
 import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-state-machines.mdx"
+import DefaultPlayback from "/snippets/runtimes/state-machines/default-playback.mdx"
 
 <Overview />
 
@@ -18,10 +19,10 @@ import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-stat
 Pass the name of the state machine you want to play with the `stateMachine` parameter.
 
 <Note>
-  `stateMachine` was added in `v2.41.0` and replaces the plural `stateMachines` parameter, which is now deprecated. `stateMachine` takes a single string and always takes priority over `stateMachines` and `animations` when both are supplied. See [Deprecated parameters](/runtimes/web/rive-parameters#deprecated-parameters) for more details.
+  `stateMachine` was added in `v2.41.0` and replaces the plural `stateMachines` parameter, which is now deprecated. `stateMachine` takes a single non-empty string and always takes priority over `stateMachines` and `animations`. See [Deprecated parameters](/runtimes/web/rive-parameters#deprecated-parameters) for more details.
 </Note>
 
-If you do not pass `stateMachine` (or the deprecated `stateMachines`) param, Rive currently plays the first linear animation it finds on the artboard. In the next major version of the JS runtime (v3), Rive will play the default state machine on the artboard instead.
+<DefaultPlayback />
 
 ### Autoplay the State Machine
 

--- a/runtimes/web/state-machines.mdx
+++ b/runtimes/web/state-machines.mdx
@@ -13,6 +13,16 @@ import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-stat
 
 <PlayingStateMachines />
 
+### Specifying a State Machine
+
+Pass the name of the state machine you want to play with the `stateMachine` parameter.
+
+<Note>
+  `stateMachine` was added in `v2.41.0` and replaces the plural `stateMachines` parameter, which is now deprecated. `stateMachine` takes a single string and always takes priority over `stateMachines` and `animations` when both are supplied. See [Deprecated parameters](/runtimes/web/rive-parameters#deprecated-parameters) for more details.
+</Note>
+
+If you do not pass `stateMachine` (or the deprecated `stateMachines`) param, Rive currently plays the first linear animation it finds on the artboard. In the next major version of the JS runtime (v3), Rive will play the default state machine on the artboard instead.
+
 ### Autoplay the State Machine
 
 To autoplay a state machine immediately after it loads, simply set `autoplay` to `true`.
@@ -22,7 +32,7 @@ const r = new rive.Rive({
     src: 'https://cdn.rive.app/animations/vehicles.riv',
     canvas: document.getElementById('canvas'),
     autoplay: true,
-    stateMachines: 'bumpy',
+    stateMachine: 'bumpy',
     onLoad: () => {}
 });
 ```
@@ -35,7 +45,7 @@ You can manually play and pause the State Machine using the `play`, `pause`, and
 const r = new rive.Rive({
     src: 'https://cdn.rive.app/animations/vehicles.riv',
     canvas: document.getElementById('canvas'),
-    stateMachines: 'bumpy',
+    stateMachine: 'bumpy',
     onLoad: () => {}
 });
 
@@ -54,11 +64,11 @@ const handleStop = () => {
 
 ### reset()
 
-To dispose the current artboard / animation / state machine instances and create fresh ones (optionally changing artboard or `stateMachines`), use **`reset()`**. Pass the same kinds of options you use on the constructor. See [Rive Parameters](/runtimes/web/rive-parameters) for the full **`RiveResetParameters`** fields (`artboard`, `stateMachines`, `autoplay`, `autoBind`).
+To dispose the current artboard / animation / state machine instances and create fresh ones (optionally changing artboard or `stateMachine`), use **`reset()`**. Pass the same kinds of options you use on the constructor. See [Rive Parameters](/runtimes/web/rive-parameters) for the full **`RiveResetParameters`** fields (`artboard`, `stateMachine`, `autoplay`, `autoBind`).
 
 ```js
 r.reset({
-  stateMachines: 'bumpy',
+  stateMachine: 'bumpy',
   autoplay: true,
 });
 ```

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -92,7 +92,7 @@ These instructions use `@rive-app/webgl2`, the package we recommend for most pro
 
     - `src`: A string representing the URL of the hosted `.riv` file (as shown in the example below) or the path to the public asset `.riv` file. For more details, refer to [Rive Parameters](/runtimes/web/rive-parameters) on how to properly use this property.
     - `artboard` - (Optional) A string representing the artboard you want to display. If not supplied, the default artboard from the `.riv` file is selected.
-    - `stateMachines` - A string representing the name of the state machine you wish to play. This must be supplied, or the Rive instance may only play the first linear animation it finds. In the next major version, the default behavior will be to play the default state machine of the artboard.
+    - `stateMachine` - A string representing the name of the state machine you wish to play. This must be supplied, or the Rive instance may only play the first linear animation it finds. In the next major version, the default behavior will be to play the artboard's default state machine when one exists.
     - `canvas` - The canvas element where the animation will be rendered.
     - `autoplay` - A boolean indicating whether the animation should play automatically.
     - `autoBind` - A boolean indicating whether to automatically data-bind the default `ViewModelInstance` if one is found. We recommend setting this to `true`.
@@ -107,7 +107,7 @@ These instructions use `@rive-app/webgl2`, the package we recommend for most pro
             autoplay: true,
             autoBind: true,
             // artboard: "Artboard", // Optional. If not supplied the default is selected
-            stateMachines: "bumpy",
+            stateMachine: "bumpy",
             onLoad: () => {
               r.resizeDrawingSurfaceToCanvas();
             },
@@ -160,7 +160,7 @@ Bringing it all together, here's how to load a Rive graphic in a single HTML fil
         autoplay: true,
         autoBind: true,
         // artboard: "Artboard", // Optional. If not supplied the default is selected
-        stateMachines: "bumpy",
+        stateMachine: "bumpy",
         onLoad: () => {
           // Ensure the drawing surface matches the canvas size and device pixel ratio
           r.resizeDrawingSurfaceToCanvas();

--- a/snippets/runtimes/state-machines/default-playback.mdx
+++ b/snippets/runtimes/state-machines/default-playback.mdx
@@ -1,0 +1,1 @@
+If you do not pass `stateMachine`, or the deprecated `stateMachines` or `animations` parameters, Rive will currently play the first linear animation it finds on the artboard. In the next major version of the JS runtime (v3), Rive will play the artboard's default state machine when one exists.


### PR DESCRIPTION
Starting in `v2.41.0`/`v4.33.0` of the JS/React runtimes respectively, we added deprecations for the following:
- `animations` - initialization param
- `stateMachines` - initialization param
- `automaticallyHandleEvents` - initialization param related to Rive events
- `useStateMachineInput` hook

Adds:
- `stateMachine` - new param that is just a single string and will replace the `stateMachines` param

Those changes also deprecate events/text run/state machine input APIs so those should be touched on in the parameters pages as well.