### PR TITLE
Update scripting API documentation

### DIFF
--- a/scripting/api-reference/gpu/gpu-canvas.mdx
+++ b/scripting/api-reference/gpu/gpu-canvas.mdx
@@ -86,6 +86,8 @@ omitted; provide them explicitly when rendering to a different
 target (e.g. MSAA). The pass's sampleCount is derived from the
 attachments (WebGPU rule: all attachments share one sampleCount).
 Must be called during draw. Issue draw calls on the
-returned pass, then call `:finish()`.
+returned pass, then call `:finish()`. A pass may begin while another
+is open, as when a drawn artboard's own scripts render: it runs ahead
+of the pass it was begun inside, so that pass can sample its output.
 
 

--- a/scripting/api-reference/gpu/gpu-render-pass.mdx
+++ b/scripting/api-reference/gpu/gpu-render-pass.mdx
@@ -141,6 +141,7 @@ finish() -> ()
 ```
 </div>
 
-Submit the pass. Any further method calls on this object will error.
+Submit the pass, along with any pass begun inside it that is still
+open. Any further method calls on this object will error.
 
 


### PR DESCRIPTION
This PR updates the scripting API documentation generated from the rive repository.

Generated from commit: 5e4ad7e34e9176391d41eb897ab29bdc4e838b77
Repository: rive-app/rive
Workflow run: https://github.com/rive-app/rive/actions/runs/34080939062