### PR TITLE
docs(apple): document GPU Canvas

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -700,6 +700,7 @@
                 "group": "Apple",
                 "pages": [
                   "runtimes/apple/apple",
+                  "runtimes/apple/gpu-canvas",
                   "runtimes/apple/faq",
                   "runtimes/apple/resource-usage",
                   "runtimes/apple/artboards",

--- a/feature-support.mdx
+++ b/feature-support.mdx
@@ -88,6 +88,9 @@ Differences may reflect:
 
 ### Features
 
+<FeatureSupportGroup feature="gpuCanvas">
+  GPU Canvas enables 3D content in the Apple runtime. See [GPU Canvas](/runtimes/apple/gpu-canvas) for setup instructions.
+</FeatureSupportGroup>
 <FeatureSupportGroup feature="globalViewModels" />
 <FeatureSupportGroup feature="dataBindingFonts" />
 <FeatureSupportGroup feature="semantics">

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -121,7 +121,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
             <Step title="Add a View">
                 Once you have created a `File`, you can move onto creating a `Rive` object. This object defines the configuration of a view. The most basic implementation is created with just a file; Rive will handle loading the default artboard and state machine for rendering. Additionally, if the artboard contains a default view model instance, it will be bound to the state machine automatically.
 
-                Once you have created a `Rive` object, you can initialize your view. In UIKit, this is done by creating a `RiveUIView` and adding it to the view hierarchy. In SwiftUI, this is done by using the `RiveUIViewRepresentable` and AsyncRiveUIViewRepresentable` types.
+                Once you have created a `Rive` object, you can initialize your view. In UIKit, this is done by creating a `RiveUIView` and adding it to the view hierarchy. In SwiftUI, this is done by using the `RiveUIViewRepresentable` and `AsyncRiveUIViewRepresentable` types.
 
                 <CodeGroup>
                     ```swift UIKit

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -4,6 +4,7 @@ description: 'Apple runtime for Rive. '
 ---
 
 import NoteOnFeatureSupport from "/snippets/runtimes/rendering-feature-support.mdx"
+import SharedWorker from "/snippets/runtimes/apple/shared-worker.mdx"
 import { Demos } from '/snippets/demos.jsx'
 
 <NoteOnFeatureSupport/>
@@ -443,32 +444,14 @@ See [Semantics](/runtimes/apple/semantics) for the available modes and more deta
 
         ### Shared Workers
 
-        For cases where you want to share resources between multiple `File` objects (i.e out-of-band / referenced assets), you can use a shared `Worker` object. An example implementation is shown below.
+        To share out-of-band or referenced assets across multiple `File` objects, use a shared `Worker`. An example implementation is shown below.
+
+        <SharedWorker />
+
+        Then, when creating a `Rive` object, use `Worker.shared()` to get the shared worker.
 
         ```swift
-        actor WorkerProvider {
-            static let shared = WorkerProvider()
-
-            @MainActor
-            private var cachedWorker: Worker?
-
-            @MainActor
-            func worker() async throws -> Worker {
-                if let cachedWorker {
-                    return cachedWorker
-                }
-
-                let worker = try await Worker()
-                cachedWorker = worker
-                return worker
-            }
-        }
-        ```
-
-        Then, when creating a `Rive` object, you can use the shared worker provider to get a worker.
-
-        ```swift
-        let worker = try await WorkerProvider.shared.worker()
+        let worker = try await Worker.shared()
         let file = try await File(source: ..., worker: worker)
         let rive = try await Rive(file: file)
         ```

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -75,8 +75,13 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 
                 ```swift
                 // In an async context
-                let worker = try await Worker()
+                // GPU Canvas is required for 3D content.
+                let worker = try await Worker(
+                    configuration: .init(enableGPUCanvas: true)
+                )
                 ```
+
+                See [GPU Canvas](/runtimes/apple/gpu-canvas) for more information about this worker configuration.
 
                 For more information on threading, see [Threading](#threading).
             </Step>
@@ -89,18 +94,24 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
 
                 <CodeGroup>
                     ```swift Local File
-                    let worker = try await Worker()
+                    let worker = try await Worker(
+                        configuration: .init(enableGPUCanvas: true)
+                    )
                     let file = try await File(source: .local("my_file", Bundle.main), worker: worker)
                     ```
 
                     ```swift Remote URL
-                    let worker = try await Worker()
+                    let worker = try await Worker(
+                        configuration: .init(enableGPUCanvas: true)
+                    )
                     let url: URL = URL(string: "https://example.com/my_file.riv")!
                     let file = try await File(source: .url(url), worker: worker)
                     ```
 
                     ```swift Data
-                    let worker = try await Worker()
+                    let worker = try await Worker(
+                        configuration: .init(enableGPUCanvas: true)
+                    )
                     let data: Data = ...
                     let file = try await File(source: .data(data), worker: worker)
                     ```
@@ -114,7 +125,9 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
                 <CodeGroup>
                     ```swift UIKit
                     let riveView = RiveUIView({
-                        let worker = try await Worker()
+                        let worker = try await Worker(
+                            configuration: .init(enableGPUCanvas: true)
+                        )
                         let file = try await File(source: .local("my_file", Bundle.main), worker: worker)
                         return try await Rive(file: file)
                     })
@@ -131,7 +144,9 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
                     var body: some View {
                         // After having created a `Rive` object, you can initialize your view.
                         AsyncRiveUIViewRepresentable {
-                            let worker = try await Worker()
+                            let worker = try await Worker(
+                                configuration: .init(enableGPUCanvas: true)
+                            )
                             let file = try await File(source: .local("my_file", Bundle.main), worker: worker)
                             return try await Rive(file: file)
                         }

--- a/runtimes/apple/gpu-canvas.mdx
+++ b/runtimes/apple/gpu-canvas.mdx
@@ -3,6 +3,8 @@ title: "GPU Canvas"
 description: "Enable GPU Canvas when creating a Worker in the Apple runtime."
 ---
 
+import SharedWorker from "/snippets/runtimes/apple/shared-worker.mdx"
+
 GPU Canvas enables 3D content in the Apple runtime. It is available through the Swift Concurrency API and is configured when creating a `Worker`. The setting applies to every `File` loaded by that worker and every `Rive` object created from those files.
 
 <Note>
@@ -42,6 +44,23 @@ GPU Canvas is disabled by default. Continue to create a worker without a configu
 
 ```swift
 let worker = try await Worker()
+```
+
+## Sharing a GPU Canvas Worker
+
+Share a GPU Canvas worker when multiple files or views can use the same worker. An example implementation is shown below.
+
+<SharedWorker />
+
+Use `Worker.sharedGPUCanvas()` when loading files that require GPU Canvas:
+
+```swift
+let worker = try await Worker.sharedGPUCanvas()
+let file = try await File(
+    source: .local("my_file", Bundle.main),
+    worker: worker
+)
+let rive = try await Rive(file: file)
 ```
 
 For a complete setup example, see the [Apple quick start](/runtimes/apple/apple#getting-started).

--- a/runtimes/apple/gpu-canvas.mdx
+++ b/runtimes/apple/gpu-canvas.mdx
@@ -1,0 +1,47 @@
+---
+title: "GPU Canvas"
+description: "Enable GPU Canvas when creating a Worker in the Apple runtime."
+---
+
+GPU Canvas enables 3D content in the Apple runtime. It is available through the Swift Concurrency API and is configured when creating a `Worker`. The setting applies to every `File` loaded by that worker and every `Rive` object created from those files.
+
+<Note>
+  GPU Canvas is required to render 3D content.
+</Note>
+
+## Enabling GPU Canvas
+
+Pass a configuration with `enableGPUCanvas` set to `true` when creating a worker:
+
+```swift
+let worker = try await Worker(
+    configuration: .init(enableGPUCanvas: true)
+)
+```
+
+The worker's GPU Canvas setting is fixed for its lifetime. Enable it before loading any files that require GPU Canvas or 3D support.
+
+Every `File` created with the worker uses the same setting:
+
+```swift
+let worker = try await Worker(
+    configuration: .init(enableGPUCanvas: true)
+)
+let file = try await File(
+    source: .local("my_file", Bundle.main),
+    worker: worker
+)
+let rive = try await Rive(file: file)
+```
+
+No additional configuration is required when creating a `RiveUIView`, `RiveUIViewRepresentable`, or `AsyncRiveUIViewRepresentable`. Each view inherits the GPU Canvas setting from the worker associated with its `Rive` object.
+
+## Default Behavior
+
+GPU Canvas is disabled by default. Continue to create a worker without a configuration when your content does not require it:
+
+```swift
+let worker = try await Worker()
+```
+
+For a complete setup example, see the [Apple quick start](/runtimes/apple/apple#getting-started).

--- a/runtimes/apple/migrating-from-legacy.mdx
+++ b/runtimes/apple/migrating-from-legacy.mdx
@@ -96,7 +96,7 @@ let viewModel = RiveViewModel(model)
 #### {{runtimeCurrentNameApple}}
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 let rive = try await Rive(file: file)
 ```
@@ -115,7 +115,7 @@ let viewModel = RiveViewModel(model)
 #### {{runtimeCurrentNameApple}}
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let webURL = URL(string: "https://example.com/my_rive_file.riv")!
 let file = try await File(
     source: .url(webURL),
@@ -140,7 +140,7 @@ let viewModel = RiveViewModel(model)
 Use the `.data` file source when your `.riv` bytes are already available in memory.
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let data: Data = ...
 let file = try await File(source: .data(data), worker: worker)
 let rive = try await Rive(file: file)
@@ -177,7 +177,7 @@ New runtime APIs throw errors, so failure handling moves to `do/catch`:
 
 ```swift
 do {
-    let worker = try await WorkerProvider.shared.worker()
+    let worker = try await Worker.shared()
     let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
     let artboard = try await file.createArtboard("My Artboard")
     let stateMachine = try await artboard.createStateMachine("My State Machine")
@@ -211,7 +211,7 @@ model.setStateMachine("My State Machine")
 #### {{runtimeCurrentNameApple}}
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 let artboard = try await file.createArtboard("My Artboard")
 let stateMachine = try await artboard.createStateMachine("My State Machine")
@@ -237,7 +237,7 @@ var body: some View {
 #### {{runtimeCurrentNameApple}}
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: ..., worker: worker)
 let rive = try await Rive(file: file)
 
@@ -246,7 +246,7 @@ let riveView = RiveUIView(rive: rive)
 
 // UIKit (async loading)
 let riveView = RiveUIView({
-    let worker = try await WorkerProvider.shared.worker()
+    let worker = try await Worker.shared()
     let file = try await File(source: ..., worker: worker)
     return try await Rive(file: file)
 })
@@ -259,7 +259,7 @@ var body: some View {
 // SwiftUI (async)
 var body: some View {
     AsyncRiveUIViewRepresentable {
-        let worker = try await WorkerProvider.shared.worker()
+        let worker = try await Worker.shared()
         let file = try await File(source: ..., worker: worker)
         return try await Rive(file: file)
     }
@@ -299,7 +299,7 @@ viewModel.layoutScaleFactor = 2.0
 #### {{runtimeCurrentNameApple}}
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 var rive = try await Rive(file: file, fit: .contain(alignment: .center))
 
@@ -310,7 +310,7 @@ rive.fit = .fitWidth(alignment: .topCenter)
 To use artboard layout sizing in the new runtime:
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 var rive = try await Rive(file: file, fit: .layout(scaleFactor: .automatic))
 
@@ -359,7 +359,7 @@ let namedInstance = viewModel.createInstance(fromName: "My Instance")
 In the new runtime, the view model is represented as source metadata passed directly into `createViewModelInstance`.
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 
 // By explicit view model name
@@ -412,7 +412,7 @@ let currentValue = stringProperty.value
 The new runtime uses typed path descriptors with methods on `ViewModelInstance` for set/get/observe.
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 let viewModelInstance = try await file.createViewModelInstance(
     from: .name("My View Model")
@@ -458,7 +458,7 @@ artboardProperty.setValue(bindableArtboard)
 The new runtime binds artboards with a typed property descriptor and `setValue` on the instance.
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 let viewModelInstance = try await file.createViewModelInstance(.viewModelDefault(from: .name("My View Model")))
 
@@ -498,7 +498,7 @@ stateMachine.bindViewModelInstance(instance) // bound successfully
 #### {{runtimeCurrentNameApple}}
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: ..., worker: worker)
 
 // Auto bind (default)
@@ -549,7 +549,7 @@ viewModel.play() // Required to advance/unsettle after mutation
 In the new runtime, update the bound value after the view is created. No explicit `play()` call is needed.
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let file = try await File(source: .local("my_rive_file", Bundle.main), worker: worker)
 
 let instance = try await file.createViewModelInstance(.viewModelDefault(from: .name("My View Model")))
@@ -641,7 +641,7 @@ let viewModel = RiveViewModel(fileName: "my_rive_file") { asset, _, factory in
 The new runtime uses a push model, where assets are registered on the worker ahead of use.
 
 ```swift
-let worker = try await WorkerProvider.shared.worker()
+let worker = try await Worker.shared()
 let image = try await worker.decodeImage(from: Data(...))
 worker.addGlobalImageAsset(image, name: "MyImage-1234")
 

--- a/runtimes/apple/migrating-from-legacy.mdx
+++ b/runtimes/apple/migrating-from-legacy.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Migrating from Legacy"
 description: "A guide to help you transition from the legacy Rive Apple runtime to the new runtime."
 ---
 
+import SharedWorker from "/snippets/runtimes/apple/shared-worker.mdx"
+
 ## Overview
 
 The [new Rive Apple runtime](/runtimes/apple/apple) is a **near-complete rewrite** of both the public API and the internal architecture. While conceptually most operations have an equivalent, the two APIs are incompatible. Any existing work in the legacy API that you would like to migrate must be rebuilt using the new API.
@@ -61,24 +63,12 @@ The new runtime introduces `Worker` objects for background processing while stil
 
 For most apps, a shared worker is recommended:
 
+<SharedWorker />
+
 ```swift
-actor WorkerProvider {
-    static let shared = WorkerProvider()
-
-    @MainActor
-    private var cachedWorker: Worker?
-
-    @MainActor
-    func worker() async throws -> Worker {
-        if let cachedWorker {
-            return cachedWorker
-        }
-
-        let worker = try await Worker()
-        cachedWorker = worker
-        return worker
-    }
-}
+let worker = try await Worker.shared()
+let file = try await File(source: ..., worker: worker)
+let rive = try await Rive(file: file)
 ```
 
 ## Shared Features

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -65,7 +65,7 @@ If a runtime is not listed here, there is no renderer setup to configure. It use
         )
         ```
 
-        GPU Canvas is required for 3D content. The setting applies to every file and renderer created with that worker and cannot be changed during the worker's lifetime.
+        GPU Canvas is required for 3D content. The setting applies to every `File` loaded by that worker and every `Rive` object created from those files. It cannot be changed during the worker's lifetime.
     </Tab>
     <Tab title="Android (Legacy)">
         Options: `Canvas / Skia (removed in v10.0.0)`

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -20,7 +20,7 @@ The Rive Renderer is designed to provide better performance and visual fidelity 
 | ------------ | ---------------- | -------------------------------------------- |
 | [Web (JS)](#web-js)          | Depends on package       | Rive / Canvas2D                              |
 | [Web (React)](#web-react)          | Depends on package       | Rive / Canvas2D                              |
-| Apple | Rive | Rive |
+| [Apple](#apple) | Rive | Rive |
 | Android (Compose)     | Rive             | Rive |
 | [Android (Legacy)](#android-legacy)     | Rive             | Rive / Canvas / Skia (removed as of v10.0.0) |
 | React Native | Rive             | Rive                     |
@@ -55,6 +55,17 @@ If a runtime is not listed here, there is no renderer setup to configure. It use
         <Note>
             These packages provide the Rive React component and hooks. If you want to use the imperative JavaScript runtime in a React app, install one of the Web JavaScript packages instead, such as `@rive-app/webgl2`, `@rive-app/canvas`, or `@rive-app/canvas-lite`.
         </Note>
+    </Tab>
+    <Tab title="Apple">
+        The Apple runtime uses the Rive Renderer. In the Swift Concurrency API, you can opt a worker into [GPU Canvas](/runtimes/apple/gpu-canvas) when it is created:
+
+        ```swift
+        let worker = try await Worker(
+            configuration: .init(enableGPUCanvas: true)
+        )
+        ```
+
+        GPU Canvas is required for 3D content. The setting applies to every file and renderer created with that worker and cannot be changed during the worker's lifetime.
     </Tab>
     <Tab title="Android (Legacy)">
         Options: `Canvas / Skia (removed in v10.0.0)`
@@ -99,4 +110,3 @@ If a runtime is not listed here, there is no renderer setup to configure. It use
         - Vector Feathering is only available with `Factory.rive`, so if you need that feature, use the Rive renderer.
     </Tab>
 </Tabs>
-

--- a/snippets/feature-support.jsx
+++ b/snippets/feature-support.jsx
@@ -53,6 +53,7 @@ export const FeatureSupportGroup = ({
     ]
 
     const featuresInOrder = [
+        "gpuCanvas",
         "globalViewModels",
         "dataBindingFonts",
         "semantics",
@@ -84,6 +85,27 @@ export const FeatureSupportGroup = ({
     ]
 
     const features = {
+        gpuCanvas: {
+            title: "GPU Canvas",
+            runtimes: {
+                webCanvas: { supported: false, description: "Coming soon" },
+                webCanvasLite: { supported: false, description: "NA" },
+                webWebGL: { supported: false, description: "Not supported" },
+                webWebGL2: { supported: false, description: "Coming soon" },
+                reactCanvas: { supported: false, description: "Coming soon" },
+                reactCanvasLite: { supported: false, description: "NA" },
+                reactWebGL: { supported: false, description: "Not supported" },
+                reactWebGL2: { supported: false, description: "Coming soon" },
+                reactNative: { supported: false, description: "Coming soon" },
+                reactNativeLegacy: { supported: false, description: "Not supported" },
+                flutter: { supported: false, description: "Coming soon" },
+                apple: { supported: true, version: "v6.25.0" },
+                android: { supported: false, description: "Coming soon" },
+                cpp: { supported: true, description: "Supported" },
+                unity: { supported: false, description: "Coming soon" },
+                unreal: { supported: false, description: "Coming soon" }
+            }
+        },
         globalViewModels: {
             title: "Global View Models",
             runtimes: {

--- a/snippets/runtimes/apple/shared-worker.mdx
+++ b/snippets/runtimes/apple/shared-worker.mdx
@@ -6,7 +6,7 @@
 ```swift AsyncShared.swift
 /// Lazily creates and caches a value. Failed initialization can be retried.
 @MainActor
-final class AsyncShared<Value: Sendable> {
+final class AsyncShared<Value> {
     private let makeValue: @MainActor () async throws -> Value
     private var cachedValue: Value?
     private var loadingTask: Task<Value, Error>?

--- a/snippets/runtimes/apple/shared-worker.mdx
+++ b/snippets/runtimes/apple/shared-worker.mdx
@@ -1,0 +1,67 @@
+<Note>
+  `AsyncShared` and the `Worker` extensions below are application-level helpers. They are not included with `RiveRuntime`.
+</Note>
+
+<CodeGroup>
+```swift AsyncShared.swift
+/// Lazily creates and caches a value. Failed initialization can be retried.
+@MainActor
+final class AsyncShared<Value> {
+    private let makeValue: @MainActor () async throws -> Value
+    private var cachedValue: Value?
+    private var loadingTask: Task<Value, Error>?
+
+    init(_ makeValue: @escaping @MainActor () async throws -> Value) {
+        self.makeValue = makeValue
+    }
+
+    func value() async throws -> Value {
+        if let cachedValue {
+            return cachedValue
+        }
+
+        let task = loadingTask ?? Task {
+            defer { loadingTask = nil }
+            let value = try await makeValue()
+            cachedValue = value
+            return value
+        }
+        loadingTask = task
+
+        return try await task.value
+    }
+}
+```
+
+```swift AsyncShared+Worker.swift
+import RiveRuntime
+
+extension AsyncShared where Value == Worker {
+    convenience init(configuration: Worker.Configuration = .init()) {
+        self.init {
+            try await Worker(configuration: configuration)
+        }
+    }
+}
+
+extension Worker {
+    @MainActor
+    private static let sharedWorker = AsyncShared<Worker>()
+
+    @MainActor
+    private static let sharedGPUCanvasWorker = AsyncShared<Worker>(
+        configuration: .init(enableGPUCanvas: true)
+    )
+
+    @MainActor
+    static func shared() async throws -> Worker {
+        try await sharedWorker.value()
+    }
+
+    @MainActor
+    static func sharedGPUCanvas() async throws -> Worker {
+        try await sharedGPUCanvasWorker.value()
+    }
+}
+```
+</CodeGroup>

--- a/snippets/runtimes/apple/shared-worker.mdx
+++ b/snippets/runtimes/apple/shared-worker.mdx
@@ -6,7 +6,7 @@
 ```swift AsyncShared.swift
 /// Lazily creates and caches a value. Failed initialization can be retried.
 @MainActor
-final class AsyncShared<Value> {
+final class AsyncShared<Value: Sendable> {
     private let makeValue: @MainActor () async throws -> Value
     private var cachedValue: Value?
     private var loadingTask: Task<Value, Error>?


### PR DESCRIPTION
## Summary

- add a dedicated Apple GPU Canvas setup page and navigation entry
- update the Apple quick start and renderer overview with the 3D opt-in
- add reusable application-level shared worker guidance for standard and GPU Canvas workers
- update the legacy migration guide to use the shared worker helper