### PR TITLE
docs(editor): globals binds are relative

### DIFF
--- a/editor/data-binding/binding-data.mdx
+++ b/editor/data-binding/binding-data.mdx
@@ -149,6 +149,11 @@ After the initial value is applied, future changes to the source or target are i
 
 By default, new data binding connections are created as absolute binds.
 
-- **Absolute Binding**: The binding points to a specific property instance within the View Model hierarchy.
-- **Relative Binding**: The binding searches for a property with a matching name relative to the current context.
+- **Absolute Binding** points to a specific property instance within the View Model hierarchy.
+- **Relative Binding** searches for a property with a matching name, starting with the closest View Model and working up the hierarchy.
 
+Because relative bindings resolve by name, a closer property with the same name can take precedence over the property you intended to bind. For example, if a binding targets a property named `scale` in the main View Model, but a closer View Model also contains a property named `scale`, the binding will resolve to the closer property.
+
+<Note>
+Bindings to [Global View Models](/editor/data-binding/view-models#global-view-model-instances) are always relative.
+</Note>

--- a/editor/data-binding/view-models.mdx
+++ b/editor/data-binding/view-models.mdx
@@ -133,13 +133,18 @@ Rive supports a few common patterns:
 
 ### Global View Model Instances
 
-Global view models are not connected to a specific artboard. Instead, the view model instance and its properties are directly accessible to all artboards.
+Global View Models provide data that can be accessed throughout your Rive file.
+
+Under the hood, global view models are not connected to a specific artboard. Instead, the view model instance and its properties are directly accessible to all artboards.
 
 <YouTube id="SPrxwHfPyP4" />
 
-<UseCase title="Game">
-A game's main view model might contain a `brandColor` or `score` property. This property might be used by various nested components, like the header, on buttons, or on a high scores screen.
-</UseCase>
+Bindings to Global View Model properties are always **relative bindings**. This means the binding searches for a property with the same name starting from the closest View Model, rather than pointing directly to the global property.
+
+If a closer View Model contains a property with the same name, that property will be used instead. For example, a binding to a global `scale` property will resolve to a `scale` property on a closer View Model if one exists.
+
+Learn more about [Absolute vs Relative Binding](/editor/data-binding/binding-data#absolute-vs-relative-binding).
+
 
 ### Instances Attached to Artboards
 


### PR DESCRIPTION
Documenting something that @pedroalpera resported here: https://2dimensions.slack.com/archives/C07MPAN5FDE/p1785742997402369

Globals use relative binding, which can result in naming conflicts. 