### PR TITLE
docs(ios): document global file asset loading

### DIFF
--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -434,7 +434,7 @@ See [Semantics](/runtimes/apple/semantics) for the available modes and more deta
 
         The `Worker` object is responsible for creating and managing the background thread for the Rive instance.
 
-        Each worker shares out-of-band assets, such as images, fonts, and audio. This means that each `File` initialized with the same worker will share the same out-of-band assets.
+        Each worker shares global out-of-band assets, such as images, fonts, and audio. Query a file with `File.getAssets()` and register a replacement on its worker using the asset's `uniqueName`. The replacement applies to matching assets in files using that worker, including files already loaded and files loaded later. See [Loading Assets](/runtimes/apple/loading-assets) for examples.
 
         One worker roughly equates to one background thread. If you are rendering multiple heavy Rive graphics, you can create one `Worker` per file to have each processed on its own background thread.
 

--- a/runtimes/apple/loading-assets.mdx
+++ b/runtimes/apple/loading-assets.mdx
@@ -24,47 +24,153 @@ import Resources from '/snippets/runtimes/loading-assets/resources.mdx'
     <Tab title={"{{runtimeCurrentNameApple}}"}>
         This section assumes that you have read through the [Apple](/runtimes/apple/apple) overview.
 
-        Referenced assets can be added using the global asset APIs of a `Worker`.
+        ### Discovering and Loading File Assets
 
-        Adding global assets is a two-step process:
-        1. Decode the asset from its bytes
-        2. Add the asset to the worker
+        Use `File.getAssets()` to discover a file's assets, then decode and register replacements on its `Worker`. This replaces the legacy `customLoader` callback for out-of-band assets.
 
-        Global assets are push-based, meaning that you have to know the unique name of the asset ahead of time. You can retrieve the unique name of the asset from the exported `.zip` file containing the assets. The unique identifier is the identifier that is appended to the asset name (e.g `Font-1234`).
+        A global asset applies to matching assets in that file and other files loaded by the same worker, including files loaded later. Register it using `asset.uniqueName`. You can register assets after creating the file, and register a new asset under the same unique name to replace it.
 
-        There is no need to maintain a strong reference to the asset. The asset will be automatically cleaned up when the worker is disposed.
+        Each `File.Asset` provides the following metadata:
 
-        <CodeGroup>
-            ```swift Font
+        | Property | Description |
+        | --- | --- |
+        | `name` | The authored asset name stored in the file. |
+        | `uniqueName` | The exact name to pass to the worker's global asset APIs. |
+        | `assetID` | The asset identifier stored in the file. |
+        | `type` | `.image`, `.font`, `.audio`, or `.unknown(UInt16)`. |
+        | `fileExtension` | The file extension without a leading period. |
+        | `cdn` | Optional hosted asset metadata with `baseURL` and `uuid`. |
+
+        `getAssets()` includes embedded and referenced assets. Use the metadata to choose which assets your app supplies.
+
+        <Steps>
+            <Step title="Create a Worker and File">
+                Load the file before querying its asset metadata. Call these APIs from a main-actor async context.
+
+                ```swift
+                let worker = try await Worker()
+                let file = try await File(
+                    source: .local("my_rive_file", .main),
+                    worker: worker
+                )
+                ```
+            </Step>
+            <Step title="Choose and Load Assets">
+                Iterate the file's assets and use their metadata to locate their bytes. This example matches bundled resources using each asset's `uniqueName` and `fileExtension`, skipping unknown asset types and resources that are not bundled.
+
+                ```swift
+                for asset in try await file.getAssets() {
+                    if case .unknown = asset.type { continue }
+                    guard let url = Bundle.main.url(
+                        forResource: asset.uniqueName,
+                        withExtension: asset.fileExtension
+                    ) else { continue }
+
+                    let data = try await Task.detached {
+                        try Data(contentsOf: url)
+                    }.value
+
+                    // Decode and register the asset here, as shown below.
+                }
+                ```
+            </Step>
+            <Step title="Register Global Assets">
+                Inside the loop, decode each asset with the worker and register it using `asset.uniqueName`. The worker applies it to files using that unique name.
+
+                ```swift
+                switch asset.type {
+                case .image:
+                    let image = try await worker.decodeImage(from: data)
+                    worker.addGlobalImageAsset(image, name: asset.uniqueName)
+                case .font:
+                    let font = try await worker.decodeFont(from: data)
+                    worker.addGlobalFontAsset(font, name: asset.uniqueName)
+                case .audio:
+                    let audio = try await worker.decodeAudio(from: data)
+                    worker.addGlobalAudioAsset(audio, name: asset.uniqueName)
+                case .unknown:
+                    break
+                }
+                ```
+            </Step>
+        </Steps>
+
+        #### Complete Example
+
+        This example loads bundled resources whose filenames match each asset's `uniqueName` plus its `fileExtension` (for example, `picture-47982.jpeg`). It skips assets without a matching bundled resource and leaves them unchanged.
+
+        ```swift
+        @MainActor
+        func loadFileWithAssets() async throws -> File {
             let worker = try await Worker()
-            let fontData: Data = ...
-            let font = try await worker.decodeFont(from: fontData)
-            worker.addGlobalFontAsset(font, name: "MyFont-1234")
+            let file = try await File(
+                source: .local("my_rive_file", .main),
+                worker: worker
+            )
 
-            // If you would like to clean up the asset
-            worker.removeGlobalFontAsset(name: "MyFont-1234")
-            ```
+            for asset in try await file.getAssets() {
+                if case .unknown = asset.type { continue }
+                guard let url = Bundle.main.url(
+                    forResource: asset.uniqueName,
+                    withExtension: asset.fileExtension
+                ) else { continue }
 
-            ```swift Audio
-            let worker = try await Worker()
-            let audioData: Data = ...
-            let font = try await worker.decodeAudio(from: audioData)
-            worker.addGlobalAudioAsset(audio, name: "MyAudio-1234")
+                let data = try await Task.detached {
+                    try Data(contentsOf: url)
+                }.value
 
-            // If you would like to clean up the asset
-            worker.removeGlobalAudioAsset(name: "MyAudio-1234")
-            ```
+                switch asset.type {
+                case .image:
+                    let image = try await worker.decodeImage(from: data)
+                    worker.addGlobalImageAsset(image, name: asset.uniqueName)
+                case .font:
+                    let font = try await worker.decodeFont(from: data)
+                    worker.addGlobalFontAsset(font, name: asset.uniqueName)
+                case .audio:
+                    let audio = try await worker.decodeAudio(from: data)
+                    worker.addGlobalAudioAsset(audio, name: asset.uniqueName)
+                case .unknown:
+                    break
+                }
+            }
 
-            ```swift Image
-            let worker = try await Worker()
-            let imageData: Data = ...
-            let image = try await worker.decodeImage(from: imageData)
-            worker.addGlobalImageAsset(image, name: "MyImage-1234")
+            return file
+        }
+        ```
 
-            // If you would like to clean up the asset
-            worker.removeGlobalImageAsset(name: "MyImage-1234")
-            ```
-        </CodeGroup>
+        Create your `Rive` and view from the returned file. You can also register replacements after displaying a file. Using the same unique name updates matching assets across files on that worker; use separate workers when those files need different replacements.
+
+        ### Loading Hosted Assets
+
+        The new runtime does not automatically fetch hosted assets. For an asset with `cdn` metadata, fetch its bytes from `baseURL` with `uuid` appended as a path component, then decode and register it using the same global asset APIs.
+
+        For example, inside an asset loop, load hosted images with:
+
+        ```swift
+        guard asset.type == .image,
+              let cdn = asset.cdn,
+              let baseURL = URL(string: cdn.baseURL)
+        else { continue }
+
+        let url = baseURL.appendingPathComponent(cdn.uuid)
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let response = response as? HTTPURLResponse,
+              (200..<300).contains(response.statusCode)
+        else { throw URLError(.badServerResponse) }
+
+        let image = try await worker.decodeImage(from: data)
+        worker.addGlobalImageAsset(image, name: asset.uniqueName)
+        ```
+
+        ### Managing Global Assets
+
+        The worker retains registered assets, so you do not need to keep a separate strong reference while they are registered. To remove a registration, use the corresponding API with the same unique name:
+
+        ```swift
+        worker.removeGlobalImageAsset(name: imageAsset.uniqueName)
+        worker.removeGlobalFontAsset(fontAsset.uniqueName)
+        worker.removeGlobalAudioAsset(name: audioAsset.uniqueName)
+        ```
     </Tab>
     <Tab title={"{{runtimeLegacyNameApple}}"}>
         ### Examples

--- a/runtimes/apple/migrating-from-legacy.mdx
+++ b/runtimes/apple/migrating-from-legacy.mdx
@@ -614,7 +614,7 @@ riveView.frameRate = .default
 
 #### {{runtimeLegacyNameApple}}
 
-The legacy runtime uses a pull model via a callback that resolves assets on demand.
+The legacy runtime uses a `customLoader` callback to inspect assets and provide their contents while loading a file.
 
 ```swift
 let viewModel = RiveViewModel(fileName: "my_rive_file") { asset, _, factory in
@@ -638,19 +638,39 @@ let viewModel = RiveViewModel(fileName: "my_rive_file") { asset, _, factory in
 
 #### {{runtimeCurrentNameApple}}
 
-The new runtime uses a push model, where assets are registered on the worker ahead of use.
+Use `File.getAssets()` and the worker's global asset APIs in place of `customLoader`. Create the file, inspect its asset metadata, then decode and register the assets your app supplies. You no longer need to know their unique names before loading the file.
+
+This example replaces an image selected by its authored name:
 
 ```swift
 let worker = try await Worker.shared()
-let image = try await worker.decodeImage(from: Data(...))
-worker.addGlobalImageAsset(image, name: "MyImage-1234")
+let file = try await File(
+    source: .local("my_rive_file", .main),
+    worker: worker
+)
 
-let font = try await worker.decodeFont(from: Data(...))
-worker.addGlobalFontAsset(font, name: "MyFont-1234")
+for asset in try await file.getAssets() {
+    guard asset.type == .image, asset.name == "picture.jpeg" else { continue }
+    guard let url = Bundle.main.url(
+        forResource: asset.uniqueName,
+        withExtension: asset.fileExtension
+    ) else { throw URLError(.fileDoesNotExist) }
 
-let audio = try await worker.decodeAudio(from: Data(...))
-worker.addGlobalAudioAsset(audio, name: "MyAudio-1234")
+    let data = try await Task.detached {
+        try Data(contentsOf: url)
+    }.value
+    let image = try await worker.decodeImage(from: data)
+    worker.addGlobalImageAsset(image, name: asset.uniqueName)
+}
+
+let rive = try await Rive(file: file)
 ```
+
+Use `asset.uniqueName` as the registration key. The replacement applies to this file and any other files using that unique name on the same worker, including files loaded later. You can also register or replace global assets after the file is displayed.
+
+For fonts and audio, use `decodeFont(from:)` / `addGlobalFontAsset(_:name:)` and `decodeAudio(from:)` / `addGlobalAudioAsset(_:name:)`. There is no callback return value: your app chooses which assets to register after inspecting the metadata.
+
+See [Loading Assets](/runtimes/apple/loading-assets) for the full metadata reference, examples for all three asset types, and hosted asset loading.
 
 ### Logging
 
@@ -727,9 +747,9 @@ The new runtime supports async constructors and async view wrappers (`RiveUIView
 
 Some features in the legacy runtime are intentionally not present in the new runtime.
 
-### CDN Assets
+### Automatic CDN Asset Loading
 
-Legacy file loading may use CDN-backed asset flows (for example via `loadCdn` behavior). The new runtime's asset model is worker-based and push-oriented via explicit asset registration APIs.
+The legacy runtime can fetch hosted assets automatically through `loadCdn`. In the new runtime, query `File.getAssets()` and use each asset's optional `cdn` metadata to fetch its bytes yourself, then decode and register it with the worker using `asset.uniqueName`. See [Loading Hosted Assets](/runtimes/apple/loading-assets#loading-hosted-assets).
 
 ### State Machine Inputs
 


### PR DESCRIPTION
Document the replacement for the legacy `customLoader`: create a file, inspect its assets, and register global images, fonts, or audio using each asset's `uniqueName`. Matching assets share the replacement across files on the same worker, even after loading.

Updates the Apple migration guide, asset-loading walkthrough and examples, and overview. Includes explicit CDN loading using asset metadata.

Validation: `mint broken-links` and `git diff --check`.
