### PR TITLE
rive(editor & support): reorg nav with best practices in mind

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -86,8 +86,7 @@
                   "editor/keyboard-shortcuts",
                   "editor/workflows/dependency-graph",
                   "editor/tagging",
-                  "editor/fundamentals/revision-history",
-                  "getting-started/best-practices"
+                  "editor/fundamentals/revision-history"
                 ]
               }
             ]
@@ -220,6 +219,20 @@
                   "editor/exporting/exporting-for-video-and-static-design",
                   "editor/exporting/exporting-for-backup"
                 ]
+              },
+              {
+                "group": "Best Practices",
+                "pages": [
+                  "editor/best-practices/naming-conventions",
+                  "getting-started/best-practices",
+                  {
+                    "group": "Accessibility",
+                    "pages": [
+                      "editor/accessibility/semantics",
+                      "editor/accessibility/reduced-motion"
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -254,13 +267,6 @@
                       "editor/constraints/scroll-constraint"
                     ]
                   }
-                ]
-              },
-              {
-                "group": "Accessibility",
-                "pages": [
-                  "editor/accessibility/semantics",
-                  "editor/accessibility/reduced-motion"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -76,17 +76,9 @@
                   "editor/interface-overview/toolbar",
                   "editor/interface-overview/sidebar",
                   "editor/interface-overview/inspector",
-                  "editor/interface-overview/debug-panel"
-                ]
-              },
-              {
-                "group": "Workflows",
-                "pages": [
+                  "editor/interface-overview/debug-panel",
                   "editor/interface-overview/selection-and-navigation",
-                  "editor/keyboard-shortcuts",
-                  "editor/workflows/dependency-graph",
-                  "editor/tagging",
-                  "editor/fundamentals/revision-history"
+                  "editor/keyboard-shortcuts"
                 ]
               }
             ]
@@ -219,19 +211,19 @@
                   "editor/exporting/exporting-for-video-and-static-design",
                   "editor/exporting/exporting-for-backup"
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "group": "Best Practices",
+            "pages": [
+              "editor/best-practices/naming-conventions",
+              "getting-started/best-practices",
               {
-                "group": "Best Practices",
+                "group": "Accessibility",
                 "pages": [
-                  "editor/best-practices/naming-conventions",
-                  "getting-started/best-practices",
-                  {
-                    "group": "Accessibility",
-                    "pages": [
-                      "editor/accessibility/semantics",
-                      "editor/accessibility/reduced-motion"
-                    ]
-                  }
+                  "editor/accessibility/semantics",
+                  "editor/accessibility/reduced-motion"
                 ]
               }
             ]
@@ -270,24 +262,11 @@
                 ]
               },
               {
-                "group": "Admin & Workspaces",
+                "group": "File Management",
                 "pages": [
-                  {
-                    "group": "Workspaces",
-                    "pages": [
-                      "account-admin/workspaces/workspaces-overview",
-                      "account-admin/workspaces/managing-workspaces",
-                      "account-admin/workspaces/managing-workspace-members"
-                    ]
-                  },
-                  "account-admin/bring-your-own-bucket"
-                ]
-              },
-              {
-                "group": "Legacy Features",
-                "pages": [
-                  "editor/state-machine/inputs",
-                  "editor/events/general-events"
+                  "editor/workflows/dependency-graph",
+                  "editor/tagging",
+                  "editor/fundamentals/revision-history"
                 ]
               }
             ]
@@ -882,7 +861,16 @@
                   "account-admin/account-overview/delete-my-account",
                   "account-admin/workspaces/reactivating-a-canceled-workspace"
                 ]
-              }
+              },
+              {
+                "group": "Workspaces",
+                "pages": [
+                  "account-admin/workspaces/workspaces-overview",
+                  "account-admin/workspaces/managing-workspaces",
+                  "account-admin/workspaces/managing-workspace-members"
+                ]
+              },
+              "account-admin/bring-your-own-bucket"
             ]
           }
         ]

--- a/editor/best-practices/naming-conventions.mdx
+++ b/editor/best-practices/naming-conventions.mdx
@@ -1,0 +1,23 @@
+---
+title: "Naming Conventions"
+description: "Naming conventions and guidelines for keeping Rive files organized and maintainable."
+---
+
+Use consistent naming to make Rive files easier to navigate, maintain, and use at runtime. Some objects have specific naming conventions, while others only need clear, descriptive names.
+
+You don't need to name every object. Name objects that have a meaningful role, are referenced elsewhere, or help make the hierarchy easier to understand.
+
+| Object                | Convention              | Examples                      |
+| --------------------- | ----------------------- | ----------------------------- |
+| View models           | PascalCase, noun-based  | `Product`, `LightingSettings` |
+| View model properties | camelCase               | `name`, `productName`         |
+| Enums                 | PascalCase              | `Alignment`, `ButtonState`    |
+| Scripts               | PascalCase              | `Prism`, `InputMapper`        |
+| Script inputs         | camelCase               | `scale`, `bevelAmount`        |
+| Converters            | Transformation-based    | `Clamp`, `Convert to String`  |
+| Listeners             | Target or verb + target | `Button`, `Click Button`      |
+
+## General Guidelines
+
+- **Name things for what they represent or do, not their type.** Prefer `Product`, `Navigation`, and `PlayIcon` over `ProductVM`, `NavigationSM`, and `IconPath`.
+- **Coordinate on runtime-facing names.** If names will be accessed through runtime APIs or data binding, work with your developers to establish naming conventions that fit the project.

--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -1,9 +1,11 @@
 ---
-title: "Best Practices"
-description: "Editor & runtime performance and usage considerations."
+title: "Performance & Optimization"
+description: "Editor performance and usage considerations."
 ---
 
-Rive is built to efficiently play interactive graphics in the editor and at runtime in applications and games. However, poorly optimized animations can consume significant resources and cause poor performance, particularly on low-end devices. In the following sections, we will outline important considerations and tips for maintaining optimal performance and minimal resource utilization both during design/animate time in the Rive editor, as well as during runtime in applications.
+Rive is built to efficiently play interactive graphics in the editor and at runtime in applications and games. However, poorly optimized animations can consume significant resources and cause poor performance, particularly on low-end devices.
+
+In the following sections, we will outline important considerations and tips for maintaining optimal performance and minimal resource utilization both during design/animate time in the Rive editor, as well as during runtime in applications.
 
 <Info>
   We recommend continuous testing of your animations on your target devices/platforms.
@@ -23,7 +25,7 @@ Image, audio, and font assets are often the biggest source of bloat in .riv file
 
 #### Fonts
 
-Font files often include thousands of glyphs you may not need, such as Greek letters, mathematical operators, and icons. To reduce the size of the exported font or .riv file, [select which glyphs to include](/editor/text/fonts#glyph-%2F-script-selection).
+Font files often include thousands of glyphs you may not need, such as Greek letters, mathematical operators, and icons. To reduce the size of the exported font or .riv file, [select which glyphs to include](/editor/text/fonts#export-options).
 
 #### Raster Image Sizes & Dimensions
 
@@ -45,7 +47,7 @@ For the smallest image file size and best performance, we recommend exporting as
 
 Be efficient with the number of vertices in your vector image. While a few extra vertices won’t have much of an impact, thousands might. Be especially careful when importing vectors that were generated with AI, converted from raster images, or were created in drawing apps.
 
-### Layer Blend Modes for Web
+### Layer Blend Modes (Web)
 
 Blend modes are particularly expensive on the web because WebGL doesn’t expose mechanisms for accessing the framebuffer. To apply a blend mode, Rive must copy rendered pixels into a separate texture before compositing, which introduces significant performance and memory overhead.
 

--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Performance"
-description: "Editor performance and usage considerations."
+description: "Editor and runtime performance and usage considerations."
 ---
 
 Rive is built to efficiently play interactive graphics in the editor and at runtime in applications and games. However, poorly optimized animations can consume significant resources and cause poor performance, particularly on low-end devices.

--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Performance & Optimization"
+title: "Performance"
 description: "Editor performance and usage considerations."
 ---
 


### PR DESCRIPTION


- Remove `Workflows` from the top section
  - `Selection & Nav` and `Keyboard shortcuts` both move to `Editor Interface`
  - `Best Pactices` moves to its own section (see below)
  - `Dep graph`, `Tagging`, `Revision History` go into `Andvanced Topics/File Management`. These really didn't need to be before fundamentals. 
- `Fundamentals` doesn't change. 
- `Best Practices` - new top-level section. 
  - Makes `Accessibility` and other best practices more prominent. 
  - Add `Naming` page. 
- Advanced Topics
  - Move `Admin & Workspaces` to the support page. It makes more sense to have them next to other admin topics. 
  - `Legacy Features` - Sidebar is for nav we want people to go to. These legacy features were deprecated long enough ago that no reason to specifically drive people there. Search is enough. 

Before/After: 

<img width="926" height="1758" alt="CleanShot 2026-09-02 at 12 38 14@2x" src="https://github.com/user-attachments/assets/3ceab164-1d5e-48bd-b596-a2036eb34b4e" />

