### PR TITLE
docs: update headings to sentence case

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -49,8 +49,8 @@ Use headings to organize the page and make it easy to scan.
 - Use `##` for top-level page sections.
 - Use heading levels in order. Don't skip from `##` to `####`.
 - Avoid going past `####`.
-- Use title case for headings.
-- Prefer gerunds for task-based headings, such as **Creating Shapes** instead of **Create Shapes**.
+- Use sentence case for headings: capitalize only the first word and proper nouns (product names, platforms, APIs) and Rive feature terms (State Machine, Data Binding, View Model, Artboard, Layout, Timeline).
+- Prefer gerunds for task-based headings, such as **Creating shapes** instead of **Create shapes**.
 
 ## UI Labels and Product Terms
 

--- a/account-admin/account-overview/billing-changes.mdx
+++ b/account-admin/account-overview/billing-changes.mdx
@@ -6,7 +6,7 @@ description: "How to update your card, change your plan, or manage billing for y
 ⚠️ If you have a pending change (like a scheduled cancellation), you can't make other billing changes until it's resolved. <a href={"{{supportForm}}"}>Contact support</a> if you're stuck.
 
 
-## Where to Manage Billing
+## Where to manage billing
 
 1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Find your workspace under "Workspaces"
@@ -21,7 +21,7 @@ From here you can:
 
 ---
 
-## Update Your Payment Card
+## Update your payment card
 
 1. Click "Manage Billing" to open the Stripe Customer Portal
 2. Go to "Payment Methods"
@@ -35,7 +35,7 @@ Access is typically restored within a few minutes.
 
 ---
 
-## Change Your Plan
+## Change your plan
 
 Click "Change Plan" from the Manage Workspace page to switch between Free and Voyager.
 
@@ -43,7 +43,7 @@ Click "Change Plan" from the Manage Workspace page to switch between Free and Vo
 
 ---
 
-## If Your Card Keeps Getting Declined
+## If your card keeps getting declined
 
 Call your bank first. Common issues:
 
@@ -54,13 +54,13 @@ After your bank clears it, wait 30 minutes and try again. Still not working? Try
 
 ---
 
-## Multiple Workspaces?
+## Multiple workspaces?
 
 Each workspace has its own billing. Make sure you're managing the right one—check the workspace name at the top of the Manage Workspace page.
 
 ---
 
-## For Team Members
+## For team members
 
 Only the workspace owner can update billing. If you're seeing access errors due to a payment issue, let the owner know.
 

--- a/account-admin/account-overview/delete-my-account.mdx
+++ b/account-admin/account-overview/delete-my-account.mdx
@@ -3,7 +3,7 @@ title: "Delete My Account"
 description: "Deleting your account is permanent and removes all your data after 90 days."
 ---
 
-## Before You Can Delete
+## Before you can delete
 
 You need to remove all workspaces from your account first:
 
@@ -14,13 +14,13 @@ You need to remove all workspaces from your account first:
    - Then click "Delete Workspace"
 3. Once all workspaces are removed, you can delete your account
 
-## What Happens to Your Data
+## What happens to your data
 
 - Your account and data are deleted 90 days after cancellation
 - Files you contributed to other people's workspaces are **not** deleted
 - Content others have remixed from your Marketplace uploads is **not** deleted
 
-## If You Own a Workspace With Members
+## If you own a workspace with members
 
 Deleting your account suspends access for everyone in your workspace. If you want the workspace to continue, transfer ownership to another admin before deleting your account. See [Transfer Workspace Ownership](/account-admin/workspaces/managing-workspaces#transferring-workspace-ownership).
 

--- a/account-admin/bring-your-own-bucket.mdx
+++ b/account-admin/bring-your-own-bucket.mdx
@@ -7,7 +7,7 @@ description: "Configure your own AWS S3 bucket to work with Rive"
 This feature is available exclusively to Enterprise plan customers. If you're interested in upgrading to unlock this capability, [contact us](https://rive.app/enterprise?utm_source=docs&utm_medium=content).
 </Note>
 
-## What is a Custom S3 Bucket?
+## What is a custom S3 bucket?
 
 A custom S3 bucket allows Enterprise customers to store their Rive file and asset data in their own AWS environment instead of Rive's default storage. This premium feature gives you greater control over your data, allowing you to:
 

--- a/account-admin/pricing.mdx
+++ b/account-admin/pricing.mdx
@@ -15,7 +15,7 @@ For full details and feature comparison, see [rive.app/pricing](https://rive.app
 
 Annual billing saves money but requires full payment upfront.
 
-## What's Included
+## What's included
 
 **Free**
 
@@ -49,7 +49,7 @@ Annual billing saves money but requires full payment upfront.
 
 ---
 
-## Legacy Pricing
+## Legacy pricing
 
 If you're on a legacy plan, your pricing is locked in as long as your plan stays active. Adding users may move you to current pricing. If your plan cancels, legacy pricing cannot be reinstated.
 

--- a/account-admin/workspaces/managing-workspace-members.mdx
+++ b/account-admin/workspaces/managing-workspace-members.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Workspace Members"
 description: "Add, remove, and change the roles of members in a workspace."
 ---
 
-## Member Roles
+## Member roles
 
 | Role       | What they can do               | Cost      |
 | :--------- | :----------------------------- | :-------- |
@@ -13,7 +13,7 @@ description: "Add, remove, and change the roles of members in a workspace."
 | **Editor** | View and edit files            | Paid seat |
 | **Admin**  | View, edit, and manage members | Paid seat |
 
-## Inviting Members to a Workspace
+## Inviting members to a workspace
 
 Inviting a member to a workspace gives them access to all projects in that workspace.
 
@@ -40,7 +40,7 @@ Inviting a member to a workspace gives them access to all projects in that works
   For paid workspaces, you're charged a prorated amount immediately for each Editor or Admin seat.
 </Note>
 
-## Accepting an Invite to a Workspace
+## Accepting an invite to a workspace
 
 <Steps>
   <Step>
@@ -51,7 +51,7 @@ Inviting a member to a workspace gives them access to all projects in that works
   </Step>
 </Steps>
 
-## Changing Member Roles
+## Changing member roles
 
 <Steps>
   <Step>
@@ -72,7 +72,7 @@ Inviting a member to a workspace gives them access to all projects in that works
   For paid workspaces, you're charged a prorated amount immediately for each Editor or Admin seat.
 </Note>
 
-## Removing Members from a Workspace
+## Removing members from a workspace
 
 Admins can remove members from a workspace at any time.
 

--- a/account-admin/workspaces/managing-workspaces.mdx
+++ b/account-admin/workspaces/managing-workspaces.mdx
@@ -6,7 +6,7 @@ description: "Create, upgrade, transfer, and delete workspaces."
 
 import { VideoEmbed } from '/snippets/video-embed.jsx'
 
-## Workspace Admin
+## Workspace admin
 
 The workspace admin lets you:
 
@@ -18,7 +18,7 @@ To view the workspace admin, go to the editor **Home** tab, open the dropdown ne
 
 <VideoEmbed src="https://static.rive.app/video/workspace-status.mp4" />
 
-## Creating a New Workspace
+## Creating a new workspace
 
 Create a new workspace when you want a separate space for a team or project.
 
@@ -42,7 +42,7 @@ Create a new workspace when you want a separate space for a team or project.
 
 You should now see an empty workspace with a **Personal** project. You can create files in this workspace.
 
-## Upgrading a Workspace
+## Upgrading a workspace
 
 For more information about plans and features, see [Pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).
 
@@ -68,7 +68,7 @@ For more information about plans and features, see [Pricing](https://rive.app/pr
   </Step>
 </Steps>
 
-## Transferring Workspace Ownership
+## Transferring workspace ownership
 
 <Steps>
   <Step>
@@ -86,7 +86,7 @@ For more information about plans and features, see [Pricing](https://rive.app/pr
 
 We'll handle the transfer for you.
 
-## Deleting a Workspace
+## Deleting a workspace
 
 <Note>
   If you want to cancel your plan without permanently deleting your files, see [Cancel Your Plan](/account-admin/account-overview/cancel-my-account).

--- a/account-admin/workspaces/reactivating-a-canceled-workspace.mdx
+++ b/account-admin/workspaces/reactivating-a-canceled-workspace.mdx
@@ -14,7 +14,7 @@ Your workspace is now active again.
 
 ---
 
-## ⚠️ Don't Create a New Workspace by Mistake
+## ⚠️ Don't create a new workspace by mistake
 
 "Create new Workspace" is **not** the same as reactivating. If you have multiple workspaces, double-check you're reactivating the right one—each workspace has a display name and a username.
 

--- a/account-admin/workspaces/workspaces-overview.mdx
+++ b/account-admin/workspaces/workspaces-overview.mdx
@@ -20,7 +20,7 @@ For example, you might have:
 </Note>
 
 
-## Switching Workspaces
+## Switching workspaces
 
 To view or work with files in another workspace, go to the editor Home tab, click the dropdown next to the workspace name, and hover over Switch Workspace.
 

--- a/community/support.mdx
+++ b/community/support.mdx
@@ -4,11 +4,11 @@ description: 'Choose the best way to get help with Rive—from community support
 ---
 
 
-## Quick Links
+## Quick links
 
 Not sure where to start? Ask in the [community](https://community.rive.app/c/support?utm_source=docs&utm_medium=support_page&utm_content=peer_support) — you’ll usually get the fastest response.
 
-### Get Help
+### Get help
 
 - [Peer-to-peer Support](https://community.rive.app/c/support?utm_source=docs&utm_medium=support_page&utm_content=peer_support) — Best for how-to questions, learning Rive, and general debugging help from the community
 - [Voyager Support](https://community.rive.app/c/voyager-support?utm_source=docs&utm_medium=support_page&utm_content=voyager_support) — Priority support with direct help from the Rive team for production issues and blocking bugs (included with Voyager)
@@ -20,7 +20,7 @@ Not sure where to start? Ask in the [community](https://community.rive.app/c/sup
   For faster, more accurate help, include a `.rev` file, a video, a code snippet, and a minimal example.
 </Tip>
 
-### Report & Request
+### Report & request
 
 - [Report a Bug](https://community.rive.app/c/bug-reports?utm_source=docs&utm_medium=support_page&utm_content=bug_report) — Report issues with the editor or runtimes
 - [Request a Feature](https://community.rive.app/c/feature-requests?utm_source=docs&utm_medium=support_page) — Suggest improvements or new features

--- a/editor/accessibility/reduced-motion.mdx
+++ b/editor/accessibility/reduced-motion.mdx
@@ -14,17 +14,17 @@ Rive can’t automatically decide which motion should be reduced because motion 
   Reduced motion preferences are usually detected by the app or platform, then passed into the Rive file at runtime. For web, this often starts with the `prefers-reduced-motion` media feature. See [MDN’s `prefers-reduced-motion` documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/prefers-reduced-motion) for accessibility guidance.
 </Info>
 
-## Common Strategies
+## Common strategies
 
 <Demos examples={['accessibilityReducedMotion']} />
 
-### Use a Separate Reduced-Motion Path
+### Use a separate reduced-motion path
 
 For complex interactions and decorative motion, create separate state machine paths for full motion and reduced motion. Use a `prefersReducedMotion` Boolean property to choose which path runs.
 
 <VideoEmbed src="https://static.rive.app/video/reduced-motion-state-machine.mp4" />
 
-### Reduce or Disable Animation Speed
+### Reduce or disable animation speed
 
 For simpler cases, bind transition durations, timeline speeds, or animation speeds to a property that changes when reduced motion is enabled.
 
@@ -59,17 +59,17 @@ For example, full motion might use a normal speed value, while reduced motion us
   Now when `prefersReducedMotion` is `true`, the animation speed will be 0.
 </Tip>
 
-### Replace Motion With Non-Motion Feedback
+### Replace motion with non-motion feedback
 
 Reduced motion does not always mean removing feedback. Instead of movement, scale, rotation, or bounce, use changes in opacity, or color.
 
 <VideoEmbed src="https://static.rive.app/video/reduced-motion-non-motion.mp4" />
 
-### Reduce Distance
+### Reduce distance
 
 Large spatial movement can be difficult even when it is slow. Consider reducing the distance an object travels, or replacing large movement with a small offset and fade.
 
-## Runtime Setup
+## Runtime setup
 
 At runtime, use [data binding](/runtimes/data-binding) to pass the user’s motion preference into the Rive file.
 

--- a/editor/accessibility/semantics.mdx
+++ b/editor/accessibility/semantics.mdx
@@ -29,7 +29,7 @@ Semantics describe what an element is and how it should be understood. Adding se
   Rive handles mapping your semantics to each platform automatically. For details on which runtimes currently support semantics, see [Feature Support](/feature-support).
 </Note>
 
-## Adding Semantics
+## Adding semantics
 
 ![Adding semantics](/images/accessibility/semantics/adding-semantics.gif)
 
@@ -45,7 +45,7 @@ Semantics describe what an element is and how it should be understood. Adding se
   </Step>
 </Steps>
 
-### Semantic Role
+### Semantic role
 
 The semantic role defines what the element *is* (for example, a button or image). Screen readers use this to describe the element and determine how it should behave.
 
@@ -57,7 +57,7 @@ If your element doesn’t match a specific role, you can leave it set to **None*
   Some elements, like text, automatically infer their semantic role. See [Semantic Inference](#semantic-inference) for more info.
 </Info>
 
-## Semantic Properties
+## Semantic properties
 
 Semantic properties provide additional information about an element, such as its label, value, or hint.
 
@@ -74,7 +74,7 @@ For example, a slider that controls volume might have the label:
   Text elements automatically use their text content as the label. See [Semantic Inference](#semantic-inference) for more info.
 </Info>
 
-### Heading (Text only)
+### Heading (text only)
 
 Text elements can be marked as headings to define structure and hierarchy.
 
@@ -86,7 +86,7 @@ Headings help screen reader users navigate your content more easily.
   On web, Heading 1 maps to an `<h1>` element, Heading 2 to `<h2>`, and so on.
 </Info>
 
-### Value (Inputs only)
+### Value (inputs only)
 
 Some elements, like sliders and switches, have a **Value** property that reflects their current state.
 
@@ -140,7 +140,7 @@ Indicates that the element’s content may update dynamically and should be anno
 Semantic actions are interaction events triggered by assistive technologies. You can listen for these actions and update your experience in response.
 
 
-### Adding an Action
+### Adding an action
 
 <Steps>
   <Step title="Create a Listener">
@@ -154,7 +154,7 @@ Semantic actions are interaction events triggered by assistive technologies. You
   </Step>
 </Steps>
 
-### Types of Actions
+### Types of actions
 
 Actions include **tap**, **increase**, and **decrease**. Additional actions may be added in future releases.
 
@@ -168,7 +168,7 @@ When a user activates an element using a screen reader, a **tap** action is trig
   It’s common to add both a **Click** and a **Semantic Tap** listener to the same element to support pointer and assistive interactions.
 </Note>
 
-#### Increase / Decrease
+#### Increase / decrease
 
 Used for adjustable elements like sliders.
 
@@ -177,7 +177,7 @@ Users trigger these actions through assistive technologies—for example, by foc
 You should listen for **increase** and **decrease** and update your value accordingly.
 
 
-### Semantic Inference
+### Semantic inference
 
 Some roles and properties are inferred based on the element they are applied to.
 
@@ -185,13 +185,13 @@ For example, when adding semantics to a text element, the [Role](#semantic-role)
 
 ---
 
-## Testing Semantics
+## Testing semantics
 
 Adding semantics is only the first step. You should always test your experience at runtime to make sure it behaves as expected.
 
 Small issues—like a missing label or incorrect state—can make elements confusing or unusable for screen reader users.
 
-### Runtime Testing
+### Runtime testing
 
 The best way to test semantics is by using a screen reader.
 
@@ -204,7 +204,7 @@ Turn on a screen reader and navigate through your experience:
 - Listen to how each element is announced
 - Interact with buttons, sliders, and inputs
 
-### What to Check
+### What to check
 
 As you test, pay attention to:
 

--- a/editor/ai-agent/ai-agent.mdx
+++ b/editor/ai-agent/ai-agent.mdx
@@ -7,7 +7,7 @@ description: "Rive's AI agent helps you write code, design, and animate."
 
 Rive's AI agent helps you write code, design, and animate. Generate scripts, responsive layouts, data models, and even animation.
 
-## Getting Started
+## Getting started
 
 Open the **Agent panel** from the left sidebar and type a prompt describing what you want.
 

--- a/editor/ai/mcp.mdx
+++ b/editor/ai/mcp.mdx
@@ -13,7 +13,7 @@ You can connect the Rive Editor to AI tools through MCP (Model Context Protocol)
 
 <YouTube id="_a2Y4vzuGAs" />
 
-### Supported Features
+### Supported features
 
 - **Create and manage Rive files** — add, rename, resize, arrange, and focus artboards.
 - **Inspect and edit the scene** — query hierarchies, select objects, update properties, rename, duplicate, reorder, reparent, or delete elements.

--- a/editor/animate-mode/animate-mode-overview.mdx
+++ b/editor/animate-mode/animate-mode-overview.mdx
@@ -16,7 +16,7 @@ In Animate Mode, the editor shows animation tools such as the timeline, animatio
 
 <YouTube id="4U3er1uSjBw" />
 
-### Learn more about Animate mode
+### Learn more about Animate Mode
 
 <CardGroup cols={2}>
   <Card
@@ -49,7 +49,7 @@ In Animate Mode, the editor shows animation tools such as the timeline, animatio
   </Card>
 </CardGroup>
 
-## Use case: Building a Bouncing Ball
+## Use case: building a bouncing ball
 
 This video walks you through animating a bouncing ball in Rive. We cover keyframes, interpolation and a couple classic principles of animation.
 

--- a/editor/animate-mode/animating-draw-order.mdx
+++ b/editor/animate-mode/animating-draw-order.mdx
@@ -11,7 +11,7 @@ You can change the draw order of your graphics at design time by moving items up
 
 <YouTube id="6J3JIwgUwe0" />
 
-## Draw Order Rules
+## Draw Order rules
 
 To animate the draw order of a group or shape, start by selecting it. Use the Draw Order section of the Inspector to create Draw Order Rules.
 

--- a/editor/animate-mode/interpolation-easing.mdx
+++ b/editor/animate-mode/interpolation-easing.mdx
@@ -11,9 +11,9 @@ When you set two keys on a property, the value in between those keys is automati
 
 You can set the easing on your keys by either using the Interpolation panel to the right of the Timeline, or by using the Graph Editor, which you can toggle on via the shortcut near the Timeline options.
 
-## Using the Interpolation Panel
+## Using the Interpolation panel
 
-The Interpolation Panel appears to the right of the timeline when you select any number of keys on the timeline.
+The Interpolation panel appears to the right of the timeline when you select any number of keys on the timeline.
 
 ![Image](/images/editor/animate-mode/dfb3cbee-603c-4fd5-932f-ad07defaaca2.webp)
 
@@ -57,19 +57,19 @@ When inputting values manually, use a comma or a space to separate each of the f
 
 ![Image](https://ucarecdn.com/b8f9898c-ea40-404f-8749-daf1fec86325/)
 
-## Default Interpolation
+## Default interpolation
 
 You can set a default interpolation to control the interpolation used by new keys.
 
 There are two ways to set the default interpolation:
 
-### Set a Selected Key as the Default
+### Set a selected key as the default
 
 Select a key, then open the interpolation options in the Inspector and click Set as default.
 
 ![Set current interpolation as default](/images/editor/animate-mode/interpolation-set-as-default.png)
 
-### Set the Default from the Inspector
+### Set the default from the Inspector
 
 Deselect everything on the stage. The Inspector shows the default interpolation options for new keys.
 
@@ -94,11 +94,11 @@ Note that only objects that are selected will appear on the Graph Editor.
 
 The Graph Editor gives a visual representation of the current interpolation. You have two ways to edit the interpolation on the graph.
 
-#### Using Cubic interpolation
+#### Using cubic interpolation
 
 Cubic interpolation describes the easing function applied between one key and the next, much like a cubic Bezier easing curve in CSS. It shapes how fast the value changes over time, but it always lands exactly on the values you keyed. Adjust a Cubic curve from the Interpolation Panel; the Graph Editor shows the curve, but you set it from the panel.
 
-#### Using Cubic Value
+#### Using cubic value
 
 Cubic Value gives you draggable Bezier handles directly on the Graph Editor, similar to After Effects. Because Rive stores the X and Y position of each handle, it uses a little more data than Cubic, but it gives you much more control over the motion, including the ability to overshoot a value before settling on the final key.
 

--- a/editor/animate-mode/keys.mdx
+++ b/editor/animate-mode/keys.mdx
@@ -8,7 +8,7 @@ import { VideoEmbed } from '/snippets/video-embed.jsx'
 
 <YouTube id="BiaWH6rHd7o" />
 
-### Set Keys
+### Set keys
 
 Objects and their properties appear on the Timeline once they have been keyed. There are a few different ways to key a property. You can manipulate an object directly on the Stage (which will set keys for any resulting transformation, like position, rotation, or scale) or change the property in the Inspector. You can also use the key button that appears next to any property that can be animated. This will set a key for the current value.
 
@@ -24,7 +24,7 @@ Keyed objects and their properties appear on rows in the timeline. Keys for prop
 
 You can change a key's position on the timeline by clicking and dragging it to the desired location. Use the grey keys to move all of the keyed properties of an object or use the blue keys to change a single property's location.
 
-## Binding Key Values
+## Binding key values
 
 You can [data bind](/editor/data-binding/overview) the value stored in a key. This lets a keyed value come from data instead of being fixed directly on the timeline.
 
@@ -44,11 +44,11 @@ Once bound, the key uses the bound value when the animation reaches that point i
 
 <VideoEmbed src="https://static.rive.app/video/bind-key.mp4" />
 
-### Copy Keys
+### Copy keys
 
 You can copy the keys from one object to another by copying the property keys from the animated object and pasting them to another object.
 
-## Resize Keys
+## Resize keys
 
 You can resize a selection of keys by holding `alt` and dragging them from the start or end. This serves as a quick way to shrink or lengthen a selection of keys.
 

--- a/editor/animate-mode/timeline.mdx
+++ b/editor/animate-mode/timeline.mdx
@@ -31,13 +31,13 @@ The Navigate Timeline menu gives you a list of helpful shortcuts to navigate the
 
 ![Image](/images/editor/animate-mode/08ccf645-e2df-43e5-8bc6-0fa64ab264f5.webp)
 
-## Show Only Selected
+## Show only selected
 
 The Show Only Selected toggle can be helpful when dealing with animations with many different objects keyed. When this option is toggled on, only objects that you have selected will appear on the timeline.
 
 ![Image](/images/editor/animate-mode/31b183db-26be-400f-be2c-52a6ab73bd03.webp)
 
-## Timeline Options
+## Timeline options
 
 Located to the right of the playback select, the Timeline Options show you the current time, duration, playback speed, and snap keys options.
 

--- a/editor/assets/audio.mdx
+++ b/editor/assets/audio.mdx
@@ -6,11 +6,11 @@ description: Import, clip, and configure audio assets in Rive.
 import { VideoEmbed } from '/snippets/video-embed.jsx'
 
 
-## Importing Audio
+## Importing audio
 
 See [Importing Assets](/editor/fundamentals/assets-overview#importing-assets) for information about importing files, including MP3, WAV, and FLAC files.
 
-### Browse Sounds
+### Browse sounds
 
 Browse Sounds gives you direct access to a free library of over 3,000 sounds from Soundly.
 
@@ -30,7 +30,7 @@ Browse Sounds gives you direct access to a free library of over 3,000 sounds fro
 
 After adding a sound to the Assets panel, you can use it in an [Audio Event](/editor/events/audio-events) or reference it from a [script](/scripting/getting-started).
 
-## Export Options
+## Export options
 
 Audio assets include a **Source** option that controls the audio format used for export.
 
@@ -39,7 +39,7 @@ Audio assets include a **Source** option that controls the audio format used for
 - **FLAC**: Export the audio as FLAC.
 - **MP3**: Export the audio as MP3.
 
-## Previewing Sounds
+## Previewing sounds
 
 You can create a shorter clip from any audio asset.
 
@@ -57,7 +57,7 @@ You can create a shorter clip from any audio asset.
 
 ![Audio asset volume](/images/editor/assets/preview-audio.png)
 
-## Creating Clips
+## Creating clips
 
 You can create a shorter clip from any audio asset.
 
@@ -80,7 +80,7 @@ The new clip will now appear as its own audio asset under the parent audio in th
 
 <VideoEmbed src="https://static.rive.app/video/create-audio-clip.mp4" />
 
-## Setting Asset Volume
+## Setting asset volume
 
 Select an audio asset or clip to set its **Volume** in the Inspector.
 

--- a/editor/assets/lottie.mdx
+++ b/editor/assets/lottie.mdx
@@ -11,11 +11,11 @@ Lottie import lets you bring .lottie animations into Rive as a starting point fo
 
 Lottie files can vary significantly depending on how they were created, exported, and used. Importing them into Rive can introduce risks that vary across customer setups, including performance and reliability considerations. Helping customers assess and mitigate these risks takes significant time and support, which is why this workflow is available on Enterprise.
 
-## Importing Lottie Files
+## Importing Lottie files
 
 Import a .lottie file from the Assets panel or drag it into Rive. After import, Rive converts supported parts of the Lottie file into editable Rive content.
 
-## After Importing
+## After importing
 
 Lottie and Rive are different animation formats with different runtimes, features, and optimization models. A Lottie file is not automatically optimized for Rive just because it can be imported.
 

--- a/editor/assets/psd.mdx
+++ b/editor/assets/psd.mdx
@@ -8,7 +8,7 @@ import { VideoEmbed } from '/snippets/video-embed.jsx'
 
 <YouTube id="Mlo9mQBUaTE" />
 
-## Importing PSD Files
+## Importing PSD files
 
 Drag a PSD file into Rive or import it from the Assets panel. When you import a PSD file, Rive adds its visible image layers to the Assets panel so you can place individual layers or the full composition on an artboard.
 
@@ -16,7 +16,7 @@ Drag a PSD file into Rive or import it from the Assets panel. When you import a 
   Hidden layers in the PSD are not imported into Rive.
 </Note>
 
-## Using PSD Layers
+## Using PSD layers
 
 You can use PSD layers individually or as a full composition.
 
@@ -25,17 +25,17 @@ You can use PSD layers individually or as a full composition.
 
 <VideoEmbed src="https://static.rive.app/video/adding-psd-to-stage.mp4" />
 
-## Asset Settings
+## Asset settings
 
 PSD layers use the same asset settings as raster images. You can configure settings for individual layers or apply settings to all layers in the PSD.
 
-## Export Behavior
+## Export behavior
 
 Only PSD layers used in the Rive file are included in the exported `.riv` file by default.
 
 You can adjust export options for individual layers or for all layers in the PSD. See [Assets](/editor/fundamentals/assets-overview#asset-settings) for more about export behavior.
 
-## Reimporting PSD Files
+## Reimporting PSD files
 
 You can replace or reimport a PSD to update its layers in Rive.
 

--- a/editor/assets/svg.mdx
+++ b/editor/assets/svg.mdx
@@ -8,7 +8,7 @@ SVG is one of the easiest ways to bring existing vector artwork into Rive.
 When you import an SVG, Rive converts the SVG into native Rive vector objects. After import, the artwork is no longer an SVG—it becomes editable shapes, paths, fills, strokes, and groups that behave like any artwork created directly in Rive.
 
 
-## Importing SVG Files
+## Importing SVG files
 
 You can import SVG files or copy vector artwork from design tools like Figma and Illustrator.
 
@@ -30,13 +30,13 @@ When exporting or copying SVGs from Illustrator, use **Presentation Attributes**
 
 Also disable **Preserve Illustrator Editing Capabilities**. This adds extra Illustrator data that can make the SVG much larger and may include data Rive’s importer does not recognize.
 
-## Export Behavior
+## Export behavior
 
 SVG assets only use **Automatic** export behavior.
 
 Rive converts SVGs into native vector objects before runtime export. The original SVG file is not included in the `.riv`, and runtimes do not currently convert SVG assets at runtime.
 
-## Unsupported Features
+## Unsupported features
 
 Most SVG artwork imports without issue, but some SVG features do not have direct equivalents in Rive and are imported differently or ignored.
 

--- a/editor/constraints/constraints-overview.mdx
+++ b/editor/constraints/constraints-overview.mdx
@@ -12,11 +12,11 @@ import { Demos } from "/snippets/demos.jsx";
 
 Constraints are a way to control the properties of an object through another target object. Some constraints can set limits on these properties (and their hierarchical relationships), while others can copy properties from one object to another.
 
-## Learn By Example
+## Learn by example
 
 <Demos examples={["constraints", "ikConstraint"]} />
 
-## Common Use Cases
+## Common use cases
 
 - Make a character's eyes follow a target.
 

--- a/editor/constraints/follow-path-constraint.mdx
+++ b/editor/constraints/follow-path-constraint.mdx
@@ -13,7 +13,7 @@ For text that follows a path, use the [Follow Path Text Modifier](/editor/text/t
 
 <YouTube id="9Gp_Kz-ylT4" />
 
-## Setting up a Follow Path Constraint
+## Setting up a Follow Path constraint
 
 First we’ll need both an object to constrain and a path to constrain it to.
 
@@ -23,7 +23,7 @@ Next, add a new constraint and select the Follow Path Constraint.
 
 Now, use the target button and select the path you want to constrain the object to.
 
-## Follow Path Properties
+## Follow Path properties
 
 Like other Constraints, the Follow Path Constraint has many different properties we can customize.
 

--- a/editor/constraints/ik-constraint.mdx
+++ b/editor/constraints/ik-constraint.mdx
@@ -8,7 +8,7 @@ import { Demos } from "/snippets/demos.jsx";
 
 <YouTube id="8FK5E5WBUpM" />
 
-## Forward vs Inverse Kinematics
+## Forward vs inverse kinematics
 
 Most skeletal animation in Rive uses **Forward Kinematics**. With Forward Kinematics, you pose a bone chain by rotating each bone. Child bones move based on the rotation of their parents.
 
@@ -20,7 +20,7 @@ IK is useful for rigs where the end of a chain needs to follow something else. F
 
 <Demos examples={["ikConstraint"]} />
 
-## Creating an IK constraint
+## Creating an IK Constraint
 
 To use IK, you need a bone chain and a target. The target can be any object, though in most cases you'll want to use a group with its [Style set to Target](/editor/fundamentals/groups#group-style).
 
@@ -51,9 +51,9 @@ To use IK, you need a bone chain and a target. The target can be any object, tho
     </Step>
 </Steps>
 
-## IK Properties
+## IK properties
 
-### Bone Count
+### Bone count
 
 Use **Bone Count** to set how far up the bone chain the IK constraint should reach.
 
@@ -61,7 +61,7 @@ When the target is selected, bones affected by the IK constraint are highlighted
 
 ![Image](https://ucarecdn.com/de7b0c48-49b2-4c6b-8935-1530fef7bffa/)
 
-### Invert Direction
+### Invert direction
 
 Use **Invert Direction** to swap the angle used to solve the IK chain.
 
@@ -83,7 +83,7 @@ If the constraints use lower Strength values, Rive blends between them. Drag con
 
 ![Image](https://ucarecdn.com/4751a9cd-f2c8-4b4a-9043-bd71276315f6/)
 
-## Multiple IK constraints and nested targets
+## Multiple IK Constraints and nested targets
 
 You can use multiple IK constraints to create more complex rigs.
 

--- a/editor/constraints/rotation-constraint.mdx
+++ b/editor/constraints/rotation-constraint.mdx
@@ -48,7 +48,7 @@ Choose whether this constraint should use World or Local coordinates for the Sou
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
-### Min/Max Space
+### Min/max space
 
 Choose whether this constraint should use World or Local coordinates for the Min/Max Space.
 
@@ -62,6 +62,6 @@ Allows the constraint owner to be manually offset from the constraint source.
 
 Define the rate at which the rotation property is copied.
 
-## Min/Max
+## Min/max
 
 Use the numerical values to define the minimum and maximum limits of the constraint.

--- a/editor/constraints/scale-constraint.mdx
+++ b/editor/constraints/scale-constraint.mdx
@@ -48,6 +48,6 @@ Choose whether this constraint should use World or Local coordinates for the Sou
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
-### Min/Max Space
+### Min/max space
 
 Choose whether this constraint should use World or Local coordinates for the Min/Max Space.

--- a/editor/constraints/scroll-constraint.mdx
+++ b/editor/constraints/scroll-constraint.mdx
@@ -8,7 +8,7 @@ Scrolling comes to Rive in the form of two new constraints; one to add touch-bas
 
 ---
 
-## Content Scrolling
+## Content scrolling
 
 To create a content scroll region, set up a hierarchy that includes:
 - Scroll view - the Layout that defines the area that is the scroll region
@@ -33,11 +33,11 @@ Once added, use the options fly-out to adjust the Scroll content properties.
 
 **All** - Scrolls in both directions
 
-#### Scroll Percent X/Y (Animatable)
+#### Scroll percent X/Y (animatable)
 
 This property allows you to set the percentage scroll of the content where 0% is scrolled to the top/left and 100% is scrolled to the bottom/right. This property works when the content is set to scroll in one or all directions and can be keyed on the timeline
 
-#### Scroll Index (Animatable)
+#### Scroll index (animatable)
 
 This property allows you to set the 0 based index of the Scroll item to scroll to. This only works when scroll is set to either Vertical or Horizontal and can be keyed on the timeline.
 
@@ -59,7 +59,7 @@ Once you have applied your desired properties, switch to animate mode and start 
 
 ---
 
-## List Scrolling
+## List scrolling
 
 In order to scroll Lists, use the same setup as described above in Content Scrolling, but rather than adding multiple Scroll items to the Scroll content layout, you can add a single List. See [Data Binding Lists](/editor/data-binding/lists) for more information.
 
@@ -75,7 +75,7 @@ When enabled, the List will scroll endlessly in either direction. In order to us
 
 ---
 
-## Creating a Scroll Bar
+## Creating a scroll bar
 
 To create a content bar, set up a hierarchy that includes:
 - Scroll Bar - the Layout that defines the area that is the scroll bar and track

--- a/editor/constraints/translation-constraint.mdx
+++ b/editor/constraints/translation-constraint.mdx
@@ -50,7 +50,7 @@ Choose whether this constraint should use World or Local coordinates for the Sou
 
 Choose whether this constraint should use World or Local coordinates for the Destination Space.
 
-### Min/Max Space
+### Min/max space
 
 Choose whether this constraint should use World or Local coordinates for the Min/Max Space.
 
@@ -64,6 +64,6 @@ Allows the constraint owner to be manually offset from the constraint source.
 
 Allows you to decide if the constraint owner will copy the translation in the X and Y direction. Additionally, use the numerical value to define the rate at which it copies the value.
 
-## Max/Min
+## Max/min
 
 Use the numerical values to define the minimum and maximum limits of the constraint.

--- a/editor/data-binding/binding-data.mdx
+++ b/editor/data-binding/binding-data.mdx
@@ -14,7 +14,7 @@ Bindings are not limited to visual properties. You can bind values throughout yo
 
 This allows the same data to drive behavior, animation, and logic across your scene, helping keep everything in sync.
 
-## Binding a Property
+## Binding a property
 
 Let's control the `X` position of a circle using `circleX`, which is a Number property in our View Model.
 
@@ -51,19 +51,19 @@ The circle's horizontal position is now driven by the `circleX` property. Any ti
   ![Preview data binding](/images/editor/data-binding/binding-data/preview-data-binding.gif)
 </Tip>
 
-### Updating a Binding
+### Updating a binding
 
 Right-click the bound element and select **Update Bind**.
 
 ![Update a binding](/images/editor/data-binding/binding-data/update-bind.gif)
 
-### Removing a Binding
+### Removing a binding
 
 Right-click the bound element and select **Unbind**.
 
 ![Remove a binding](/images/editor/data-binding/binding-data/unbind.gif)
 
-## Binding Options
+## Binding options
 
 Each binding has the following properties.
 
@@ -89,13 +89,13 @@ The path determines which specific property instance the binding should use.
 
 See also [Absolute vs Relative Binding](#absolute-vs-relative-binding).
 
-### Bind Direction
+### Bind direction
 
 By default, the View Model property (**source**) controls the bound element or value (**target**), but it can also work the other way around.
 
 <YouTube id="Syt6i4-Bkm4" />
 
-#### Target to Source
+#### Target to source
 
 When a binding has `Target to Source` toggled on, a change to the element will update the view model property.
 
@@ -129,7 +129,7 @@ In rare cases, both the source and target may change at the same time. This sett
   As the piece is dragged, the piece itself (target) updates those property values (target to source).
 </UseCase>
 
-### Bind Once
+### Bind once
 
 When **Bind Once** is enabled, the binding only applies the value a single time when the scene starts or the binding is created.
 
@@ -143,7 +143,7 @@ After the initial value is applied, future changes to the source or target are i
   You could bind the particle's rotation to a random number property using **Bind Once**. Each particle would receive its initial rotation value, but future changes to the property would not affect existing particles.
 </UseCase>
 
-### Absolute vs Relative Binding
+### Absolute vs relative binding
 
 <YouTube id="4LOXhXesG74" />
 

--- a/editor/data-binding/converters.mdx
+++ b/editor/data-binding/converters.mdx
@@ -31,7 +31,7 @@ Use them to adapt your data to match the property you're binding to—for exampl
   </Step>
 </Steps>
 
-## Converter Types
+## Converter types
 
 Converters can be used individually or combined into [groups](#converter-groups) to perform more complex transformations.
 
@@ -74,7 +74,7 @@ If the string is shorter than the specified length, the pad value is repeated an
 
 ---
 
-### Range Map
+### Range map
 
 Maps a number from one range to another.
 
@@ -93,7 +93,7 @@ Convert a slider value (0–100) into an opacity value (0–1):
 
 ---
 
-### Numeric Interpolator
+### Numeric interpolator
 
 ![interpolate a shape](/images/editor/data-binding/converters/numeric-interpolator.gif)
 
@@ -133,7 +133,7 @@ Click the + button to add values, operations, and functions. This builds the for
   ```
 </Tip>
 
-#### Random Mode
+#### Random mode
 
 When using `random()` in your formula, the Random Mode determines when a new random value is generated.
 
@@ -143,7 +143,7 @@ When using `random()` in your formula, the Random Mode determines when a new ran
 
 ---
 
-### Number to List
+### Number to list
 
 The Number to List converter allows you to generate a specified number of Components based on a number.
 
@@ -151,7 +151,7 @@ See [Lists](/editor/data-binding/lists#view-model-number-with-converter) for mor
 
 ---
 
-### Color Interpolator
+### Color interpolator
 
 ![interpolate a color](/images/editor/data-binding/converters/color-interpolator.gif)
 
@@ -166,7 +166,7 @@ Scripting lets you create your own custom converters when you need behavior that
 
 See [Converter Scripts](/scripting/protocols/converter-scripts) for more information.
 
-## Converter Groups
+## Converter groups
 
 ![Build and converter group](/images/editor/data-binding/converters/group.gif)
 

--- a/editor/data-binding/lists.mdx
+++ b/editor/data-binding/lists.mdx
@@ -20,7 +20,7 @@ A List is a way to display a set of items that are dynamically generated based o
 
 ---
 
-## Artboard Lists
+## Artboard lists
 
 Artboard Lists enable you to generate a number of list items using an Artboard to represent each item in your List. Artboard Lists must be added as children of an Artboard or Layout.
 
@@ -37,7 +37,7 @@ The next step is to bind data to it using Data Binding. This will determine the 
 - Using the View Model List property
 - Using a View Model Number property together with a Number to List converter
 
-## View Model List Property
+## View Model list property
 
 <Note>
   Before continuing, it's important to understand the fundamentals of Data Binding, in particular, what a View Model is, how to create one and how to bind it to an object's properties. Learn more in the [Data Binding Overview](/editor/data-binding/overview).
@@ -74,7 +74,7 @@ Run the state machine and you should see your list items. Remember that the layo
   Rive's runtimes provide [APIs to modify the List and List items at runtime](/runtimes/data-binding#lists) (for example, adding or removing items).
 </Note>
 
-## View Model Number with Converter
+## View Model number with Converter
 
 The second way to populate your list is by specifying the number of items you want in your List along with the ViewModel (Artboard) you want to instance. This can be done using a View Model Number property in combination with the new Number to List converter.
 
@@ -106,7 +106,7 @@ To Create a View Model Number to List converter and bind it to an Artboard List:
 
 Run the state machine and you should see your list items. Remember that the layout will be determined by the Artboard List's parent, so modify the parent's settings in order to tweak your List's layout
 
-## View Model List Item Index
+## View Model list item index
 
 There may be times where it is useful for the Artboard to know at which index it exists within its parent List. This is available using the View Model list item index property.
 
@@ -122,7 +122,7 @@ This property can then be bound to an object's properties and used directly (for
   When using item index with the [List property](/editor/data-binding/lists#view-model-list-property) and list items, be aware that if more than 1 list item is bound to the same View Model instance, they will share the same index value
 </Info>
 
-## Lists & Scrolling
+## Lists & scrolling
 
 If you add your Artboard List as a child of a Layout, your List items will behave as children of its parent's Layout. This means things like direction, wrapping, padding, gap, alignment, etc. are all dictated by the parent Layout's properties.
 

--- a/editor/data-binding/migration-guide.mdx
+++ b/editor/data-binding/migration-guide.mdx
@@ -27,7 +27,7 @@ It provides more data types in a more flexible, consistent system for both sendi
 </Note>
 
 
-## Migrating from Deprecated Features
+## Migrating from deprecated features
 
 ### State Machine Inputs
 
@@ -55,7 +55,7 @@ With data binding, you instead expose **view model properties** that can drive S
   - Provide a more flexible and scalable data model
 </Note>
 
-### Communicating with Code via Events
+### Communicating with code via events
 
 Events were previously used to send information from a Rive file back to runtime code.
 
@@ -83,7 +83,7 @@ For more info, see [Data Binding](/runtimes/data-binding)
 
 ---
 
-### Updating Text Runs at Runtime
+### Updating Text Runs at runtime
 
 Previously, updating text required:
 - Knowing the exact **name**
@@ -110,7 +110,7 @@ Use constraints when:
 - The relationship is purely visual or spatial
 - You want a simple, editor-only solution
 
-### When to use data binding instead
+### When to use Data Binding instead
 
 Use data binding when:
 - The value needs to come from **runtime code**

--- a/editor/data-binding/overview.mdx
+++ b/editor/data-binding/overview.mdx
@@ -18,7 +18,7 @@ For example, you might:
 - Bind a `health` value to a health bar in the UI and to the character.
 - Swap images, artboards, or components based on your application's state.
 
-## Why Use Data Binding?
+## Why use Data Binding?
 
 Data binding lets you organize your data independently from your scene hierarchy.
 
@@ -26,7 +26,7 @@ For example, you might have a `health` property stored at the top level of your 
 
 Once the property is bound, the hierarchy no longer matters. You can move elements, reorganize components, or rename properties without rewriting runtime code.
 
-## Core Concepts
+## Core concepts
 
 1. [View Models](/editor/data-binding/view-models) define the structure of your data.
 2. View Model Instances store actual values for that data.

--- a/editor/data-binding/property-groups.mdx
+++ b/editor/data-binding/property-groups.mdx
@@ -24,9 +24,9 @@ View Model properties are global and shared, while timelines and state machines 
 </Steps>
 
 
-## Common Use Cases
+## Common use cases
 
-### Controlling a View Model Property with a Timeline
+### Controlling a View Model property with a Timeline
 
 You can’t key a View Model property directly in the timeline. Instead, you key a Property Group value, then bind that value to a View Model property.
 
@@ -59,7 +59,7 @@ This lets you use [Keyframes](/editor/animate-mode/keys) in a timeline to update
 
 When you run your state machine, the View Model property updates based on the keyed Property Group values.
 
-### Controlling one View Model Property with another
+### Controlling one View Model property with another
 
 You can't directly control one View Model Property with another View Model Property. Instead, you can use a Property Group value that reads one View Model Property and sets another.
 

--- a/editor/data-binding/property-types.mdx
+++ b/editor/data-binding/property-types.mdx
@@ -29,7 +29,7 @@ In the Data panel, click the **Add View Model Property** button next to the view
 | [View Model](#view-model) | Nested View Model instance                  |
 | [List](#list)         | Collection of view models |
 
-## Property Types
+## Property types
 
 ### Trigger
 

--- a/editor/data-binding/stateful-components.mdx
+++ b/editor/data-binding/stateful-components.mdx
@@ -9,7 +9,7 @@ Stateful components let you expose specific view model properties directly on a 
 
 <YouTube id="unMfjqrKjNc" />
 
-### Setting Up a Component for Stateful Use
+### Setting up a component for stateful use
 
 Before a component can be used statefully, its artboard needs a view model with the properties you want to expose.
 
@@ -23,7 +23,7 @@ Before a component can be used statefully, its artboard needs a view model with 
 
 ![Image](/images/editor/data-binding/stateful-components/stateful-input-and-output-props.png)
 
-### Using a Stateful Component
+### Using a stateful component
 
 When you nest a component (press N and select it from the menu), it comes in as a stateless component by default. Switch it to a stateful component in the inspector.
 
@@ -33,13 +33,13 @@ Once switched to stateful, the nested view model instance selector goes away, an
 
 Because the values are owned by the component instance, you don't need a separate view model instance for each one.
 
-### Nesting Stateful Components
+### Nesting stateful components
 
 Stateful components can be nested inside other components. For example, a card component might contain a stateful button component.
 
 If you want the card's parent to be able to override the button's properties, add those properties to the card's view model and data bind them to the button's stateful properties. Once added to the card's Properties panel as inputs, they'll be available to override when the card is nested.
 
-### Output Properties
+### Output properties
 
 Output properties report a value out of a component when it's nested. They appear with a lock icon in the inspector and are marked as read-only — you can interact with the component, but you can't set the value from outside.
 
@@ -47,7 +47,7 @@ Output properties report a value out of a component when it's nested. They appea
 
 To read an output value in the parent artboard, add a property to the parent's view model and data bind it (target to source) to the component's output property. The value will update in real time as the state machine runs.
 
-### Keying Input Properties on Timelines
+### Keying input properties on Timelines
 
 Input properties can be keyed on a timeline. Open the timeline view with a stateful component selected and you'll see a key indicator next to each exposed input property. Key the values at different points in the timeline to animate them.
 

--- a/editor/data-binding/view-models.mdx
+++ b/editor/data-binding/view-models.mdx
@@ -59,11 +59,11 @@ A View Model defines the structure of your data. Before creating View Model Inst
 
 ![Create a View Model](/images/editor/data-binding/view-models/create-view-model.gif)
 
-## Creating and Editing Instances
+## Creating and editing instances
 
 Once your View Model has been created, you can create one or more View Model Instances that store actual values for those properties.
 
-### Creating a View Model Instance
+### Creating a View Model instance
 
 A View Model can have multiple instances. Each instance contains its own set of property values while sharing the same structure defined by the View Model.
 
@@ -96,7 +96,7 @@ When creating a new View Model, Rive automatically creates a View Model Instance
   </Step>
 </Steps>
 
-### Removing Instances
+### Removing instances
 
 Click the `-` icon next to the instance name to delete it.
 
@@ -106,7 +106,7 @@ Click the `-` icon next to the instance name to delete it.
   Deleting a View Model Instance does not remove the View Model or its properties. It only removes that instance and its stored values.
 </Note>
 
-### Exporting Instances
+### Exporting instances
 
 By default, exported View Model Instances are included in the .riv file. Disable Export Instance when the data is only needed during development, not in your application at runtime.
 
@@ -118,7 +118,7 @@ By default, exported View Model Instances are included in the .riv file. Disable
   In this case embedding the example data just increases your .riv file size.
 </UseCase>
 
-## Connecting View Model Instances to Artboards
+## Connecting View Model instances to Artboards
 
 Before binding data, you'll need to decide where the data should live.
 
@@ -131,7 +131,7 @@ Rive supports a few common patterns:
 | [Instances as nested properties](#instances-as-nested-properties) |	The parent view model instance stores a reference to a nested view model instance |
 | [Stateful nested components](#stateful-components) |	Self-contained, reusable components that store their own unique data |
 
-### Global View Model Instances
+### Global View Model instances
 
 Global View Models provide data that can be accessed throughout your Rive file.
 
@@ -146,7 +146,7 @@ If a closer View Model contains a property with the same name, that property wil
 Learn more about [Absolute vs Relative Binding](/editor/data-binding/binding-data#absolute-vs-relative-binding).
 
 
-### Instances Attached to Artboards
+### Instances attached to Artboards
 
 View Model instances can be attached to a specific artboard or nested component. This is useful when only that artboard and its children need access to that data.
 
@@ -159,7 +159,7 @@ EnemyVM
 An Enemy view model might contain a `health` property. This property might be used by the enemy itself, but not by its parent.
 </UseCase>
 
-### Instances as Nested Properties
+### Instances as nested properties
 
 View Models can have properties that are View Model instances.
 
@@ -186,7 +186,7 @@ This approach is useful when a parent artboard needs to manage a collection of i
 An inventory screen might contain a list of Item View Model Instances, with each inventory slot component bound to a different item.
 </UseCase>
 
-### Stateful Components
+### Stateful components
 
 A stateful component is an instance of a component that maintains its own data.
 

--- a/editor/design/rulers-and-guides.mdx
+++ b/editor/design/rulers-and-guides.mdx
@@ -14,7 +14,7 @@ Use ruler guides to place individual horizontal or vertical guides, or use guide
 
 ![Rive interface showing grids, guides, and ruler guides](/images/editor/design/rulers-and-guides.png)
 
-## Toggling Ruler and Guide Visibility
+## Toggling ruler and guide visibility
 
 To show or hide rulers and guides, press **;** or select **View Menu > Rulers & Guides**.
 
@@ -43,7 +43,7 @@ With rulers visible, click and drag from a ruler into the viewport to create a r
 
 Guides let you add rows, columns, or a grid to an artboard. Like ruler guides, they belong to the artboard they're created on.
 
-### Creating a Guide
+### Creating a guide
 
 With an artboard selected, go to the **Guides** panel in the Inspector and click the **+** button. Choose the type of guide you want to add:
 
@@ -53,7 +53,7 @@ With an artboard selected, go to the **Guides** panel in the Inspector and click
 
 ![Guide types - rows, columns, grid](/images/editor/design/guide-types.png)
 
-### Guide Options
+### Guide options
 
 The available options depend on the guide type.
 
@@ -71,7 +71,7 @@ The available options depend on the guide type.
 
 <VideoEmbed src="https://static.rive.app/video/guide-alignment-type.mp4" />
 
-### Managing Guides
+### Managing guides
 
 You can add multiple guides to the same artboard, allowing you to combine grids, rows, and columns.
 

--- a/editor/embed-urls/overview.mdx
+++ b/editor/embed-urls/overview.mdx
@@ -13,7 +13,7 @@ An embed URL is a **snapshot** of your file at the moment it’s generated. If y
   Embeds use iframes and don't provide access to Rive's runtime APIs. If you need to control or interact with your Rive programmatically, use a [Rive runtime](/runtimes/getting-started) instead.
 </Note>
 
-## Creating an Embed URL
+## Creating an embed URL
 
 <Steps>
   <Step title="Open the Embed URL dialog">
@@ -50,10 +50,10 @@ An embed URL is a **snapshot** of your file at the moment it’s generated. If y
 </Steps>
 
 
-## Sharing on Social Media
+## Sharing on social media
 
 Copy the **Hosted Link** and paste it into a supported social platform. The link includes metadata that allows supported platforms to display a preview of your Rive file.
 
-## Managing Embed URLs
+## Managing embed URLs
 
 Visit the [Embed URLs](https://rive.app/account/links?utm_source=docs&utm_medium=content) section of your settings to manage the links you've generated. You can disable an embed URL by turning off **Active**.

--- a/editor/events/audio-events.mdx
+++ b/editor/events/audio-events.mdx
@@ -19,7 +19,7 @@ Audio events are ideal for triggering shorter sounds in response to user interac
 For use cases requiring greater control over volume and playback, consider using [Scripting](/scripting/getting-started). Check out [AudioSound](/scripting/api-reference/interfaces/audio-sound) and [AudioSource](/scripting/api-reference/interfaces/audio-source) for more information.
 </Info>
 
-## Working with Audio Assets
+## Working with audio assets
 
 Audio events use sounds from the Assets panel. See [Importing Assets](/editor/fundamentals/assets-overview#importing-assets) to import MP3, WAV, and FLAC files, or see [Audio Assets](/editor/assets/audio) to browse Soundly sounds, create clips, and adjust asset volume.
 

--- a/editor/events/open-url-events.mdx
+++ b/editor/events/open-url-events.mdx
@@ -20,7 +20,7 @@ noindex: true;
 
 For general information about adding, creating, and signaling events, see [Rive Events](/editor/events/overview).
 
-### URL Properties
+### URL properties
 
 When you select the **Open URL** Event type, additional configuration options become available.
 
@@ -44,7 +44,7 @@ The **Target** determines where the URL opens in the browser.
   For security reasons, URLs are not opened by default in embeds or Marketplace posts. This behavior may change in the future.
 </Info>
 
-### Properties (Deprecated)
+### Properties (deprecated)
 
 Properties allow an Event to carry additional data to the runtime.
 

--- a/editor/events/overview.mdx
+++ b/editor/events/overview.mdx
@@ -13,7 +13,7 @@ Rive supports three types of Events:
 - [Audio Event](/editor/events/audio-events) — Plays a sound
 - [General Event (deprecated)](/editor/events/general-events) — Previously used to communicate with runtime code
 
-## Creating an Event
+## Creating an event
 
 <Steps>
   <Step title="Create an Event">
@@ -49,7 +49,7 @@ Rive supports three types of Events:
 </Tip>
 
 
-## Signaling an Event
+## Signaling an event
 
 We can signal an Event in four ways: from a timeline, a listener, a state, or a transition.
 
@@ -61,7 +61,7 @@ First, select the timeline you want to add the Event to. Then use the **Report E
 
 ![Keying an Event on the timeline](https://ucarecdn.com/bd8d36f9-9cd1-4eec-9c37-85d4a0a19643/)
 
-### Transition & State
+### Transition & state
 
 You can report an event on a Transition or a State. To report an event, select the desired State or Transition and use the `+` button next to the Events section in the Inspector.
 

--- a/editor/exporting/exporting-for-runtime.mdx
+++ b/editor/exporting/exporting-for-runtime.mdx
@@ -9,7 +9,7 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 A `.riv` file is the final Rive file you load at runtime. You can use the same exported file across supported runtimes, including web, mobile, game engines, and other platforms.
 
-## Exporting a .riv File
+## Exporting a .riv file
 
 <YouTube id="H_px35jTqhg" />
 

--- a/editor/exporting/exporting-for-video-and-static-design.mdx
+++ b/editor/exporting/exporting-for-video-and-static-design.mdx
@@ -7,7 +7,7 @@ description: ''
 
 Rive is all about interactive animation, but sometimes you need  traditional formats such as MP4, GIF, or PNG sequence. Our Cloud Renderer turns any device into a supercomputer, allowing you to continue working while we generate your video or design file.
 
-# Supported Formats
+## Supported Formats
 
 - H.264
 - GIF
@@ -17,11 +17,11 @@ Rive is all about interactive animation, but sometimes you need  traditional for
 - PNG
 - SVG
 
-# How to render
+## How to render
 
 All rendering is done by creating Rendering Presets, then adding those Render Presets to the Render Que.
 
-## Creating a preset
+### Creating a preset
 
 With the Artboard selected, you'll find the Render Presets option. Hitting the plus button will create a new Render Preset. This can be done from either [design or animate mode](/editor/fundamentals/design-vs-animate-mode).
 
@@ -44,7 +44,7 @@ To the left of the Render Preset name, you'll find additional options which allo
 - Bit rate
 - Size
 
-## Adding a Preset to the Render Queue
+### Adding a preset to the Render Queue
 
 When you're finished creating a preset, you'll need to add it to the Render Queue.
 

--- a/editor/exporting/exporting-for-video-and-static-design.mdx
+++ b/editor/exporting/exporting-for-video-and-static-design.mdx
@@ -7,7 +7,7 @@ description: ''
 
 Rive is all about interactive animation, but sometimes you need  traditional formats such as MP4, GIF, or PNG sequence. Our Cloud Renderer turns any device into a supercomputer, allowing you to continue working while we generate your video or design file.
 
-## Supported Formats
+## Supported formats
 
 - H.264
 - GIF

--- a/editor/exporting/exporting-names.mdx
+++ b/editor/exporting/exporting-names.mdx
@@ -14,7 +14,7 @@ You may want to export names when:
   Exporting names slightly increases file size. Only export names for objects you need to access at runtime.
 </Note>
 
-## Export a Name
+## Export a name
 
 ![Export name](/images/editor/exporting/export-name.gif)
 
@@ -28,7 +28,7 @@ You may want to export names when:
   </Step>
 </Steps>
 
-## Export All Names
+## Export all names
 
 Exports the names of all objects in the file.
 
@@ -46,7 +46,7 @@ Exports the names of all objects in the file.
   </Step>
 </Steps>
 
-## Remove Name Exports
+## Remove name exports
 
 Removes all exported names from the file.
 

--- a/editor/fundamentals/artboards.mdx
+++ b/editor/fundamentals/artboards.mdx
@@ -16,7 +16,7 @@ Artboards can also be converted to [components](/editor/fundamentals/components)
 
 ## Creating Artboards
 
-### From a New Rive File
+### From a new Rive file
 
 When you create a new Rive file, you'll be prompted to create an artboard. Choose a size from one of the presets, or enter a custom width and height. You can resize the artboard at any time.
 
@@ -28,7 +28,7 @@ The width and height define the artboard's dimensions in Rive. The size and aspe
 Artboard dimensions are measured in units rather than pixels. For example, if a 500-unit-wide artboard is displayed at 1000 pixels wide, each unit represents 2 pixels. For simplicity, you can often treat these units like pixels while working in the editor.
 </Note>
 
-### Creating Additional Artboards
+### Creating additional Artboards
 
 A Rive file can contain multiple artboards.
 
@@ -69,7 +69,7 @@ Animations and state machines belong to individual artboards. Select an artboard
 See [Animations](/editor/animate-mode/animate-mode-overview) and [State Machines](/editor/state-machine/state-machine) to learn more.
 
 
-## Artboard Properties
+## Artboard properties
 
 Select an artboard to view and edit its properties in the Inspector.
 

--- a/editor/fundamentals/assets-overview.mdx
+++ b/editor/fundamentals/assets-overview.mdx
@@ -21,7 +21,7 @@ Use the panel to import new assets, create Rive assets, sort and filter by type,
 
 <YouTube id="B9uD-Gh8zjg" />
 
-## Asset Types
+## Asset types
 
 Imported file assets include:
 
@@ -37,9 +37,9 @@ Imported file assets include:
   Blob assets are useful for advanced workflows where a script needs access to a custom file type, such as a 3D model.
 </Note>
 
-## Importing Assets
+## Importing assets
 
-### Drag and Drop
+### Drag and drop
 
 You can import assets by dragging files into Rive or by using the Assets panel.
 
@@ -47,7 +47,7 @@ You can import assets by dragging files into Rive or by using the Assets panel.
 
 If the file type is not directly supported, Rive asks if you want to import it as a custom blob asset.
 
-### Browse Files
+### Browse files
 
 To import from the Assets panel, click **+**, then choose the asset you want to import.
 
@@ -60,7 +60,7 @@ To import from the Assets panel, click **+**, then choose the asset you want to 
 * [Font Files](/editor/text/fonts) for adding custom and Google Fonts.
 * [Audio Assets](/editor/assets/audio) for browsing sounds, importing audio, and creating clips.
 
-## Asset Settings
+## Asset settings
 
 Select an asset in the Assets panel to view its settings in the Inspector. The available settings depend on the asset type.
 
@@ -89,7 +89,7 @@ Raster images and PSD files include a **Compression** panel. Use compression set
 
 Choose a compression format, then adjust the **Quality** value to balance image quality and file size. WebP is recommended for most raster images because it usually provides smaller file sizes while preserving good visual quality.
 
-### Export Options
+### Export options
 
 Export options control how an imported asset is handled when you export a .riv file for runtime. Use these settings to decide whether an asset is included in the .riv file, loaded separately at runtime, or excluded from the export.
 

--- a/editor/fundamentals/components.mdx
+++ b/editor/fundamentals/components.mdx
@@ -20,9 +20,9 @@ Components can include their own graphics, animations, state machines, and data,
 <YouTube id="HRUr9mnh41A" />
 
 
-## Creating a Component
+## Creating a component
 
-### Converting Artboards to Components
+### Converting Artboards to components
 
 Any artboard can be converted into a reusable component.
 
@@ -44,7 +44,7 @@ You can identify components by their purple artboard title on the stage.
 Artboards that aren't components aren't exported with your Rive file. This can be useful for artboards used only while authoring, such as tests or reference artboards.
 </Note>
 
-### Converting Objects to Components
+### Converting objects to components
 
 You can select one or more objects on an artboard and convert them into a new component.
 
@@ -77,7 +77,7 @@ For example, a draw order dependency that crosses the new component's boundary w
 
 ![Can't create component error caused by a dependency crossing the component boundary](/images/editor/artboards/cannot-create-new-component.png)
 
-## Placing Components
+## Placing components
 
 Use the **Component Tool**, formerly known as the Nested Artboard Tool, to place instances of components on the stage. Select the tool from the toolbar or press `N`.
 
@@ -101,13 +101,13 @@ The component menu follows the sort mode used in the Assets panel:
 
 ![Sort assets by Custom](/images/editor/artboards/assets-sort.png)
 
-## Editing Components
+## Editing components
 
 Double-click a component instance to open its source component. Changes you make to the source component are reflected in all of its instances, while properties configured on individual instances remain unchanged.
 
 ![Double click to edit a component](/images/editor/artboards/edit-component.gif)
 
-## Component Instance Properties
+## Component instance properties
 
 Select a component instance to configure its properties in the Inspector. These properties control the data, animation, source, layout, and other behavior of that specific instance without changing the source component.
 

--- a/editor/fundamentals/design-vs-animate-mode.mdx
+++ b/editor/fundamentals/design-vs-animate-mode.mdx
@@ -12,7 +12,7 @@ Use the **Mode Toggle** in the toolbar, or press `Tab`, to switch between modes.
 
 ![The Design and Animate mode toggle in the top-right of the toolbar being switched back and forth](/images/switch.gif)
 
-## Avoiding Accidental Keys
+## Avoiding accidental keys
 
 When you're in **Animate Mode**, some edits can create animation keys depending on what is selected.
 
@@ -22,7 +22,7 @@ If a **timeline** is selected, changes to animatable properties may be keyed aut
   Before making design changes, make sure you're in **Design Mode**, or make sure a timeline is not selected.
 </Warning>
 
-## When to Use Design Mode
+## When to use Design Mode
 
 Use **Design Mode** when you want to change the default design of your file.
 
@@ -34,7 +34,7 @@ Common design changes include:
 - Importing assets
 - Adding bones, constraints, or other rigging
 
-## When to Use Animate Mode
+## When to use Animate Mode
 
 Use **Animate Mode** when you want to create animation behavior.
 

--- a/editor/fundamentals/edit-vertices.mdx
+++ b/editor/fundamentals/edit-vertices.mdx
@@ -5,7 +5,7 @@ description: "No matter the type of vector you create, you can edit the vertices
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-## Edit Vertices mode
+## Edit vertices mode
 
 To enter Edit Vertices mode, either select the shape and hit enter twice or select a path and hit enter once.
 
@@ -19,7 +19,7 @@ After activating Edit Vertices mode, you can select any vertex, reposition it, a
   Use [Deep Select](/editor/interface-overview/selection-and-navigation#deep-select) to select a specific path inside nested groups on the stage.
 </Tip>
 
-### Path Options
+### Path options
 
 Each path in Edit Vertices mode has a set of path options at the top of the Inspector.
 
@@ -51,7 +51,7 @@ Straight vertices with a corner radius will deform when the scale transform is a
 ![Convert Radial Corners button in the path options converts a single rounded corner into two vertices on the stage](/images/convert.gif)
 
 
-## Bezier Handles
+## Bezier handles
 
 
 **‌Straight**

--- a/editor/fundamentals/fill-and-stroke.mdx
+++ b/editor/fundamentals/fill-and-stroke.mdx
@@ -7,21 +7,21 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 <YouTube id="4ZRzKScvJbQ" />
 
-# Fill
+## Fill
 
-### **Create a new Fill**
+### Create a new Fill
 
 To create a fill, select a shape, then use the plus button under the Fill and Stroke section of the Inspector. Be sure to select Fill from the new menu. You'll be able to tell that a layer is a fill by looking at the color box on the left side.
 
 ![Creating a fill by clicking the plus button in the Fill and Stroke section of the Inspector and choosing Fill from the menu](/images/newFill.gif)
 
-### **Changing Fill color**
+### Changing Fill color
 
 To change the color of a Fill, select the color box on the left side of the Fill layer. This will open the Color Picker. From there, you can use the various sliders to choose which color you'd like for the Fill.
 
 ![Opening the Color Picker from a fill layer and adjusting the sliders to change the color](/images/changecolor.gif)
 
-### **Changing Fill Type**
+### Changing Fill type
 
 When a new shape is created, by default the shape will have a solid fill. When a new fill is added, by default the fill type is set to linear. We often need to change the fill type between the different types. This can be done by selecting the color box.
 
@@ -35,7 +35,7 @@ The different fills that can be selected are:
 - **Linear Gradient**
 - **Radial Gradient**
 
-### **Changing Fill color (Gradient)**
+### Changing Fill color (gradient)
 
 To change the color of a Fill, select the color box on the left side of the Fill layer. This will open the Color Picker.
 
@@ -45,13 +45,13 @@ When a gradient is selected, you'll notice a new bar appear above the color pick
 
 By default, a gradient has two points.
 
-### **Changing the color of a stopper**
+### Changing the color of a stopper
 
 To change the color of a particular color stopper, start by selecting the stopper you'd like to change.
 
 Next, use the various sliders to choose which color that stopper should be.
 
-### **Adding and removing stoppers**
+### Adding and removing stoppers
 
 To add a new color stopper, click any space along the long that isn't currently occupied by another stopper. This will generate an additional color stopper.
 
@@ -59,7 +59,7 @@ To add a new color stopper, click any space along the long that isn't currently 
 
 To delete a color stopper, select the stopper you'd like to delete, then hit the Delete or Backspace key.
 
-### **Change Fill Order**
+### Changing Fill order
 
 The order of fills determines their render order, with fills on top rendered in front and fills at the bottom rendered in back.
 
@@ -67,7 +67,7 @@ The order of fills determines their render order, with fills on top rendered in 
 
 This order can be changed at any time by clicking and dragging on an empty area within the layer.
 
-### **Fill Properties**
+### Fill properties
 
 Each Fill has its own properties which can be edited and keyed on the timeline. Some of these properties can be found by using the fill option button.
 
@@ -81,13 +81,13 @@ Each Fill has its own properties which can be edited and keyed on the timeline. 
 
 \*\*Feather - \*\*This option can be toggled to feather the chosen Fill. Read more about Feathering below.
 
-### **Deleting and hiding a Fill**
+### Deleting and hiding a Fill
 
 Often times we'll need to delete or hide a particular Fill. This can be done by selecting the shape, then using the eye icon to hide the Fill, or the minus icon to delete the fill.
 
 ![Deleting a fill with the minus icon and hiding a fill with the eye icon in the Fill and Stroke section](/images/delete.gif)
 
-### Fill Rule
+### Fill rule
 
 The Fill Rule determines how overlapping paths in a shape will be filled:
 
@@ -95,7 +95,7 @@ The Fill Rule determines how overlapping paths in a shape will be filled:
 - **Even-Odd** assigns a \+1 value to clockwise paths and a -1 value to counter clock wise paths. Areas that equal an even value will be filled while odd values wont be.
 - **Clockwise** a Fill Rule exclusive to Rive. This fill rule enables manual subtraction of paths which can be found in edit vertices mode. This fill rule is also required for shapes where you'd like to enable vector feathering.
 
-# Stroke
+## Stroke
 
 ### Create a new Stroke
 
@@ -103,13 +103,13 @@ To create a Stroke, select a shape, then use the plus button under the Fill and 
 
 ![Creating a stroke by clicking the plus button in the Fill and Stroke section of the Inspector and choosing Stroke from the menu](/images/NewStroke.gif)
 
-### **Changing stroke color (solid)**
+### Changing stroke color (solid)
 
 To change the color of a Stroke, select the color box on the left side of the Stroke layer. This will open the Color Picker. From there, you can use the various sliders to choose which color you'd like for the Stroke.
 
 ![Opening the Color Picker from a stroke layer and adjusting the sliders to change the color](/images/StrokeColor.gif)
 
-### **Changing Stroke type**
+### Changing Stroke type
 
 By default, strokes are set to a solid color, but various stroke types are available from the Color Picker menu.
 
@@ -121,7 +121,7 @@ The different strokes that can be selected are:
 - **Linear Gradient**
 - **Radial Gradient**
 
-### **Changing Stroke color (Gradient)**
+### Changing Stroke color (gradient)
 
 To change the color of a Stroke, select the color box on the left side of the Stroke layer. This will open the Color Picker.
 
@@ -129,7 +129,7 @@ When a gradient is selected, you'll notice a new bar appear above the color pick
 
 By default, a gradient has two points.
 
-### **Changing the color of a stopper**
+### Changing the color of a stopper
 
 To change the color of a particular color stopper, start by selecting the stopper you'd like to change.
 
@@ -137,7 +137,7 @@ To change the color of a particular color stopper, start by selecting the stoppe
 
 Next, use the various sliders to choose which color that stopper should be.
 
-### **Adding and removing stoppers**
+### Adding and removing stoppers
 
 To add a new color stopper, click any space along the long that isn't currently occupied by another stopper. This will generate an additional color stopper.
 
@@ -145,11 +145,11 @@ To add a new color stopper, click any space along the long that isn't currently 
 
 To delete a color stopper, select the stopper you'd like to delete, then hit the Delete or Backspace key.
 
-### **Deleting and hiding a Stroke**
+### Deleting and hiding a Stroke
 
 Often times we'll need to delete or hide a particular Stroke. This can be done by selecting the shape, then using the eye icon to hide the Stroke, or the minus icon to delete the Stroke.
 
-# Stroke Properties
+## Stroke Properties
 
 Each Stroke has its own properties which can be edited and keyed on the timeline. Some of these properties can be found by using the Stroke option button.
 
@@ -179,11 +179,11 @@ Each Stroke has its own properties which can be edited and keyed on the timeline
 - **Trim -**  Lets you animate the start, end, and offset of a line segment. Read more [here](/editor/manipulating-shapes/trim-path).
 - **Dashed -** Lets you create dashed strokes with animatable property like the length of the dashed segment and offset.  Read more [here.](/editor/manipulating-shapes/trim-path)
 
-# Vector Feathering
+## Vector Feathering
 
 Vector feathering is a new way to feather both Fills and Strokes. Vector Feathering is a technique we invented at Rive that can soften the edge of vector paths without the typical performance impact of traditional blur effects.
 
-### **Enabling Vector Feathering**
+### Enabling Vector Feathering
 
 There are two main ways to enable vector feathering on any Stroke of Fill.
 
@@ -192,7 +192,7 @@ There are two main ways to enable vector feathering on any Stroke of Fill.
 - **Feather Icon -** The feathering icon can be used on any Fill or Stroke layer to enable vector feathering.
 - **Feather Toggle -** The feather toggle can be found in the Fill / Stroke options panel.
 
-### Feathering Options
+### Feathering options
 
 Feathers can be customized in a number of ways. The Feathering options can be found in the options panel once Feathering has been enabled on a Fill or Stroke.
 
@@ -218,7 +218,7 @@ Feathers can be customized in a number of ways. The Feathering options can be fo
 
 ![Image](/images/amount.gif)
 
-# Effect Groups
+## Effect Groups
 
 Effect groups let you apply a single path effect — or a stack of effects — to multiple strokes and fills at once, without having to configure each one individually. This is useful any time you have multiple shapes that need to share the same trim, dash, or scripted effect behavior, and you want to control them from one place.
 

--- a/editor/fundamentals/freeze-and-origin.mdx
+++ b/editor/fundamentals/freeze-and-origin.mdx
@@ -12,7 +12,7 @@ For example, manipulating the scale of a group creates different results if the 
 
 You need to reposition the parent group to change the point of origin for these transformations. However, moving a parent causes all the children to move with it. The Freeze feature makes it possible to achieve this without having to rework the hierarchy structure.
 
-# Origin of a Procedural Path
+## Origin of a Procedural Path
 
 Procedural objects (like artboards and procedural paths) have an origin property. The origin of a procedural path determines where its properties originate from. For example, changing the width of a rectangle with its origin in the middle (50% X and 50% Y) causes it to grow from its center.
 
@@ -26,9 +26,9 @@ This is particularly useful when animating paths that have other procedural prop
 
 You can use the Freeze feature to change the Origin position on the Stage. Alternatively, set the exact value in the Inspector.
 
-# Origin of a Custom Path and Group
+## Origin of a Custom Path and Group
 
-### Freeze Mode
+### Freeze mode
 
 The Freeze feature allows you to move any parent object (groups, shapes, bones) without affecting the position of its children. Activate Freeze in the [Transform Tools menu](/editor/interface-overview/toolbar) or use the `Y` shortcut.
 
@@ -36,7 +36,7 @@ When Freeze Mode is active, you'll notice that your Stage is wrapped in a blue o
 
 Be sure to turn off Freeze by pressing `Y` again.
 
-# Changing Origin with Align Tools
+## Changing Origin with Align Tools
 
 You can quickly change the location of an origin with the align tools.
 

--- a/editor/fundamentals/groups.mdx
+++ b/editor/fundamentals/groups.mdx
@@ -13,7 +13,7 @@ You can also wrap a selection of shapes into a group with `⌘`\+`G` in macOS or
 
 Unwrap a group with `⌘`\+`Shift`\+`G` in macOS or `Ctrl`\+`Shift` +`G` in Windows.
 
-## Group Style
+## Group style
 
 The Style property of a group can be set to Group or Target.
 

--- a/editor/fundamentals/procedural-shapes.mdx
+++ b/editor/fundamentals/procedural-shapes.mdx
@@ -10,7 +10,7 @@ Shape tools let you create common shapes, such as rectangles, ellipses, polygons
 
 <YouTube id="vU5SrgymGD8" />
 
-## Creating a Shape
+## Creating a shape
 
 Shape tools are available from the **Create Tools** menu.
 
@@ -31,7 +31,7 @@ Shape tools are available from the **Create Tools** menu.
   See [Freeze and Origin](/editor/fundamentals/freeze-and-origin) to learn how to change the center point of a shape.
 </Info>
 
-## Shape Properties
+## Shape properties
 
 You can update a shape's properties in the inspector. Available properties depend on the selected shape type.
 
@@ -68,7 +68,7 @@ Drag the handle on the inner point up or down to adjust the angle on the inner a
 
 ![Adjusting the angle of the inner points of a star](/images/editor/drawing/star-angle.gif)
 
-## Converting a Shape to a Custom Path
+## Converting a shape to a custom path
 
 Press `Enter` to convert the selected shape to a path. After conversion, you can edit each vertex directly.
 

--- a/editor/fundamentals/revision-history.mdx
+++ b/editor/fundamentals/revision-history.mdx
@@ -15,7 +15,7 @@ Select a revision to preview it and press the Edit Current Revision button. This
 
 ![Restore a revision](/images/editor/fundamentals/revision-history-restore.gif)
 
-## Save a Revision
+## Save a revision
 
 From the Editor Menu, select the Create a Revision button. You'll then be prompted to name the revision.
 

--- a/editor/fundamentals/shapes-and-paths-overview.mdx
+++ b/editor/fundamentals/shapes-and-paths-overview.mdx
@@ -33,7 +33,7 @@ Path layers display properties that to the type of path. Learn more about [Proce
 
 ![Path layer Properties](/images/editor/fundamentals/shape-and-path-properties.png)
 
-## Enter and esc shortcuts
+## `Enter` and `Esc` shortcuts
 
 Use the `Enter` key to quickly navigate down the Hierarchy. If you have a shape selected, this allows you to select the child path layer quickly.
 

--- a/editor/fundamentals/shapes-and-paths-overview.mdx
+++ b/editor/fundamentals/shapes-and-paths-overview.mdx
@@ -33,7 +33,7 @@ Path layers display properties that to the type of path. Learn more about [Proce
 
 ![Path layer Properties](/images/editor/fundamentals/shape-and-path-properties.png)
 
-## Enter and Esc shortcuts
+## Enter and esc shortcuts
 
 Use the `Enter` key to quickly navigate down the Hierarchy. If you have a shape selected, this allows you to select the child path layer quickly.
 

--- a/editor/fundamentals/transform-spaces.mdx
+++ b/editor/fundamentals/transform-spaces.mdx
@@ -10,7 +10,7 @@ This technique is a fundamental concept for all motion graphics. To learn more a
 
 <YouTube id="IcSXchdnzHM" />
 
-## Transform space example
+## Transform Space example
 
 ![Image](https://ucarecdn.com/8d60bc32-96ce-4b77-ade8-836f7c92b51d/)
 

--- a/editor/interface-overview/file-browser.mdx
+++ b/editor/interface-overview/file-browser.mdx
@@ -15,7 +15,7 @@ The Home view shows your recent files, links to tutorial videos, and Marketplace
 
 ![File Browser home](/images/editor/interface/file-browser.png)
 
-## Managing Files
+## Managing files
 
 Right-click anywhere within the File Browser to create a new file or folder.
 
@@ -43,7 +43,7 @@ Use projects to group related files, such as files for a client, feature, campai
 
 <Note>Projects and folders are available on Cadet, Voyager, and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
-#### Create a New Project
+#### Create a new project
 
 <Steps>
   <Step>
@@ -56,7 +56,7 @@ Use projects to group related files, such as files for a client, feature, campai
 
 ![Create a project](/images/editor/interface/create-project.png)
 
-#### Managing Project Members
+#### Managing project members
 
 You can invite people to a specific project. This is useful when someone needs access to a set of files, but does not need access to the entire workspace.
 

--- a/editor/interface-overview/hierarchy.mdx
+++ b/editor/interface-overview/hierarchy.mdx
@@ -10,13 +10,13 @@ import { VideoEmbed } from '/snippets/video-embed.jsx'
 
 The Hierarchy is a tree view that shows the objects on the stage. It shows both how objects are nested and the order in which they are rendered.
 
-## Renaming Items
+## Renaming items
 
 You can rename items in the Hierarchy to make your file easier to understand and navigate.
 
 To rename an item, double-click its name in the Hierarchy, enter a new name, then press Enter.
 
-## Parent-Child Relationships
+## Parent-child relationships
 
 Each row in the Hierarchy represents an item on the stage. Items with children have a button with an arrow next to them. Use this button to expand or collapse the list of children.
 
@@ -46,7 +46,7 @@ To change draw order, drag objects up or down in the Hierarchy.
 
 ![Change hierarchy order](/images/editor/interface/hierarchy-reorder.gif)
 
-## Lock, Isolate, and Hide Items
+## Lock, isolate, and hide items
 
 When you hover over an item in the Hierarchy, controls appear for locking, isolating, or hiding that item.
 
@@ -60,7 +60,7 @@ These controls also apply to any children nested under the item.
   Lock and isolate are editor workflow tools. They do not change the exported file or runtime behavior.
 </Note>
 
-## Context Menu
+## Context menu
 
 Right-click an item in the Hierarchy to open additional options. Depending on the selected item, options may include:
 

--- a/editor/interface-overview/inspector.mdx
+++ b/editor/interface-overview/inspector.mdx
@@ -9,7 +9,7 @@ The Inspector is the right sidebar in the editor. It shows the available propert
 
 ![Inspector](/images/inspector.png)
 
-## Selection Properties
+## Selection properties
 
 When you select an element, the Inspector updates to show controls for that element.
 
@@ -17,7 +17,7 @@ For example, selecting an artboard, object, joystick, script, property group, or
 
 <VideoEmbed src="https://static.rive.app/video/inspector-context.mp4" />
 
-## File Properties
+## File properties
 
 When nothing is selected, the Inspector shows file-level options.
 

--- a/editor/interface-overview/overview.mdx
+++ b/editor/interface-overview/overview.mdx
@@ -8,7 +8,7 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 <YouTube id="-NumdcojOTs" />
 
-## File Browser
+## File browser
 
 ![File Browser home](/images/editor/interface/file-browser.png)
 

--- a/editor/interface-overview/selection-and-navigation.mdx
+++ b/editor/interface-overview/selection-and-navigation.mdx
@@ -11,7 +11,7 @@ Use selection and navigation controls to choose objects, move through nested gro
   For a complete list of shortcuts, see [Keyboard Shortcuts](/editor/keyboard-shortcuts).
 </Tip>
 
-## Selecting Objects
+## Selecting objects
 
 <YouTube id="xQK498Y1J8M" />
 
@@ -19,13 +19,13 @@ Click an object to select it. To select multiple objects, drag over them to crea
 
 Hold `Shift` while clicking or dragging to add objects to the current selection or remove selected objects.
 
-### Select Objects Inside Groups
+### Select objects inside groups
 
 To select an object inside a group, double-click the object. This moves you one level down in the hierarchy, so you can select objects inside that group.
 
 ![Double Click](/images/editor/fundamentals/DoubleClick2.gif)
 
-### Deep Select
+### Deep select
 
 To select an object inside nested groups, hold `⌘` on macOS or `Ctrl` on Windows, then click the object.
 
@@ -37,7 +37,7 @@ Deep select lets you select an object directly, even when it is inside multiple 
 
 ![Deep Select](/images/editor/fundamentals/DeepSelect.gif)
 
-### Select Behind
+### Select behind
 
 When you hover over an object on the stage, Rive outlines the object that will be selected if you click.
 
@@ -45,7 +45,7 @@ If multiple objects overlap, press `Alt` to cycle through objects under the curs
 
 ![Select behind](/images/editor/interface-overview/select-behind.gif)
 
-### Moving Up and Down the Hierarchy
+### Moving up and down the Hierarchy
 
 Use `Enter` and `Esc` to move through nested objects in the hierarchy.
 
@@ -77,7 +77,7 @@ You can also use keyboard shortcuts:
 * Press `-` to zoom out.
 * Press `⌘` + `0` on macOS or `Ctrl` + `0` on Windows to return to 100%.
 
-### Fit Selection
+### Fit selection
 
 Press `F` to fit the current selection in the viewable stage area.
 

--- a/editor/interface-overview/sidebar.mdx
+++ b/editor/interface-overview/sidebar.mdx
@@ -19,11 +19,11 @@ The sidebar includes several panels:
 - [Animations](/editor/animate-mode/animate-mode-overview) - Create and manage animations and State Machines.
 - [Agent](/editor/ai-agent/ai-agent) - Use the AI Agent to help create, edit, and explore your file.
 
-## Panel Options
+## Panel options
 
 Use the **…** menu on a panel to access options such as filtering, sorting, collapsing the panel, or resetting the sidebar layout.
 
-## Organizing Panels
+## Organizing panels
 
 You can customize how panels appear in the sidebar.
 
@@ -33,7 +33,7 @@ You can customize how panels appear in the sidebar.
 
 <VideoEmbed src="https://static.rive.app/video/sidebar-organize-panels.mp4" />
 
-### Open AI Agent in Viewport
+### Open AI agent in Viewport
 
 The Agent panel also has an option to open in the viewport, where it appears alongside the Stage or Script panel.
 

--- a/editor/interface-overview/sidebar.mdx
+++ b/editor/interface-overview/sidebar.mdx
@@ -33,7 +33,7 @@ You can customize how panels appear in the sidebar.
 
 <VideoEmbed src="https://static.rive.app/video/sidebar-organize-panels.mp4" />
 
-### Open AI agent in Viewport
+### Open AI Agent in viewport
 
 The Agent panel also has an option to open in the viewport, where it appears alongside the Stage or Script panel.
 

--- a/editor/interface-overview/stage.mdx
+++ b/editor/interface-overview/stage.mdx
@@ -24,7 +24,7 @@ The Stage is an infinite canvas where you can place artboards containing all you
   To learn how to navigate and select items on the stage, see [Keyboard Shortcuts](/editor/keyboard-shortcuts).
 </Tip>
 
-### View Options menu
+### View options menu
 
 ![View options](/images/interface/stage-view-options.png)
 
@@ -36,7 +36,7 @@ The View Options menu controls what appears on the stage while you work. Use it 
 - **Show Final Playback:** show the final playback state while editing
 - **Rulers and guides:** show rulers, lock guides, or clear guides from the stage
 
-### Stage Background Colors
+### Stage background colors
 
 You can set separate stage background colors for Design mode and Animate mode.
 

--- a/editor/interface-overview/toolbar.mdx
+++ b/editor/interface-overview/toolbar.mdx
@@ -7,7 +7,7 @@ description: "Access file, design, rigging, preview, and export tools from the R
 
 Use the toolbar to switch tools, create objects, adjust view options, invite collaborators, publish your file, and access file-level actions.
 
-## Editor Menu
+## Editor menu
 
 ![Editor menu](/images/interface/editor-menu.png)
 
@@ -52,7 +52,7 @@ Use **Publish** to export, embed, or publish your file.
 * [Embed](/editor/embed-urls/overview)
 * Publish to the [marketplace](/community/marketplace-overview#marketplace-overview)
 
-## Preview Bound Values
+## Preview bound values
 
 By default, data-bound values update while the state machine is playing.
 
@@ -60,7 +60,7 @@ Turn on the **Data Binding Preview Toggle** to preview bound values while editin
 
 ![Preview data binding](/images/editor/data-binding/binding-data/preview-data-binding.gif)
 
-## Mode Toggle
+## Mode toggle
 
 Use the **Mode Toggle** to switch between **Design** and **Animate** mode. Press `Tab` to switch modes quickly.
 

--- a/editor/keyboard-shortcuts.mdx
+++ b/editor/keyboard-shortcuts.mdx
@@ -139,7 +139,7 @@ Applies to the selected keys.
 | Next/Previous File Tab          | <kbd>Ctrl</kbd> + <kbd>Tab</kbd> / <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd>      |
 
 
-## Align and Origin
+## Align and origin
 
 | Purpose                         | Shortcut                                                                                     |
 |---------------------------------|---------------------------------------------------------------------------------------------|

--- a/editor/layouts/layout-animation.mdx
+++ b/editor/layouts/layout-animation.mdx
@@ -14,7 +14,7 @@ When a Layout resizes or its content changes, its children may move to new posit
   href="https://rive.app/community/files/28493-53866-enable-layout-animation"
 />
 
-## Adding Layout Animation
+## Adding Layout animation
 
 <Steps>
   <Step title="Add a Layout Animation">

--- a/editor/layouts/layout-parameters.mdx
+++ b/editor/layouts/layout-parameters.mdx
@@ -9,7 +9,7 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 ---
 
-## Absolute vs Relative
+## Absolute vs relative
 
 To control the flow of child Layouts in a Row or Column requires the Layout children to be Relative, i.e. not have their Absolute position option enabled. Use the icon in the top right of the Layout inspector to toggle between an Absolute and Relative Layout.
 
@@ -18,7 +18,7 @@ To control the flow of child Layouts in a Row or Column requires the Layout chil
 - **Absolute:** An Absolute Layout positions itself within an artboard or parent Layout container. It can have 2 or more of it’s edges pinned to the container.
 - **Relative:** A Relative Layout has it’s position defined by the parent artboard or Layout. Changing the flex properties on the parent will determine the child layout behaviour.
 
-## Scale Types
+## Scale types
 
 A layout’s width and height can make use of 3 different scale behaviours:
 
@@ -46,7 +46,7 @@ The clip toggle hides any child elements within the layout that extend beyond th
 
 ![Image](/images/editor/layouts/80299f91-7525-42cc-ba64-20ca7ea7e5ad.webp)
 
-## Position (Absolute Layouts only)
+## Position (absolute Layouts only)
 
 Absolute Layouts provide additional options to set their position within the artboard or parent Layout. The position is defined by at least 2 pinned edges — one horizontal and one vertical, however additional edges can also be enabled.
 
@@ -54,7 +54,7 @@ Set the desired edges to pin by selecting the markers within the inspector graph
 
 ![Image](/images/editor/layouts/987f6999-4db4-487e-a8f0-c8760b037012.webp)
 
-## Padding and Margin
+## Padding and margin
 
 <Info>Padding ONLY affects Layout children. For example if you want to have a button with a label, the text should be wrapped in a Layout and that Layout should be the child of another Layout that applies the padding.</Info>
 
@@ -71,11 +71,11 @@ Padding and margin can be applied symmetrically along an axis, or to individual 
 </video>
 
 
-## Layout Children
+## Layout children
 
 <Note>A layout’s flex parameters are only applied to other layouts contained within it. In order to generate rows, columns, and grids of content that reflow, content items must themselves be wrapped in an additional layout container.</Note>
 
-## Row/Column
+## Row/column
 
 - **Row:** Lay out children along the horizontal axis.
 - **Column:** Layout children along the vertical axis.
@@ -110,7 +110,7 @@ Spacing between content (gaps) can be set both horizontally and vertically, and 
 
 ![Image](/images/editor/layouts/84dba879-e23b-4144-963a-3d4e5f50a144.webp)
 
-## Left-to-Right/Right-to-Left
+## Left-to-right/right-to-left
 
 <YouTube id="oLjFOu-UFxM" />
 

--- a/editor/layouts/layout-tools.mdx
+++ b/editor/layouts/layout-tools.mdx
@@ -6,7 +6,7 @@ description: 'There are several Layout tools available in Rive to build your res
 
 import { YouTube } from '/snippets/youtube.mdx'
 
-## Getting Started with Layouts
+## Getting started with Layouts
 
 There are a number of ways to start adding layouts to your designs.
 
@@ -17,7 +17,7 @@ There are a number of ways to start adding layouts to your designs.
 
 ---
 
-### Layout Tools in the Arrangement Tools Menu
+### Layout tools in the arrangement tools menu
 
 <Frame caption="Arrangement Tools Menu showing the Layout, Row and Column Tools">
   <img src="/images/editor/layouts/53f42ad0-4045-41c4-bcfe-90a40ad0dc1d.webp" alt="Arrangement Tools menu open in the toolbar, listing the Layout (L), Row (R), and Column (C) tools" />
@@ -69,7 +69,7 @@ Instead of starting with an empty Layout container, you can wrap existing object
 
 ---
 
-### Add Child Layout
+### Add child Layout
 
 When a Layout is the current selection, an `Add Child Layout` button will appear in the Layout inspector. Clicking this will add a new Layout as a child of the selected Layout, with its width and height set to Fill.
 
@@ -77,7 +77,7 @@ When a Layout is the current selection, an `Add Child Layout` button will appear
 
 ---
 
-### Dragging and Dropping Layouts
+### Dragging and dropping Layouts
 
 Layouts (both Absolute and Relative) can be dragged and dropped into other Layouts at any time. This can be done in two ways:
 

--- a/editor/layouts/layouts-overview.mdx
+++ b/editor/layouts/layouts-overview.mdx
@@ -36,7 +36,7 @@ Prior to the addition of Layouts in Rive, all objects on an Artboard were positi
 
 ---
 
-## Layout Parents and Children
+## Layout parents and children
 
 In order to create more complex UI that responds to the screen or browser size, it is important to understand that Layouts can be placed inside other Layouts. We refer to the outer Layout as the parent and the inner Layout as the child. The Layout children are typically positioned relative to their Layout parent (similar to how [Groups](/editor/fundamentals/groups) work). In addition, the parent can either be sized to the children ([Hug](/editor/layouts/layout-parameters#scale-types)) or the children can size to their parent ([Fill](/editor/layouts/layout-parameters#scale-types)). Here is an example to help visualize how these relationships work.
 
@@ -48,7 +48,7 @@ In the image below we will focus on the regions contained by the dashed lines. T
 
 ---
 
-## Absolute vs Relative Layouts
+## Absolute vs relative Layouts
 
 Layouts can exist within Rive's freeform transform space, which means that you can draw a Layout to the Artboard and position it as you would any other Rive object. This type of Layout is referred to as **Absolute** (positioned absolutely).
 
@@ -83,13 +83,13 @@ Unlike in some other tools, Rive will provide an additional hierarchy item to re
 
 ## Use cases
 
-#### Building a Responsive Button
+#### Building a responsive button
 
 This tutorial shows how you can build a responsive button from scratch.
 
 <YouTube id="dx63jfWJtLQ" />
 
-#### Reflow With Dynamic Components
+#### Reflow with dynamic components
 
 This tutorial explains how to build Rive files that can reposition their elements dynamically when resized.
 

--- a/editor/libraries.mdx
+++ b/editor/libraries.mdx
@@ -21,7 +21,7 @@ With Libraries:
 
 <Note>Libraries are available on Voyager and Enterprise plans. [Learn more about our plans and pricing](https://rive.app/pricing?utm_source=docs&utm_medium=content).</Note>
 
-## Creating a Library
+## Creating a library
 Any file can be made into a library. First, you'll need to create a [component](/editor/fundamentals/components) and/or a view model before you can publish the file as a library. Select an artboard on the stage and use the component icon in the inspector or `Shift` + `N` to toggle its status as a component.
 
 ![Image](/images/editor/libraries/01-component.webp)
@@ -32,7 +32,7 @@ With a component or view model present in the file, select the **Publish Library
 
 <Tip>You can identify a library file by the icon in the tab bar and in the file browser.</Tip>
 
-## Importing from a Library
+## Importing from a library
 To start using components and view models from a published library, select the library icon present in both the asset and data panels. The library panel displays alongside the hierarchy/asset/data column, and displays a list of the available libraries for the active file.
 
 ![Image](/images/editor/libraries/05-browse.webp)
@@ -51,7 +51,7 @@ With the chosen elements added to your file, you can access and reuse components
 
 ![Image](/images/editor/libraries/08-assets.webp)
 
-## Updating a Library
+## Updating a library
 After publishing, you can continue to make changes, add, or remove components, view models, and enums. Republish the library via the same option in the export or file menus. Upon publishing an updated version of the library, any files that have imported elements from it will display a small badge indicating an available update.
 
 ![Image](/images/editor/libraries/09-update-badge.webp)
@@ -76,7 +76,7 @@ After importing a component from a library and creating an instance of it on the
 
 ![Image](/images/editor/libraries/13-detach.webp)
 
-## Export Options
+## Export options
 By using libraries, you create a series of dependencies between files. For example, an instance of an imported component depends on the library file it came from, which in turn may depend on an image asset used within the component, or perhaps another component from a different library entirely.
 
 The export options control what and how components and any assets they depend on get exported to a riv file. These options are available across assets and components, with an additional layer of separation for libraries specifically.
@@ -95,7 +95,7 @@ You may want to adjust these options to suit your needs at runtime as opposed to
 
 ![Image](/images/editor/libraries/11-library-wide-options.webp)
 
-## Unpublishing a Library
+## Unpublishing a library
 Use the **Unpublish Library** action in the file menu to prevent additional files from accessing the library and its components. Unpublishing does not remove library components from host files that had already imported them. Host files that have imported library components will retain access to previously published versions of the library. You may republish a library at any time.
 
 ![Image](/images/editor/libraries/14-unpublish.webp)

--- a/editor/manipulating-shapes/bones.mdx
+++ b/editor/manipulating-shapes/bones.mdx
@@ -27,7 +27,7 @@ You can combine these methods in the same rig. For example, a character’s hand
 
 <YouTube id="WDILxfmCEt0" />
 
-## Creating Bone Chains
+## Creating Bone chains
 
 Select the Bone tool from the **Bones** menu, or press **B**.
 
@@ -58,10 +58,10 @@ Joints do not appear as separate objects in the Hierarchy. Moving a joint change
 The first bone in a chain is the **root bone**. It controls the position of the entire chain and is the only bone in the chain with X and Y position properties. Every other bone is positioned by its length and rotation relative to its parent.
 
 
-## Controlling Elements With Bones
+## Controlling elements with Bones
 
 
-### Transforming Elements
+### Transforming elements
 
 Make an element a child of a bone to control its transform. When the bone moves, rotates, or scales, its children follow without being deformed.
 
@@ -71,7 +71,7 @@ This method works well for rigid parts that should keep their shape, such as a h
 
 <YouTube id="g8MWMKixURo" />
 
-### Deforming Elements
+### Deforming elements
 
 
 You can bind bones to the control points of both vector paths and raster images:
@@ -107,7 +107,7 @@ After binding, Rive assigns each bone a color. The same colors appear on the bon
 Rive automatically assigns an initial influence, or weight, to each vertex. Vector paths also allow you to weight their Bézier handles. Adjust these weights to fine-tune how the element deforms.
 
 
-#### Adjusting Vertex Weights
+#### Adjusting vertex weights
 
 A weight determines how much influence a bone has over a vertex. A vertex can be influenced by one or more bound bones, but its combined weights always equal 100%.
 
@@ -131,7 +131,7 @@ You can lock a vertex’s weight for a specific bone. Locked weights stay fixed 
 
 <VideoEmbed src="https://static.rive.app/video/lock-bone-weight.mp4"/>
 
-#### Weight Editing Tools
+#### Weight editing tools
 
 Rive includes tools to help you adjust vertex weights after bones are bound.
 
@@ -148,7 +148,7 @@ Auto-Weights includes two settings:
 - **Blend** - controls how widely weights blend at the boundary between two bones. Higher values spread the blend across more of the mesh, creating softer deformation. Lower values create a more rigid result, where each vertex sticks more closely to its nearest bone.
 - **Influence** - controls the maximum number of bones that can influence each vertex.
 
-#### Mesh View Options
+#### Mesh view options
 
 **Show Weights** shows or hides weight pie charts on unselected vertices. Selected vertices always show their weights while you edit them.
 

--- a/editor/manipulating-shapes/clipping.mdx
+++ b/editor/manipulating-shapes/clipping.mdx
@@ -7,7 +7,7 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 <YouTube id="bxmipy1Gv6Y" />
 
-## How to use Clipping
+## How to use clipping
 
 Select the shape or group you want to clip and hit the plus button next to the Clipping options in the Inspector. After hitting the plus button, you'll notice a blue border appear around the stage, indicating that you can pick a shape as the clipping source. Now, select the path you want to use as a clipping path. Remember, the clipping target must be a shape, not a group or any other object.
 
@@ -21,7 +21,7 @@ If you have shapes that aren't clipping, or only partially clipping, be sure to 
 
 ![Reverse Direction](/images/editor/manipulating-shapes/ReverseDirection.gif)
 
-## Inverse Clipping
+## Inverse clipping
 
 Clipping is typically used to hide a part of your graphics. In the example below, we're using an ellipse to show only part of our jewel graphic.
 

--- a/editor/manipulating-shapes/joysticks.mdx
+++ b/editor/manipulating-shapes/joysticks.mdx
@@ -23,7 +23,7 @@ To create a new joystick, either find the Joystick Tool in the Stage Controls To
   ![toggle joysticks visibility](/images/editor/interface/toggle-show-joysticks.gif)
 </Tip>
 
-## Joystick Properties
+## Joystick properties
 
 With the Joystick selected, you’ll see a number of properties that you can use in the Inspector.
 
@@ -67,7 +67,7 @@ After you add a timeline to an axis, you’ll notice a toggle that appears next 
 
 ![Invert Toggle](/images/editor/manipulating-shapes/InvertToggle.gif)
 
-### Handle Source
+### Handle source
 
 The handle source allows you to constrain the position of the handle to another object's position properties. Use the button, then select an object you'd like to use as the handle's position source. This option is helpful when you want the mouse cursor to drive the joystick while the state machine is running.
 
@@ -83,6 +83,6 @@ The most important consideration is that when you have multiple animations assig
 
 Be sure to separate animated properties to prevent any conflicts. We now actively prevent you from creating keys for properties that are already being used in a timeline assigned to a joystick.
 
-### Creating Complex Deformations
+### Creating complex deformations
 
 You can add as many keys to a joystick timeline as you’d like. By doing this, we can create incredibly complex deformations, but remember, these deformations will often bloat the size of your file, so use them sparingly.

--- a/editor/manipulating-shapes/meshes.mdx
+++ b/editor/manipulating-shapes/meshes.mdx
@@ -16,7 +16,7 @@ A mesh is built from a [contour](#contours), which defines the mesh’s shape an
   href="https://rive.app/community/files/28327-53500-mesh-and-bones/"
 />
 
-## Adding a Mesh to an Image
+## Adding a Mesh to an image
 
 <Steps>
   <Step>
@@ -49,11 +49,11 @@ The position of these vertices can be keyed on a timeline or [controlled by bone
 
 The contour defines the visible shape and vertex structure of the mesh. Editing the contour changes the mesh structure without deforming the image.
 
-### Creating Contours
+### Creating contours
 
 When you add a mesh to an image, Rive automatically creates a simple contour with four vertices that make two triangles. You can use this contour as a starting point or make your own.
 
-#### Manually Create a New Contour
+#### Manually create a new contour
 
 Click the **New Contour** button to draw a new contour from scratch.
 
@@ -61,7 +61,7 @@ This is useful when the default contour does not match the shape of the image, o
 
 <VideoEmbed src="https://static.rive.app/video/new-contour.mp4" />
 
-#### Auto-Trace a New Contour
+#### Auto-trace a new contour
 
 Use **Auto-Trace** to quickly create a contour that follows the visible shape of an image.
 
@@ -75,7 +75,7 @@ Adjust the settings to control the generated contour:
 
 <VideoEmbed src="https://static.rive.app/video/auto-trace.mp4" />
 
-#### Contour Bounds
+#### Contour bounds
 
 Only the area inside the contour is rendered. Anything outside the contour is hidden.
 
@@ -83,7 +83,7 @@ This can be useful when you want to create multiple meshes from different parts 
 
 <VideoEmbed src="https://static.rive.app/video/outside-contour.mp4" />
 
-### Editing Contours
+### Editing contours
 
 Use **Edit Contour** or press **P** to adjust the existing contour. The Mesh Pen lets you add new vertices or move existing vertices without warping the image.
 
@@ -93,7 +93,7 @@ Click continuously to create forced edges between vertices. Press **Esc** betwee
 
 <VideoEmbed src="https://static.rive.app/video/auto-generate-triangles.mp4" />
 
-#### Forced Edges
+#### Forced edges
 
 Forced edges are edges you manually add between mesh vertices. Use forced edges when you need more control over the mesh structure, such as defining an important seam, crease, corner, or area where the mesh triangles should follow a specific path.
 
@@ -121,13 +121,13 @@ A more complex mesh can create smoother deformations, but it can also be harder 
 <VideoEmbed src="https://static.rive.app/video/generate.mp4" />
 
 
-### Resetting a Contour
+### Resetting a contour
 
 Use **Reset** to return the mesh to its default contour.
 
 <VideoEmbed src="https://static.rive.app/video/reset-mesh.mp4" />
 
-## Managing Meshes
+## Managing meshes
 
 ### Copying a Mesh
 
@@ -144,7 +144,7 @@ You can copy a mesh and apply it to another image.
 
 <VideoEmbed src="https://static.rive.app/video/copy-paste-mesh.mp4" />
 
-### Swapping Images
+### Swapping images
 
 A mesh can continue to work when the image is changed.
 
@@ -169,7 +169,7 @@ After an image has a mesh, the **Deform** section shows options for editing or r
   Removing a mesh deletes the mesh and its vertex edits from the image.
 </Warning>
 
-## Mesh View Options
+## Mesh view options
 
 Mesh view options control how the mesh and image appear while editing. These options can make it easier to focus on vertices, edges, weights, or the deformed result.
 

--- a/editor/manipulating-shapes/solos.mdx
+++ b/editor/manipulating-shapes/solos.mdx
@@ -23,7 +23,7 @@ You can animate solos by opening a timeline and clicking the solo's radio button
 
 ![Image](/images/editor/manipulating-shapes/8be34515-c2e9-46f9-9dc3-7347e2528dd9.webp)
 
-## Creating New Skins
+## Creating new skins
 
 One of the most common use cases for Solos is creating new skins for a character.
 

--- a/editor/manipulating-shapes/trim-path.mdx
+++ b/editor/manipulating-shapes/trim-path.mdx
@@ -11,7 +11,7 @@ The Trim Path feature allows you to draw only a portion of the stroke on a vecto
 
 To activate Trim Path, select a shape that has a stroke and click the stroke options in the inspector. Now, use the Trim Path drop-down menu and select either Sequential or Synced mode. Both modes enable Trim Path, but behave differently when used on a shape with multiple paths.
 
-### Sequential 
+### Sequential
 
 When Trim Path is set to Sequential, paths are animated sequentially. The order in which they animate is dictated by their order under the shape.
 
@@ -35,19 +35,19 @@ Use Offset to easily move the trimmed portion of the path.
 
 ![Image](https://ucarecdn.com/50b672cd-610a-4829-a46d-5f106dcad0e9/)
 
-# Dashed Stroke 
+## Dashed Stroke
 
 Much like Trim Path, the Dashed Stroke option allows you to dynamically change and animate parts of a path. Dash strokes allow you to customize the size of the dash and offset the dashes around the path. Note that you can add more than one dash size and gap to a path.
 
 ![Image](https://ucarecdn.com/56fa4778-555d-460e-8133-809e73c7746a/)
 
-## Dash 
+## Dash
 
 The dash property controls the size of the dashed segments. This option can be in pixels, or a percentage length of the path.
 
 ![Image](https://ucarecdn.com/34d7c4d3-3f92-4140-9a12-bc83b67f8e0d/)
 
-## Offset 
+## Offset
 
 The offset property moves the dashes along the path. This option can be in pixels, or a percentage.
 

--- a/editor/manipulating-shapes/trim-path.mdx
+++ b/editor/manipulating-shapes/trim-path.mdx
@@ -41,7 +41,7 @@ Much like Trim Path, the Dashed Stroke option allows you to dynamically change a
 
 ![Image](https://ucarecdn.com/56fa4778-555d-460e-8133-809e73c7746a/)
 
-## Dash
+### Dash
 
 The dash property controls the size of the dashed segments. This option can be in pixels, or a percentage length of the path.
 

--- a/editor/state-machine/inputs.mdx
+++ b/editor/state-machine/inputs.mdx
@@ -27,13 +27,13 @@ The best use for Inputs is quick, prototype interactions that you don't plan to 
 
 <YouTube id="rJVfBs6VA0I" />
 
-### Creating a new Input
+### Creating a new input
 
 To create a new Input, use the plus button in the input panel. After hitting the plus button, you’ll be prompted to select the type of input you want to create. There are three types of inputs; booleans, triggers, and numbers.
 
 ![Image](https://ucarecdn.com/11d24273-9c87-4adb-963a-fd45f8e667b6/)
 
-## Input Types
+## Input types
 
 We can use three types of inputs depending on the situation and type of interactive content: booleans, triggers, and numbers. We'll discuss each of these inputs below.
 
@@ -55,11 +55,11 @@ A number input give you a number box that can be any integer.
 
 ![Number input for rating animation](https://ucarecdn.com/dbd19760-02e4-4d37-a3a8-627ce8e0b65c/)
 
-## Exposing Inputs and Events
+## Exposing inputs and events
 
 Expose the Inputs and/or Events of a Component to control them from a parent/host Artboard. This allows you to control one Component with another via a State Machine.
 
-### How to Expose an Input
+### How to expose an input
 
 Exposing an Input allows the parent artboard to access and manipulate it. To do this, select the desired input, then check the expose to main artboard option in the inspector.
 
@@ -67,19 +67,19 @@ Exposing an Input allows the parent artboard to access and manipulate it. To do 
 
 After creating a Component, you’ll see any exposed inputs in the Inspector via the options panel and in the Inputs panel.
 
-### Using Inputs on a Parent Artboard
+### Using inputs on a parent Artboard
 
 Exposed inputs can be found in the Inputs panel or in the inspector. You can use them through listeners, an event, or by keying them on a timeline.
 
 ![Image](https://ucarecdn.com/ee1dd959-9fba-45c9-a74b-1173cd71e894/)
 
-#### Via a Listener
+#### Via a listener
 
 When you create a listener, you’ll find all exposed Inputs as a set input property of a Listener. This option lets you, for example, change the boolean input of multiple artboards simultaneously.
 
 ![Image](https://ucarecdn.com/2349fdd6-5a5a-434e-a1dc-3974e6f1e01c/)
 
-#### Using Events
+#### Using events
 
 Additionally, we can use Listeners to listen for Events firing from our Component, and change inputs accordingly.
 

--- a/editor/state-machine/layers.mdx
+++ b/editor/state-machine/layers.mdx
@@ -17,7 +17,7 @@ To create a layer, click the **+** button in the **Layers** tab.
 
 ![Adding a new layer](/images/editor/state-machine/state-machine-layer-create.gif)
 
-## Layer Order
+## Layer order
 
 Layer order determines which layer takes priority when multiple layers animate the same property.
 
@@ -32,7 +32,7 @@ To change layer order, drag layers up or down in the **Layers** tab.
 
 ![Reorder state machine layers](/images/editor/state-machine/state-machine-layer-order.gif)
 
-## Layer Menu
+## Layer menu
 
 Click the **...** button next to a layer name to open the layer menu.
 

--- a/editor/state-machine/listeners.mdx
+++ b/editor/state-machine/listeners.mdx
@@ -18,7 +18,7 @@ Use listeners to create dynamic experiences that react to user input and changes
 
 <YouTube id="RBQdLRXNVbE" />
 
-## Creating a Listener
+## Creating a listener
 
 <Steps>
   <Step>
@@ -50,7 +50,7 @@ The **Target** determines what the listener watches. The target can be an elemen
 
 Use an element as the target when you want to listen for interactions on that element, such as clicks or drags. Use an artboard or nested component as the target when you want to listen for view model property changes, Rive events, or other events that belong to that artboard or component.
 
-### Opaque Target
+### Opaque target
 
 **Opaque Target** controls whether pointer events stop at this listener's hit area or continue through to elements behind it.
 
@@ -58,7 +58,7 @@ When **Opaque Target** is enabled, pointer events stop at the target. When it's 
 
 <VideoEmbed src="https://static.rive.app/video/docs/listener-opaque-target.mp4" />
 
-## Listen To
+## Listen to
 
 **Listen to** is the condition the listener watches for. When the condition is met, the listener is triggered.
 
@@ -106,7 +106,7 @@ You can add multiple actions to a single listener.
   You can data bind values in listener actions.
 </Tip>
 
-### Align Target
+### Align target
 
 The **Align Target** action positions an object so it follows the pointer when the listener is triggered within the listener area.
 

--- a/editor/state-machine/states.mdx
+++ b/editor/state-machine/states.mdx
@@ -10,7 +10,7 @@ States are simply timeline animations that can play at any point in your state m
 
 There are a few types of states that you’ll end up using as you work with the State Machine, including Default States, Single animations, and Blend States. We’ll explore each of these below.
 
-## Default States
+## Default states
 
 The Default States are the states that, by default, are added to every State Machine.
 
@@ -36,7 +36,7 @@ Unlike normal states, states connected to the Any State can be played at any tim
 
 ![Rating system using the Any state](https://ucarecdn.com/6c4401fc-1b7c-4748-901d-a6e237f57e51/)
 
-## Animation States
+## Animation states
 
 Animation states include all states other than the default states added to a State Machine. These states will control the look and motion of your interactive content. There are three types of animation states; Single Animation, 1D blend, and Direct blend states.
 
@@ -59,13 +59,13 @@ To assign a timeline to a state, use the timeline dropdown in the inspector.
 
 Any timeline that we create can be used as a single animation state. Depending on the type of animation we are using, the single animation state could be a one-shot, looping, or ping-pong state. In most cases, you’ll be using single animation states to create most of your state machines.
 
-### Blend states
+### Blend States
 
 A Blend State is any state that blends together two or more timeline animations. We use these states for content like loading bars, health systems, scrolling interactions, and dynamic face rigs.
 
 There are two types of blend states; 1D and Direct Blend states.
 
-#### 1D Blend state:
+#### 1D Blend State:
 
 A 1D Blend State allows us to mix multiple timelines together with a single numerical view model property. This state works by ramping up one animation and ramping down the other while you increase or decrease a number value. Note that this mixing is not linear, but is additive and could give you unexpected results.
 
@@ -99,7 +99,7 @@ Notice that once you define the range, a graphic appears above the property drop
 
 ![Blend State in action](https://ucarecdn.com/44a40cb9-90d9-4aca-920f-6042cc52340f/)
 
-#### Additive Blend state:
+#### Additive Blend State:
 
 An Additive Blend state allows you to blend together multiple timelines using multiple number properties. This allows us to create unique poses and facial positions by mixing multiple animations together. While working with an Additive Blend, you’ll either be mixing an animation by value or property. Read more below.
 
@@ -115,7 +115,7 @@ A Blend by Value timeline can be thought of as the baseline animation, or defaul
 
 A view model property blend is an animation that is mixed with the default pose or motion via a number property. Each of your different property blends should have their own number property.
 
-## State Options
+## State options
 
 When you select a state in the State Machine Graph, you can change its options in the Inspector, including:
 
@@ -176,14 +176,14 @@ Actions can be used to:
 
 <YouTube id="4Uuu0MkBawE" />
 
-### Action Timing
+### Action timing
 
 Each action can run at either:
 
 - **Start** — Runs when the state begins
 - **End** — Runs after the state completes
 
-### Creating an Action
+### Creating an action
 
 ![Creating an transition action](/images/editor/state-machine/transitions/state-action.gif)
 
@@ -196,11 +196,11 @@ Each action can run at either:
   </Step>
 </Steps>
 
-## Common Issues
+## Common issues
 
 <YouTube id="TnTvFkMC7iI" />
 
-## Use case: Build a simple button
+## Use case: build a simple button
 
 In this exercise, we will use our state machine knowledge to create a simple button with two layers of interactivity. Hover and click.
 

--- a/editor/state-machine/transitions.mdx
+++ b/editor/state-machine/transitions.mdx
@@ -35,7 +35,7 @@ Transitions define how and when a State Machine moves from one state to another.
 
 <YouTube id="C4KNgrrqt7k" />
 
-## Transition Path
+## Transition path
 
 A transition path determines how the State Machine moves from one state to another.
 
@@ -63,7 +63,7 @@ Conditions determine when a transition can occur.
 
 <YouTube id="30HJo_DaLDk" />
 
-### Adding a Condition
+### Adding a condition
 
 To add a condition to a transition, select the transition, then click the plus button next to **Conditions**.
 
@@ -79,7 +79,7 @@ In this condition, `isWalking` is the **source value**, **equals** is the **oper
 
 ![Add a transition condition](/images/editor/state-machine/transitions/add-condition.gif)
 
-#### The Source Value
+#### The source value
 
 Conditions can be driven by many different sources, including:
 
@@ -89,13 +89,13 @@ Conditions can be driven by many different sources, including:
 
 ![Source value](/images/editor/state-machine/transitions/source-value.png)
 
-#### The Operator
+#### The operator
 
 Conditions can use comparisons such as equals, does not equal, greater than, greater than or equal to, less than, and less than or equal to. The available comparisons depend on the type of value being compared.
 
 ![Operators](/images/editor/state-machine/transitions/comparisons.png)
 
-#### Comparison Value
+#### Comparison value
 
 The comparison value is the value the source value is compared against.
 
@@ -105,14 +105,14 @@ You can enter a fixed comparison value, such as `true`, `100`, or `"mobile"`. Yo
 
 For example, a transition might occur when `speed` is greater than a data-bound `walkThreshold` value.
 
-### Adding Multiple Conditions
+### Adding multiple conditions
 
 You can add multiple conditions to a single transition. All conditions must be met before the transition occurs.
 
 ![Adding multiple conditions](/images/editor/state-machine/transitions/or-condition.png)
 
 
-## Transition Properties
+## Transition properties
 
 Once you’ve added a transition, selecting the direction indicator will allow you to configure the transition. There are three different sections to the transition panel, the transition properties, conditions, and interpolation.
 
@@ -144,7 +144,7 @@ For example, if you want the state machine to play the entire animation before t
 
 ![Exit time 100%](/images/editor/state-machine/transitions/exit-time-100.gif)
 
-### Pause Source When Exiting
+### Pause source when exiting
 
 **Pause Source When Exiting** pauses the animation in the state you are leaving while the transition plays.
 
@@ -152,7 +152,7 @@ In this example, the up-and-down motion pauses as soon as the transition begins.
 
 ![Pause when exiting](/images/editor/state-machine/transitions/pause-source-when-exiting.gif)
 
-### Allow Exit During Transition
+### Allow exit during transition
 
 **Allow exit during transition** controls whether the State Machine can leave a transition before that transition finishes.
 
@@ -189,7 +189,7 @@ Actions can be used to:
 
 <YouTube id="4Uuu0MkBawE" />
 
-### Creating an Action
+### Creating an action
 
 ![Creating a transition action](/images/editor/state-machine/transitions/transition-action.gif)
 
@@ -202,14 +202,14 @@ Actions can be used to:
   </Step>
 </Steps>
 
-#### Action Timing
+#### Action timing
 
 Each action can run at either:
 
 - **Start** — Runs when the transition begins
 - **End** — Runs after the transition completes
 
-## Randomize Exit
+## Randomize exit
 
 
 **Randomize Exit** lets a state choose from its outgoing transition paths at random.
@@ -221,7 +221,7 @@ To use it, select the origin state and enable **Randomize Exit**. The state list
 The higher the weight, the more likely that path is to be chosen. For example, if **Timeline 1** has a weight of `3` and **Timeline 2** has a weight of `1`, the State Machine has a 75% chance of transitioning to **Timeline 1** and a 25% chance of transitioning to **Timeline 2**.
 
 
-## Disabling a Transition
+## Disabling a transition
 
 You can temporarily disable a transition without deleting it. Disabling is useful when you want to isolate part of a state machine for testing, or temporarily remove a path without losing its configuration.
 

--- a/editor/tagging.mdx
+++ b/editor/tagging.mdx
@@ -5,7 +5,7 @@ description: ''
 
 Tagging is a way to organize your hierarchy further. Create tags, then apply them to objects in the Hierarchy like Bones or Groups, then filter the view to see exactly what you need, when you need it. 
 
-## Creating Tags
+## Creating tags
 
 There are two ways to create a Tag: either through the Hierarchy or by using the Inspector. Remember that any Tag created can be used on any artboard in the file.
 
@@ -17,7 +17,7 @@ To create a new tag, ensure that you have nothing selected on the artboard, then
 
 Once the Tag has been added, you can change the name and color to your liking.
 
-### In the Hierarchy 
+### In the Hierarchy
 
 There are two ways to create tags through the Hierarchy. The first is by using the tag menu at the top of the Hierarchy. From here you can create new Tags, edit Tags, collapse Tags, filter, lock, or select assigned Tags.
 
@@ -29,13 +29,13 @@ The second way is to select one or more objects to create a tag directly in the 
 
 To edit the Tag's properties, use the steps above.
 
-## The Tags Menu 
+## The tags menu
 
 The Tags Menu is where you will find most of the Tag Options. Some of these options are self-explanatory, such as creating or editing a tag. Let’s explore some of the other available options.
 
 ![Tag menu](/images/editor/b4ba7047-3927-467f-9528-32c9b066f0d2.webp)
 
-### Collapse Tag
+### Collapse tag
 
 When you add a tag to an object, you’ll notice that the Tag's name and the color pip are displayed to the right.
 
@@ -43,7 +43,7 @@ When you add a tag to an object, you’ll notice that the Tag's name and the col
 
 We can use the Collapse Tag option to hide the name. Conversely, we can use the Reveal Tag option to display the names again.
 
-### Filter Tags 
+### Filter tags
 
 When you mouse over a tag in the menu, you’re given the option to Filter. This option will filter your Hierarchy and only show you the objects with the filtered tag. The current filtered tabs are shown next to the Tag Menu.
 
@@ -51,7 +51,7 @@ When you mouse over a tag in the menu, you’re given the option to Filter. This
 
 Note that you can add as many tags to the filter as you want. This is a great way to show only the controls you need to create an animation.
 
-### Locked 
+### Locked
 
 The Locked option will allow you to lock the objects with the selected Tag. When locked, you can no longer select that object on the stage.
 
@@ -61,7 +61,7 @@ This is a great tool to use when you want to hand off a file to another animator
 
 This option is also available via the Inspector via the lock icon.
 
-### Select 
+### Select
 
 The Select option will select every object with the assigned tag.
 

--- a/editor/text/fonts.mdx
+++ b/editor/text/fonts.mdx
@@ -5,7 +5,7 @@ description: 'Import and customize fonts.'
 
 import { VideoEmbed } from '/snippets/video-embed.jsx'
 
-## Importing Fonts
+## Importing fonts
 
 See [Importing Assets](/editor/fundamentals/assets-overview#importing-assets) for information about importing files, including TTF and OTF files.
 
@@ -15,7 +15,7 @@ You can add Google Fonts directly from the text style font options. Select a tex
 
 <VideoEmbed src="https://static.rive.app/video/font-asset.mp4" />
 
-## Export Options
+## Export options
 
 Font assets include an Include option that controls which glyphs are included when the font is exported.
 
@@ -37,7 +37,7 @@ Font assets include an Include option that controls which glyphs are included wh
   ![Glyphs used hack](/images/editor/assets/glyphs-used-hack.png)
 </Tip>
 
-### Custom - Export Scripts
+### Custom - export Scripts
 
 When **Include** is set to **Custom**, you can use **Export Scripts** to choose which glyph groups to include, such as Latin, Thai, or other writing systems.
 

--- a/editor/text/fonts.mdx
+++ b/editor/text/fonts.mdx
@@ -37,7 +37,7 @@ Font assets include an Include option that controls which glyphs are included wh
   ![Glyphs used hack](/images/editor/assets/glyphs-used-hack.png)
 </Tip>
 
-### Custom - export Scripts
+### Custom - Export Scripts
 
 When **Include** is set to **Custom**, you can use **Export Scripts** to choose which glyph groups to include, such as Latin, Thai, or other writing systems.
 

--- a/editor/text/text-modifiers.mdx
+++ b/editor/text/text-modifiers.mdx
@@ -44,7 +44,7 @@ Each modifier group can modify one or more of the following properties:
 
 Multiple properties can be combined within a single modifier group to create more complex effects.
 
-#### Adding a Property
+#### Adding a property
 
 Select a text object, then click the `+` button in the **Modifier Group**. Each property has its own settings, which can be adjusted and animated.
 
@@ -122,7 +122,7 @@ Use Offset to move the range along the text. Try animating the offset value to c
 
 ![Text Runs Modifiers Offset](/images/editor/text/text-runs-modifiers-offset.gif)
 
-#### Range Options
+#### Range options
 
 Additional range options can be found in the fly-out alongside the range name for more fine-grained control over the range selection behavior.
 
@@ -160,7 +160,7 @@ Set the range type to configure range start, end, and offset values as a percent
 
 Modify the falloff interpolation to define a custom cubic curve. The falloff defaults to linear interpolation.
 
-## View Options
+## View options
 
 Toggle visual guides on the stage via the visibility menu in the toolbar:
 
@@ -169,7 +169,7 @@ Toggle visual guides on the stage via the visibility menu in the toolbar:
 
 ![Text Runs Modifiers View Options](/images/editor/text/text-runs-modifiers-options.gif)
 
-## Use case: Animating a text pendulum
+## Use case: animating a text pendulum
 
 This simple example will get you used to animating with Text Modifiers.
 

--- a/editor/text/text-overview.mdx
+++ b/editor/text/text-overview.mdx
@@ -9,7 +9,7 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 <YouTube id="nykDEo6XqXY" />
 
-## Creating Text
+## Creating text
 
 Press `T` or select the **Text Tool** from the toolbar.
 
@@ -18,11 +18,11 @@ Press `T` or select the **Text Tool** from the toolbar.
 
 Double-click text to edit its content.
 
-## Text Properties
+## Text properties
 
 Select text to view its properties in the Inspector. In addition to standard properties such as position, rotation, and origin, you can control how text sizes, wraps, aligns, and handles overflow.
 
-### Align Origin to Baseline
+### Align origin to baseline
 
 Enable **Align Origin to Baseline** to align the text's origin to its baseline.
 
@@ -73,7 +73,7 @@ The available alignment options depend on the sizing mode:
 ![Text elements showing horizontal and vertical alignment options](/images/editor/design/text/text-alignment.png)
 </Note>
 
-### Paragraph Spacing
+### Paragraph spacing
 
 Use **Paragraph Spacing** to control the amount of space between paragraphs.
 
@@ -99,7 +99,7 @@ Text bounds determine how the bounds of the text are calculated relative to the 
 
 ![Text with Bounds option set to none, text, and alphabetic](/images/editor/design/text/text-bounds-options.png)
 
-## Flatten to Shape
+## Flatten to shape
 
 Use **Flatten to Shape** to convert text into vector shapes. Once flattened, the resulting shapes can be edited like other vector geometry but can no longer be edited as text.
 

--- a/editor/workflows/dependency-graph.mdx
+++ b/editor/workflows/dependency-graph.mdx
@@ -3,7 +3,7 @@ title: "Dependencies Graph"
 description: "Use the Dependency Graph to visualize relationships between elements in your file"
 ---
 
-## Show Dependencies
+## Show dependencies
 
 To show dependencies, select an item and press **D**. Rive displays arrows connecting the selected item to its parent and child dependencies.
 

--- a/feature-support.mdx
+++ b/feature-support.mdx
@@ -19,7 +19,7 @@ Use the table below to verify whether a feature used in your `.riv` file is supp
 
 When a feature requires API changes, migration notes will be included below.
 
-## Feature Support by Runtime
+## Feature support by runtime
 
 ### Runtimes
 
@@ -44,7 +44,7 @@ When a feature requires API changes, migration notes will be included below.
 <FeatureSupportGroup runtime="unity" />
 <FeatureSupportGroup runtime="unreal" />
 
-### Lite Runtimes
+### Lite runtimes
 
 <FeatureSupportGroup runtime="webCanvasLite">
     This lightweight version uses the same API as `@rive-app/canvas`, but excludes certain features to reduce bundle size.
@@ -53,7 +53,7 @@ When a feature requires API changes, migration notes will be included below.
     This lightweight version uses the same API as `@rive-app/react-canvas`, but excludes certain features to reduce bundle size.
 </FeatureSupportGroup>
 
-### Legacy Runtimes
+### Legacy runtimes
 
 <FeatureSupportGroup runtime="webWebGL">
     <Warning>
@@ -73,7 +73,7 @@ When a feature requires API changes, migration notes will be included below.
     </Warning>
 </FeatureSupportGroup>
 
-## Runtime Support by Feature
+## Runtime support by feature
 
 A green checkmark (✅) indicates that a feature is supported in all current runtimes.
 A yellow circle (🟡) indicates that support varies by runtime or renderer.
@@ -143,7 +143,7 @@ Differences may reflect:
 <FeatureSupportGroup feature="cachingARiveFile" />
 <FeatureSupportGroup feature="rasterAssets" />
 
-### Legacy Features
+### Legacy features
 
 <FeatureSupportGroup feature="events">
     <Warning>

--- a/game-runtimes/unity/audio.mdx
+++ b/game-runtimes/unity/audio.mdx
@@ -15,13 +15,13 @@ Each `RiveWidget` that plays a Rive file with audio needs access to an `AudioPro
 
 If you need more control (for example, to manage volume or audio mixer groups independently per widget), you can assign a **custom** `AudioProvider` to individual widgets.
 
-## Global Audio Provider
+## Global audio provider
 
 The global `AudioProvider` is created automatically the first time a widget with audio needs it. It is shared across all `RiveWidget` instances that don't have a custom provider assigned.
 
 This is the recommended setup for most projects, and no additional configuration is required.
 
-## Custom Audio Provider
+## Custom audio provider
 
 To use a custom `AudioProvider` for a specific widget:
 
@@ -48,7 +48,7 @@ private void Start()
 
 Setting `CustomAudioProvider` to `null` reverts the widget to using the shared global provider.
 
-## Platform Notes
+## Platform notes
 
 | Platform | Behavior |
 |---|---|

--- a/game-runtimes/unity/best-practices.mdx
+++ b/game-runtimes/unity/best-practices.mdx
@@ -29,7 +29,7 @@ When you're getting started with Rive, it can be tempting to use it as a simple 
 
 For most projects, the recommended approach is to build your full menu (or at least larger chunks of a screen) in Rive, render it single widget/panel, and drive it with data binding.
 
-### Prefer data binding with lists for dynamic content
+### Prefer Data Binding with lists for dynamic content
 
 If your UI needs to create and remove items dynamically (for example: inventories, chat feeds, spawning characters), prefer using **data binding list properties** instead of creating lots of separate Rive Widgets.
 
@@ -40,7 +40,7 @@ See:
 - Concepts + examples: [Data binding lists](/game-runtimes/unity/data-binding#lists)
 - Editor setup: [Lists in the editor](/editor/data-binding/lists)
 
-### Screen space UI vs world space UI
+### Screen Space UI vs World Space UI
 
 - **Screen space UI**: You can usually structure your UI so a single panel covers the whole screen.
 - **World space UI / VR**: If your UI exists in the world and needs different sizes, transforms, or visibility rules, you may end up needing more panels and more careful control of render textures.
@@ -76,7 +76,7 @@ For example, one per screen or menu:
   - Transitions between screens typically happen in C# (outside Rive).
   - Be sure to **disable/destroy** widgets you aren't using so they aren't advancing or rendering.
 
-#### Hybrid approach: data binding with artboard slots
+#### Hybrid approach: Data Binding with artboard slots
 
 If you want modular loading *and* want to stay in a single widget/panel, a hybrid approach can work well:
 

--- a/game-runtimes/unity/components.mdx
+++ b/game-runtimes/unity/components.mdx
@@ -148,13 +148,13 @@ Create an instance: Right-click in the scene hierarchy `→ Rive → Widgets →
 | --- | --- |
 | Load(ProceduralDrawing proceduralDrawing) | Loads a new procedural drawing into the widget. |
 
-## Panel Renderers
+## Panel renderers
 
 Panel renderers connect RivePanel's render texture to Unity's display systems. By separating rendering logic from display concerns, we can support different rendering contexts (UI, world space, etc.) while keeping the core Rive functionality consistent.
 
 Each renderer type specializes in a specific Unity rendering pathway, handling details like input systems and render order automatically.
 
-### Rive Canvas Renderer
+### Rive canvas renderer
 
 The Rive Canvas Renderer displays Rive content within Unity's UI system (uGUI). It automatically configures the necessary Canvas components and handles UI-specific concerns like proper render order and raycasting.
 
@@ -185,7 +185,7 @@ You can also create a Rive Panel that has been automatically configured to use t
 | --- | --- |
 | Rive Panel | The panel being rendered. |
 
-### Rive Texture Renderer
+### Rive texture renderer
 
 Rive Texture Renderer projects Rive content onto materials in your 3D scene. It bridges the gap between Rive's 2D rendering system and Unity's 3D material system, making it easy to apply Rive content to any mesh in your scene.
 
@@ -218,7 +218,7 @@ Rive Texture Renderer projects Rive content onto materials in your 3D scene. It 
 | SetPanel(IRivePanel panel) | Assigns a new panel to render. |
 | RefreshMaterials() | Updates material references after material changes. |
 
-## Render Target Strategies
+## Render Target strategies
 
 Render Target Strategies control how **Rive Panels** render to textures. They determine whether panels get individual textures or share a texture atlas, and handle details like texture creation, panel arrangement, and memory management.
 
@@ -318,7 +318,7 @@ This approach is particularly useful for scenes with dynamic UI elements that ap
 | Max Pool Size | Current maximum pool size. |
 | Draw Timing | Current draw timing mode. |
 
-#### Public Methods
+#### Public methods
 
 | Name | Description |
 | --- | --- |

--- a/game-runtimes/unity/data-binding.mdx
+++ b/game-runtimes/unity/data-binding.mdx
@@ -226,7 +226,7 @@ if (labels != null)
 ```
 
 
-#### Overriding Globals After Auto Bind
+#### Overriding globals after Auto Bind
 
 Auto Bind fills every global with a default instance. To replace some of those defaults at runtime, bind again and pass the widget's current main instance plus the globals you want to change. Globals you leave out of the dictionary keep the instance they already have.
 
@@ -245,7 +245,7 @@ riveWidget.StateMachine.BindViewModelInstance(
     globals);
 ```
 
-#### Binding Manually
+#### Binding manually
 
 With **Manual**, nothing is bound after `Load`. Create the main instance and the globals, then bind them together.
 
@@ -265,7 +265,7 @@ riveWidget.StateMachine.BindViewModelInstance(main, globals);
 
 The two-argument overload returns `false` and leaves the state machine unchanged if the main instance is disposed, a dictionary key is not a global in the file, or a value is `null` or disposed. A `null` dictionary is treated as empty: omitted globals still receive defaults on the first bind.
 
-#### Binding Globals Only
+#### Binding globals only
 
 Pass `null` as the main instance to bind globals without supplying a main. Bind creates a default main when the artboard has a default view model, and still fills any global you leave out of the map.
 
@@ -281,7 +281,7 @@ riveWidget.StateMachine.BindViewModelInstance(
 riveWidget.StateMachine.BindViewModelInstance(null);
 ```
 
-#### Sharing a Global Across Widgets
+#### Sharing a global across widgets
 
 Auto Bind creates a new default instance for each widget, so those defaults are not shared. To share a global without binding twice, set both widgets to **Manual**, then pass the same instance in each widget's first bind.
 
@@ -1040,7 +1040,7 @@ private void OnDestroy()
 }
 ```
 
-### Using Custom View Model Instances with Bindable Artboards
+### Using custom View Model instances with bindable artboards
 
 You can link a custom `ViewModelInstance` to a bindable artboard, giving you control over the data being used by that artboard.
 

--- a/game-runtimes/unity/fundamentals.mdx
+++ b/game-runtimes/unity/fundamentals.mdx
@@ -4,7 +4,7 @@ title: "Fundamentals"
 
 import LegacyApiNotice from '/snippets/unity/legacy-api-notice.mdx';
 
-## Adding Rive Assets
+## Adding Rive assets
 
 To add a `.riv` file to a Unity project, simply drag it into the Project Window. Once dropped, a **Rive Asset** will be automatically created.
 
@@ -25,7 +25,7 @@ The `Rive.File` class also provides several methods to load Rive content into Un
   If the file is already in memory, a cached version will be returned to improve performance and avoid redundant loading.
 </Note>
 
-#### 1. From a Rive Asset (.riv file)
+#### 1. From a Rive asset (.riv file)
 
 You can load a `Rive.File` from an imported `.riv` asset in the inspector:
 
@@ -63,7 +63,7 @@ private void Start()
 }
 ```
 
-#### 3. From a Byte Array
+#### 3. From a byte array
 
 If you have the raw bytes of a `.riv` file, you can load it directly from a byte array. This method provides flexibility if you're loading the file data from a custom source or dynamically (e.g. from a CDN-stored file):
 

--- a/game-runtimes/unity/getting-started.mdx
+++ b/game-runtimes/unity/getting-started.mdx
@@ -18,7 +18,7 @@ New to Rive? Start with the [Rive Editor](/editor/fundamentals/overview) to crea
   </Card>
 </CardGroup>
 
-## Example Projects
+## Example projects
 
 To quickly experiment with Rive in Unity, run one of our [example projects](https://github.com/rive-app/rive-unity-examples).
 
@@ -79,7 +79,7 @@ Once you have a `.riv` file, drag it into the Unity **Project** window. Unity wi
 
 On the [Marketplace](https://rive.app/marketplace), you can find Rive files that can be remixed.
 
-## Displaying a Rive File
+## Displaying a Rive file
 
 **Drag-and-Drop**
 

--- a/game-runtimes/unity/inputs.mdx
+++ b/game-runtimes/unity/inputs.mdx
@@ -8,7 +8,7 @@ import LegacyDataBindingNotice from '/snippets/unity/legacy-databinding-notice.m
 
 <LegacyDataBindingNotice subject="Inputs" />
 
-## Accessing Inputs
+## Accessing inputs
 
 There are three input types, each extends `SMIInput` (State Machine Input):
 
@@ -90,7 +90,7 @@ foreach (var input in inputs)
 }
 ```
 
-## Accessing Nested Inputs
+## Accessing nested inputs
 
 ![Image](https://ucarecdn.com/2ef96393-bf13-4445-950b-1626235a25eb/)
 set the **Volume** input from the above example:
@@ -108,7 +108,7 @@ m_artboard.SetNumberInputStateAtPath("volume", 80.0f, "Volume Molecule/Volume Co
 - `bool? GetBooleanInputStateAtPath(string inputName, string path)`
 - `void FireInputStateAtPath(string inputName, string path)`
 
-### Additional Resources
+### Additional resources
 
 For a complete example see the **getting-started** project in the [examples repository](https://github.com/rive-app/rive-unity-examples) and open the **StateMachineInputScene** scene. Enter **Play** mode and in the inspector on the **Main Camera** component, you can interact with all available state machine inputs for the provided animation.
 

--- a/game-runtimes/unity/loading-assets.mdx
+++ b/game-runtimes/unity/loading-assets.mdx
@@ -19,7 +19,7 @@ Within the Rive Editor, you can select an asset (for example, an image or font) 
 
 **Embedded** assets are included with the exported `.riv` binary file, while **referenced** assets are packaged separately and must be linked at runtime. Using **referenced** assets enables you to reuse the same asset across multiple animation files or in other parts of your game. This reduces the size of your `.riv` file and the resources needed to run your animations that use a shared asset.
 
-### Embedded Assets
+### Embedded assets
 
 Any asset marked as embedded will automatically be loaded, and you do not need to do anything to configure the asset.
 
@@ -27,7 +27,7 @@ Any asset marked as embedded will automatically be loaded, and you do not need t
 
 By selecting the riv file you'll get information on the file's assets in the **Unity Inspector**. The example image above shows an embedded font called "Roboto Flex" with a size of 1MB.
 
-### Referenced Assets
+### Referenced assets
 
 Referenced assets need to be linked at runtime. The rive-unity package automatically handles the linking by attempting to find assets within the same directory that match the correct **Name** + **ID** combination. If an asset that matches the criteria is discovered, that asset is automatically converted to a Rive asset and linked.
 
@@ -64,7 +64,7 @@ Alternatively, you can set the desired Importer for an asset by selecting the co
 
 ![Image](/images/game-runtimes/unity/d65592e9-22a4-433f-b4f3-4ca8e72577aa.webp)
 
-#### Sharing Assets
+#### Sharing assets
 
 Reusing the same asset in your Rive files should result in a consistent **Name** + **ID** generation when exporting from the Rive Editor.
 

--- a/game-runtimes/unity/procedural-rendering.mdx
+++ b/game-runtimes/unity/procedural-rendering.mdx
@@ -63,7 +63,7 @@ The `Path` class provides various methods to construct a path:
 - `reset`: Resets the path to an empty state.
 - `flush`: to flush the path to native memory.
 
-### Paint 
+### Paint
 
 Paint is used to describe how to draw a shape.
 
@@ -77,7 +77,7 @@ The paint describes the color, gradient, style, thickness, blend mode, stroke ca
 
 Call `.Flush()` to flush the paint to native memory. See the [Example ](/game-runtimes/unity/procedural-rendering#example)below.
 
-## Example 
+## Example
 
 This example demonstrates drawing an animated triangle to a [RenderTexture](https://docs.unity3d.com/ScriptReference/RenderTexture.html).
 
@@ -158,6 +158,6 @@ public class RiveProcedural : MonoBehaviour
 }
 ```
 
-### Additional Resources 
+### Additional resources
 
 See the **getting-started** project in the examples repository for a complete example and open the **ProceduralRenderingScene** scene.

--- a/game-runtimes/unity/rive-events.mdx
+++ b/game-runtimes/unity/rive-events.mdx
@@ -13,7 +13,7 @@ import Overview from "/snippets/runtimes/events/overview.mdx"
 
 <Overview />
 
-## Accessing Events
+## Accessing events
 
 The following code demonstrates accessing all Rive events reported from an active state machine.
 <Tabs>
@@ -108,6 +108,6 @@ private void HandleRiveEventReported(ReportedEvent reportedEvent)
 - Properties that can be read are **bool**, **string**, and **float**.
 - Access a dictionary of all properties with: `reportedEvent.Properties`.
 
-### Additional Resources
+### Additional resources
 
 For a complete example see the **getting-started** project in the [examples repository](https://github.com/rive-app/rive-unity-examples) and open the **EventsScene** scene.

--- a/game-runtimes/unity/runtime-asset-swapping.mdx
+++ b/game-runtimes/unity/runtime-asset-swapping.mdx
@@ -18,7 +18,7 @@ This page explains how to use the `CustomAssetLoaderCallback` to swap fonts, ima
 
 This approach is useful when you want your replacement asset to be used everywhere the original appears throughout the file. For example, if you need to replace a font globally, so that all text that uses that font updates automatically, you can do so in one place instead of configuring individual property bindings for each instance.
 
-## Setting Up Asset Loading
+## Setting up asset loading
 
 To swap assets at runtime, provide a callback when loading your Rive file:
 
@@ -64,7 +64,7 @@ private void OnDestroy()
 }
 ```
 
-#### Overload With Fallback
+#### Overload with fallback
 
 An overload of `Rive.File.Load()` includes a `fallbackToAssignedAssets` parameter.
 
@@ -74,7 +74,7 @@ If set to `true `and your custom loader doesn't handle a certain asset, the runt
 var file = File.Load(myRiveAsset, MyCustomAssetLoader, fallbackToAssignedAssets: true);
 ```
 
-## Asset Types
+## Asset types
 
 You can swap these types of assets at runtime:
 
@@ -84,7 +84,7 @@ You can swap these types of assets at runtime:
 
 * `AudioOutOfBandAsset`: For audio files
 
-## Asset Reference Types
+## Asset reference types
 
 When handling assets in your callback, you'll need to check the type of the `EmbeddedAssetReference` before setting the asset. Each asset type has its own reference class with specific setter methods:
 
@@ -116,7 +116,7 @@ private bool AssetLoaderDelegate(EmbeddedAssetReference assetReference)
 }
 ```
 
-## Memory Management
+## Memory management
 
 When working with runtime asset swapping, we recommend following these best practices:
 
@@ -128,7 +128,7 @@ When working with runtime asset swapping, we recommend following these best prac
 
    * Call `Dispose()` on the Rive file when you're done with it
 
-## Creating Out-of-Band Assets Dynamically
+## Creating out-of-band assets dynamically
 
 If you have an asset that isn't in your Unity project at build time (for example, if you're loading an image from a CDN), you can create an out-of-band asset at runtime using the `OutOfBandAsset.Create<T>()` method.  Here, the `bytes` parameter should be the raw file data for the asset.
 

--- a/game-runtimes/unity/tutorials/health-bar.mdx
+++ b/game-runtimes/unity/tutorials/health-bar.mdx
@@ -130,7 +130,7 @@ public UnityEvent OnGameOver = new UnityEvent();
 public class FloatEvent : UnityEvent<float> { }
 ```
 
-### Step 4.3: Grab the view model instance properties when the widget is loaded
+### Step 4.3: Grab the View Model instance properties when the widget is loaded
 
 We use `OnWidgetStatusChanged` to access the view model instance once the widget is loaded. If you try to access the view model instance before the widget is loaded, it will be null.
 

--- a/game-runtimes/unity/unity.mdx
+++ b/game-runtimes/unity/unity.mdx
@@ -11,11 +11,11 @@ import { Demos } from '/snippets/demos.jsx'
 
 <Demos examples={['dataBindingQuickStart']} runtime="unity" />
 
-## Unity Version Support
+## Unity version support
 
 The package supports Unity LTS versions from 2021 upwards (including Unity 6).
 
-## Rendering Support
+## Rendering support
 
 The rive-unity runtime uses the [Rive Renderer](https://rive.app/renderer) and is up to date with the latest C\+\+ runtime version of Rive.
 
@@ -34,7 +34,7 @@ The rive-unity runtime uses the [Rive Renderer](https://rive.app/renderer) and i
 Planned support for:
 - Consoles
 
-### Bug Reports
+### Bug reports
 
 If you encounter any errors or unexpected crashes while integrating the Rive Unity runtime, we recommend logging a detailed issue directly to the [rive-unity](https://github.com/rive-app/rive-unity/issues) repo with an **Editor.log** attached to the issue to help provide more details and context about what might have occurred.
 
@@ -44,6 +44,6 @@ You can find more details on where to find your Editor.log file in the [Unity do
   Note that it is best to grab the Editor.log file immediately after a crash has occurred
 </Note>
 
-## Feature Support
+## Feature support
 
 The rive-unity runtime uses the latest Rive C\+\+ runtime. For more details on runtime support, see the [Feature Support](/feature-support) page. Refer to the following table for what is currently supported in the Unity runtime.

--- a/game-runtimes/unreal/getting-started.mdx
+++ b/game-runtimes/unreal/getting-started.mdx
@@ -15,7 +15,7 @@ This guide walks you through installing the Rive Unreal plugin, importing a `.ri
     - **macOS**: Xcode with the command-line tools (`xcode-select --install`).
 </Info>
 
-## 1) Install the Plugin
+## 1) Install the plugin
 
 <Tabs>
   <Tab title="Fab (Recommended)">
@@ -54,7 +54,7 @@ This guide walks you through installing the Rive Unreal plugin, importing a `.ri
   </Tab>
 </Tabs>
 
-## 2) Build the Project
+## 2) Build the project
 
 The Rive plugin is C++, so your project must be compiled before the editor
 can load it.
@@ -90,14 +90,14 @@ can load it.
 Alternatively, double-click the `.uproject` directly — if the plugin modules
 aren't built, Unreal offers to rebuild them; click **Yes**.
 
-## 3) Enable the Plugin
+## 3) Enable the plugin
 
 1. Open Edit → Plugins.
 2. Locate Rive under Runtime.
 3. Enable the plugin.
 4. Restart the editor if required.
 
-## 4) Import a Rive File
+## 4) Import a Rive file
 
 1. Open the Content Browser.
 2. Drag and drop a `.riv` file into your project.
@@ -112,7 +112,7 @@ Unreal creates a **Rive File** asset. You can inspect this asset by double-click
   The Unreal runtime does not yet support referenced assets. Be sure to embed all assets in the `.riv` file.
 </Warning>
 
-## 5) Create a Widget
+## 5) Create a widget
 
 1. Right-click on the **Rive file** asset and select **Create Rive Widget** from the context menu.
 

--- a/game-runtimes/unreal/in-world-textures.mdx
+++ b/game-runtimes/unreal/in-world-textures.mdx
@@ -3,8 +3,6 @@ title: "World-Space RenderTargets"
 description: "Drag a Rive RenderTarget into the level to create an in-world surface with an auto-generated material."
 ---
 
-# World-Space RenderTargets
-
 <Frame>
   ![Duelist Render Target](/images/unreal/DuelistRenderTarget.png)
 </Frame>
@@ -45,11 +43,11 @@ Double clicking the created RenderTarget will open the asset editor in which you
   Start with 512×512. Increase only if the screen is large and close to the camera.
 </Tip>
 
-## 2) Drag it into the Level
+## 2) Drag it into the level
 
 Drag the RenderTarget from the Content Browser into the viewport to apply it to a mesh. Unreal will automatically create a material that samples the RenderTarget texture. At this point you should see the Rive content on the surface.
 
-## 3) How updates work (Tick + Draw)
+## 3) How updates work (tick + draw)
 
 A RenderTarget is a texture output. It only changes when the runtime is advanced and drawn.
 

--- a/game-runtimes/unreal/migration-guide.mdx
+++ b/game-runtimes/unreal/migration-guide.mdx
@@ -4,8 +4,6 @@ description: "Migrate from legacy inputs and events to the ViewModel-first Unrea
 hidden: true
 ---
 
-# Migration Guide
-
 This guide helps you migrate projects built on the legacy Unreal plugin (direct **State Machine** inputs and legacy events) to the current **ViewModel**-first runtime.
 
 <Info>
@@ -16,9 +14,9 @@ This guide helps you migrate projects built on the legacy Unreal plugin (direct 
   Legacy direct inputs and legacy event APIs are deprecated. New integrations should use **ViewModels** for both input and output.
 </Warning>
 
-## What Changed
+## What changed
 
-### Supported Engine Versions
+### Supported engine versions
 
 - New minimum supported version: Unreal Engine **5.7.3 and above**
 
@@ -26,12 +24,12 @@ This guide helps you migrate projects built on the legacy Unreal plugin (direct 
   If your project is on an older Unreal version, you must upgrade Unreal before upgrading the plugin.
 </Info>
 
-### Supported Platforms
+### Supported platforms
 
 - Supported: Windows, macOS
 - Not supported yet: Android, iOS
 
-### Architectural Shift
+### Architectural shift
 
 Old model:
 
@@ -46,7 +44,7 @@ New model:
 
 Data flow: Unreal → **ViewModel Instance** → **State Machine** → **ViewModel Instance** → Unreal
 
-## Quick Migration Checklist
+## Quick migration checklist
 
 <Steps>
   <Step>
@@ -63,9 +61,9 @@ Data flow: Unreal → **ViewModel Instance** → **State Machine** → **ViewMod
   </Step>
 </Steps>
 
-## Migrating Inputs
+## Migrating inputs
 
-### Replace Direct Inputs with ViewModel Properties
+### Replace direct inputs with ViewModel properties
 
 If you previously set inputs like:
 
@@ -87,9 +85,9 @@ You should now:
   Do not mix legacy input setters and **ViewModel** writes in new integrations. Choose the ViewModel path for all new behavior.
 </Warning>
 
-## Migrating Events
+## Migrating events
 
-### Replace Legacy Events with ViewModel Observation
+### Replace legacy events with ViewModel observation
 
 If you previously relied on **State Machine** events (reported events, named events, callbacks), migrate to:
 
@@ -106,27 +104,27 @@ Common patterns:
   Use triggers for one-shot actions. Use boolean/number/enum/string/color properties for persistent state.
 </Info>
 
-## Blueprint Migration
+## Blueprint migration
 
-### Old Blueprint Pattern (Deprecated)
+### Old Blueprint pattern (deprecated)
 
 - Set **State Machine** inputs directly
 - Bind to legacy event outputs directly
 
-### New Blueprint Pattern (Recommended)
+### New Blueprint pattern (recommended)
 
 - Write values into a **ViewModel Instance**
 - Bind callbacks to **ViewModel** property changes
 - Fire actions using **Trigger Properties**
 
-## C++ Migration
+## C++ migration
 
-### Old C++ Pattern (Deprecated)
+### Old C++ pattern (deprecated)
 
 - Fetch **State Machine** inputs and set values directly
 - Register legacy event callbacks
 
-### New C++ Pattern (Recommended)
+### New C++ pattern (recommended)
 
 - Create a **ViewModel Instance**
 - Bind it to the **Artboard**

--- a/game-runtimes/unreal/observing-viewmodel-changes.mdx
+++ b/game-runtimes/unreal/observing-viewmodel-changes.mdx
@@ -3,8 +3,6 @@ title: "Observing ViewModel Changes"
 description: "React to animation and state updates by observing ViewModel property changes."
 ---
 
-# Observing ViewModel Changes
-
 In the Unreal runtime, **ViewModels** are the supported way for Rive content to communicate back to Unreal.
 
 Legacy **State Machine** events and direct callback mechanisms are deprecated.\
@@ -14,7 +12,7 @@ New integrations should observe **ViewModel** property changes instead.
   All runtime output from Rive should flow through a **ViewModel Instance**.
 </Info>
 
-## How Observation Works
+## How observation works
 
 During the **Artboard** tick:
 
@@ -26,7 +24,7 @@ During the **Artboard** tick:
 
 Observation happens synchronously during this update cycle.
 
-## Registering Callbacks
+## Registering callbacks
 
 Each property on a **ViewModel Instance** can be observed.
 
@@ -53,7 +51,7 @@ Callbacks should be:
   Use boolean or numeric properties for persistent state.
 </Tip>
 
-## Observing Structured Data
+## Observing structured data
 
 Because **ViewModels** may contain nested structures:
 
@@ -63,7 +61,7 @@ Because **ViewModels** may contain nested structures:
 
 This allows complex UI or gameplay state to remain structured and predictable.
 
-## Lifetime and Safety
+## Lifetime and safety
 
 Observation follows the lifetime of the **ViewModel Instance**.
 

--- a/game-runtimes/unreal/unreal.mdx
+++ b/game-runtimes/unreal/unreal.mdx
@@ -4,11 +4,11 @@ title: "Unreal Engine"
 
 Rive’s Unreal runtime allows you to render and control Rive animations natively inside Unreal Engine. It integrates directly with Unreal’s object system and rendering pipeline and is designed for real-time use cases.
 
-## Supported Unreal Versions
+## Supported Unreal versions
 
 - Unreal Engine 5.7.3 and above
 
-## Supported Platforms
+## Supported platforms
 
 - Microsoft DirectX 11
 - Microsoft DirectX 12
@@ -25,7 +25,7 @@ Rive’s Unreal runtime allows you to render and control Rive animations nativel
   Mobile platform support is planned but not yet available.
 </Warning>
 
-## Rendering Backends
+## Rendering backends
 
 Depending on platform and engine configuration, supported backends include:
 
@@ -38,7 +38,7 @@ Depending on platform and engine configuration, supported backends include:
 
 Rendering is handled by Rive’s native renderer and coordinated with Unreal’s render thread.
 
-## Feature Support
+## Feature support
 
 | Feature | Supported |
 | --- | --- |
@@ -58,7 +58,7 @@ Rendering is handled by Rive’s native renderer and coordinated with Unreal’s
   New integrations should use ViewModels for both input and output.
 </Warning>
 
-## Architecture Overview
+## Architecture overview
 
 The Unreal runtime is built around three core runtime objects:
 
@@ -72,7 +72,7 @@ Unreal → ViewModel → State Machine → ViewModel → Unreal
 
 State machines consume and modify ViewModel properties. Unreal observes those changes.
 
-## Support & Community
+## Support & community
 
 If you need help:
 

--- a/game-runtimes/unreal/using-triggers.mdx
+++ b/game-runtimes/unreal/using-triggers.mdx
@@ -3,8 +3,6 @@ title: "Using Triggers"
 description: "Using triggers in the Rive plugin."
 ---
 
-# Triggering Events
-
 In the Unreal runtime, "events" are modeled as **ViewModel Trigger Properties**.
 
 Fire and observe triggers through the **ViewModel Instance**.
@@ -13,14 +11,14 @@ Fire and observe triggers through the **ViewModel Instance**.
   Use **Trigger Properties** for one-shot actions (clicks, milestones, transitions).
 </Info>
 
-## Recommended Flow
+## Recommended flow
 
 1. Define a **Trigger Property** in your Rive ViewModel (for example `OnClick`).
 2. In Unreal, create and bind a **ViewModel Instance** to your Rive widget or artboard.
 3. Fire the trigger from Blueprint using **Call {TriggerName}**.
 4. Respond to the trigger in Blueprint using **Bind Event to {TriggerName}**.
 
-## Blueprint Setup
+## Blueprint setup
 
 1. Create a Rive widget from your imported `.riv` file.
 2. Create a **ViewModel Instance** using **Make View Model**.
@@ -31,7 +29,7 @@ Fire and observe triggers through the **ViewModel Instance**.
   Keep ViewModel creation and delegate binding in the same owning Blueprint so lifetime is clear.
 </Tip>
 
-## Firing a Trigger in Blueprint
+## Firing a trigger in Blueprint
 
 When you want to fire an event (button press, gameplay action, etc.), call the trigger function exposed on the bound ViewModel instance.
 
@@ -53,7 +51,7 @@ In the following image, the trigger "loaded" is being fired from Blueprint:
   />
 </Frame>
 
-## Observing Trigger Results
+## Observing trigger results
 
 If Unreal needs to react when the trigger is fired:
 

--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -9,11 +9,11 @@ Rive is built to efficiently play interactive graphics in the editor and at runt
   We recommend continuous testing of your animations on your target devices/platforms.
 </Info>
 
-## Design-time Considerations
+## Design-time considerations
 
 See below for some techniques to employ in the Rive editor to keep Rive performant:
 
-### Asset Optimizations
+### Asset optimizations
 
 Image, audio, and font assets are often the biggest source of bloat in .riv files. Unoptimized assets increase download size and must be loaded into memory, which can lead to slowdowns—especially on lower-end devices.
 
@@ -25,7 +25,7 @@ Image, audio, and font assets are often the biggest source of bloat in .riv file
 
 Font files often include thousands of glyphs you may not need, such as Greek letters, mathematical operators, and icons. To reduce the size of the exported font or .riv file, [select which glyphs to include](/editor/text/fonts#glyph-%2F-script-selection).
 
-#### Raster Image Sizes & Dimensions
+#### Raster image sizes & dimensions
 
 It is crucial to ensure that the size of an image asset is appropriate for its usage. For instance, avoid using an image with large dimensions (e.g., 8192 x 7022) when it will be displayed in a small section of your artboard (e.g., sized 100 x 100).
 
@@ -35,23 +35,23 @@ If you have a very large image and only part of it will be visible at any given 
 
 ![Image](/images/getting-started/best-practices/breaking-up-raster-images.webp)
 
-#### Raster Image Compression
+#### Raster image compression
 
 Compression involves reducing the file size by employing various algorithms to discard some image data. You can compress images directly from the Rive editor, which means you maintain the original image but compress the images for runtime use. If the asset is embedded in the animation, this will reduce the file size of the exported riv.
 
 For the smallest image file size and best performance, we recommend exporting assets using the WebP Format.
 
-#### Vector Images
+#### Vector images
 
 Be efficient with the number of vertices in your vector image. While a few extra vertices won’t have much of an impact, thousands might. Be especially careful when importing vectors that were generated with AI, converted from raster images, or were created in drawing apps.
 
-### Layer Blend Modes for Web
+### Layer blend modes for web
 
 Blend modes are particularly expensive on the web because WebGL doesn’t expose mechanisms for accessing the framebuffer. To apply a blend mode, Rive must copy rendered pixels into a separate texture before compositing, which introduces significant performance and memory overhead.
 
 While there are efforts underway to improve this through new WebGL capabilities, these solutions are still pending broader support. Until then, it’s best to use blend modes sparingly in web projects to ensure optimal performance.
 
-### Artboard Considerations
+### Artboard considerations
 
 #### Clipped Artboards
 
@@ -59,7 +59,7 @@ Clipping artboards is generally fine, but if you're experiencing performance iss
 
 In most cases you can safely remove the clip from the main artboard itself, since nothing outside the Rive instance will be rendered at runtime.
 
-#### Artboard Export
+#### Artboard export
 
 Not every artboard in your Rive file is included in the exported `.riv`. The default artboard and any artboards marked as **Components** are included automatically. Other artboards, including their animations, State Machines, and other artboard-specific content, are excluded.
 
@@ -88,11 +88,11 @@ In addition to only rendering the things you need, you also save yourself both m
 
 Similar to the guidance in “Idle Animations”, ensure blend states transition out to other states, or move to an exit state when finished if possible. When blend states are activated at runtime, Rive will continually play the state machine, even if it is not necessary anymore. Providing some transition away from the blend state when complete ensures Rive has one less “active” animation to track when considering whether to self-pause at any point while playing the state machine.
 
-## Runtime Considerations
+## Runtime considerations
 
 See below for some techniques to employ when using Rive runtimes in application to keep Rive performant:
 
-### Out-of-band Assets
+### Out-of-band assets
 
 See our documentation on [Loading Assets](/runtimes/loading-assets). This feature allows you to dynamically load and replace assets (such as fonts, images, and audio) at runtime through code and provide the resources to your Rive graphic. This has the following benefits:
 
@@ -105,7 +105,7 @@ See our documentation on [Loading Assets](/runtimes/loading-assets). This featur
 
 If you're using the same Rive file in multiple places across your page or app, you can [cache the .riv](/runtimes/caching-a-rive-file) file to improve performance. The key benefit of caching is that the file only needs to be parsed and decoded once. Creating new artboard instances from a cached, already-decoded file is significantly faster than decoding the file each time before instantiating an artboard.
 
-### Pausing Programmatically
+### Pausing programmatically
 
 There are several cases where you may want to pause a state machine configured with Rive programmatically. By pausing the Rive graphic at runtime, you may notice that Rive’s impact on the application has negligible resource consumption (i.e., CPU).
 

--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -38,7 +38,7 @@ import { CardGroupCustom } from '/snippets/card-group-custom.jsx'
   </RiveCard>
 </CardGroupCustom>
 
-## Rive at a Glance
+## Rive at a glance
 
 <CardGroup cols="2">
   <Card title="1. Design" img="/images/introduction/design.png" href="/editor/fundamentals/artboards" >
@@ -66,7 +66,7 @@ import { CardGroupCustom } from '/snippets/card-group-custom.jsx'
   </Card>
 </CardGroup>
 
-## Quick Start
+## Quick start
 
 New to Rive? This step-by-step quickstart walks through the core concepts of the editor while building a complete interactive project from start to finish.
 

--- a/home/account-admin/account-overview/add-vat-tax-id-to-your-invoice.mdx
+++ b/home/account-admin/account-overview/add-vat-tax-id-to-your-invoice.mdx
@@ -16,7 +16,7 @@ Your tax invoice will be emailed to you immediately.
 
 ---
 
-## For Future Invoices
+## For future invoices
 
 To have your tax info included automatically on all future receipts, update your billing details in Stripe:
 

--- a/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
+++ b/home/account-admin/account-overview/cancel-a-former-employees-subscription.mdx
@@ -3,13 +3,13 @@ title: "Cancel a Former Employee's Plan"
 description: "If an employee left your company but their Rive plan is still billing your card, we can help cancel it. You don't need access to their account."
 ---
 
-## What We Can Do
+## What we can do
 
 - ✅ Cancel the plan
 - ✅ Remove your payment method from their account
 - ✅ Refund recent charges (typically 1-2 months after departure)
 
-## What We Cannot Do
+## What we cannot do
 
 - ❌ Give you access to their account
 - ❌ Transfer their files to your company
@@ -21,7 +21,7 @@ If you need the files, you'll need to work that out directly with the former emp
 
 ---
 
-## How to Request Cancellation
+## How to request cancellation
 
 <a href={"{{supportForm}}"}>Contact support</a> with:
 
@@ -34,7 +34,7 @@ We'll verify you control the payment method, cancel the plan, and remove your ca
 
 ---
 
-## Prevent This Next Time
+## Prevent this next time
 
 Create a company-owned workspace and add employees as members. When someone leaves, you remove them—no plans to chase down, no files lost.
 

--- a/home/account-admin/account-overview/refunds.mdx
+++ b/home/account-admin/account-overview/refunds.mdx
@@ -2,11 +2,11 @@
 title: "Refunds"
 ---
 
-## Our Policy
+## Our policy
 
 Per Rive's [Terms of Service](/legal/terms-of-service), fees are non-refundable. If you cancel your plan, you keep access until the end of your current billing period—we just won't renew it.
 
-## Billing Errors
+## Billing errors
 
 If you were charged incorrectly (duplicate charge, charged after cancellation, wrong amount), <a href={"{{supportForm}}"}>contact support</a> with:
 
@@ -16,7 +16,7 @@ If you were charged incorrectly (duplicate charge, charged after cancellation, w
 
 We'll investigate and fix any legitimate billing errors.
 
-## Before You Upgrade
+## Before you upgrade
 
 If you're not sure Rive is right for you:
 

--- a/home/account-admin/workspaces/delete-a-workspace.mdx
+++ b/home/account-admin/workspaces/delete-a-workspace.mdx
@@ -14,7 +14,7 @@ These are different things:
 If you just want to stop paying, you probably want to [cancel your plan](/account-admin/account-overview/cancel-my-account), not delete your workspace.
 </Warning>
 
-## What Happens When You Delete Your Workspace
+## What happens when you delete your workspace
 
 **Immediately:**
 
@@ -34,11 +34,11 @@ If you just want to stop paying, you probably want to [cancel your plan](/accoun
 - ❌ Everything is permanently deleted from our servers
 - ❌ Cannot be recovered, no exceptions
 
-## How to Delete a Workspace
+## How to delete a workspace
 
 If you're certain you want to permanently delete your workspace and files, rather than [cancel your plan](/account-admin/account-overview/cancel-my-account), follow these steps:
 
-### Step 1: Back Up Your Files
+### Step 1: Back up your files
 
 This is your only chance. After deletion, files cannot be recovered — not by you, not by support, not by anyone.
 
@@ -49,13 +49,13 @@ For each file you want to keep:
 3. Select "Download backup"
 4. Save the .rev file somewhere safe
 
-### Step 2: Notify Team Members (Optional)
+### Step 2: Notify team members (optional)
 
 Members lose access immediately when you delete. If you want to give them time to download their own work first, let them know before you proceed.
 
 To remove members before deletion: [Removing Workspace Members](/account-admin/workspaces/managing-workspace-members#removing-users-from-a-workspace)
 
-### Step 3: Delete the Workspace
+### Step 3: Delete the workspace
 
 1. Go to [rive.app/account](https://rive.app/account?utm_source=docs&utm_medium=content)
 2. Scroll to "Workspaces"
@@ -110,7 +110,7 @@ After confirming:
 	</Accordion>
 </AccordionGroup>
 
-## Related Articles
+## Related articles
 
 - [Cancel My Plan](/account-admin/account-overview/cancel-my-account) - Stop paying without deleting
 - [Reactivating a Canceled Workspace](/account-admin/workspaces/reactivating-a-canceled-workspace) - Restore a canceled workspace

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -6,17 +6,17 @@ description: ""
 These integrations are maintained outside of Rive.
 For help or support, please refer to the respective tool’s documentation or community.
 
-## Website Builders
+## Website builders
 
 - **[Framer](https://www.framer.com/marketplace/plugins/rive/)** — Use the official Rive Framer plugin for direct integration
 - **[Webflow](https://help.webflow.com/hc/en-us/articles/33961216978451-Embed-Rive-animations)** — Native support for Rive animations
 
-## Video & Rendering
+## Video & rendering
 
 - **[Remotion](https://www.remotion.dev/docs/rive/)** — Render Rive animations to video programmatically
 - **[Revideo](https://github.com/redotvideo/examples/tree/main/rive-explanation-video)** — Render Rive animations to video programmatically
 
-## HTML Embed
+## HTML embed
 
 Many platforms support custom HTML embeds or link-based embeds (for example, WordPress or Notion).
 For these platforms, use the [HTML embed method](/integrations/html-embed).

--- a/runtimes/advanced-topic/format.mdx
+++ b/runtimes/advanced-topic/format.mdx
@@ -5,11 +5,11 @@ description: ''
 
 The .riv file is the binary runtime format exported from the Rive Editor and used by all Rive runtimes.
 
-## Runtime Format
+## Runtime format
 
 The Rive editor exports your project as a .riv file for consumption by the Rive runtimes. This is a binary representation of your Artboards, Shapes, Animations, State Machines, etc. This is the file that Rive's runtimes read to display your content in an application, game, website, etc. The format was designed to provide a balance of quick load times, small file sizes, and flexibility with regards to future changes/addition of features.
 
-### Binary Types
+### Binary types
 
 A binary reader for Rive runtime files needs to be able to read these data types from the stream.
 
@@ -98,13 +98,13 @@ This is a unique identifier for the file that in the future will be able to be u
 
 The Table of Contents section of the header is a list of the properties in the file along with their backing type. This allows the runtime to read past properties it wishes to skip or doesn't understand. It does this by providing the backing type for each property ID.
 
-#### Field Types
+#### Field types
 
 There are 5 fundamental backing types but they are serialized in 4 different ways. Knowing how the type is serialized allows the runtime to know how to read it in. Even if it reads the wrong value or interprets it incorrectly, the important aspect is being able to read past it so the rest of the file can be read in safely.
 
 For example, a boolean can be read as an unsigned integer as the backing type and serializer is compatible. Even though reading the boolean as an integer will not provide the valid value for the property, the runtime can still just read past it.
 
-#### ToC Data
+#### ToC data
 
 The list of known properties is serialized as a sequence of variable unsigned integers with a 0 terminator. A valid property key is distinguished by a non-zero unsigned integer id/key. Following the properties is a bit array which is composed of the read property count / 4 bytes. Every property gets 2 bits to define which backing type deserializer can be used to read past it.
 
@@ -159,7 +159,7 @@ A core object is represented by its Core type key. For example, a Shape has [cor
 
 Properties are similarly represented by a Core type key. These are unique across all objects, so [property key 13](https://github.com/rive-app/rive-cpp/blob/4512406300b7333ba543cd87930e67a24c2fc715/dev/defs/node.json#L16) will always be the X value of a Node object, and it [matches in the runtime](https://github.com/rive-app/rive-cpp/blob/4512406300b7333ba543cd87930e67a24c2fc715/include/generated/node_base.hpp#L33). A Node's X value is known to be a floating point value so when it is encountered [it will be decoded as such](https://github.com/rive-app/rive-cpp/blob/4512406300b7333ba543cd87930e67a24c2fc715/include/generated/node_base.hpp#L66-L68). Property key 0 is reserved as a null terminator (meaning we are done reading properties for the current object).
 
-### Example Serialized Object
+### Example serialized object
 
 | Data | Type/Size | Description |
 | --- | --- | --- |

--- a/runtimes/android/android.mdx
+++ b/runtimes/android/android.mdx
@@ -6,15 +6,13 @@ description: 'The Android runtime for Rive.'
 import NoteOnFeatureSupport from '/snippets/runtimes/rendering-feature-support.mdx'
 import { Demos } from '/snippets/demos.jsx'
 
+Welcome to using Rive on Android. Rive runtime libraries are open-source, with Android available in the [rive-android](https://github.com/rive-app/rive-android) GitHub repository.
+
 <NoteOnFeatureSupport />
 
 <Demos examples={['dataBindingQuickStart']} runtime="android" />
 
-# Overview
-
-Welcome to using Rive on Android. Rive runtime libraries are open-source, with Android available in the [rive-android](https://github.com/rive-app/rive-android) GitHub repository.
-
-## The Two Android APIs
+## The two Android APIs
 
 Rive for Android provides two main APIs for integrating Rive into your application.
 
@@ -36,7 +34,7 @@ The entry point for this API is the `RiveAnimationView`, which can be added to y
 
 We refer to this as the "legacy" API as we are focusing our development efforts on the new Compose API going forward, though this API will continue to be supported and maintained for some time. For all new development projects, we recommend using the new Compose API. Additionally, we recommend migrating existing projects to the new API when feasible, as this version will be deprecated in the future and will have limited to no new feature development.
 
-# Sample App
+## Sample App
 
 To explore the Android API, you can run our Android sample app. Each activity demonstrates a particular feature of the Rive Android runtime.
 
@@ -48,11 +46,11 @@ Open the cloned folder in Android Studio and select the `app` configuration and 
 
 The other build variants are for development purposes and require additional configuration. See [CONTRIBUTING.MD](https://github.com/rive-app/rive-android/blob/master/CONTRIBUTING.md).
 
-# Getting Started
+## Getting Started
 
 If you are looking for getting started instructions for the Legacy API, see [Getting Started (Legacy API)](/runtimes/android/legacy-getting-started).
 
-## Adding Rive to Your Project
+### Adding Rive to your project
 
 <Steps>
   <Step title="Add the Rive dependency">
@@ -105,14 +103,14 @@ If you are looking for getting started instructions for the Legacy API, see [Get
   </Step>
 </Steps>
 
-## Enabling Logging
+### Enabling logging
 The Compose API uses extensive logging, especially at the debug level, to help diagnose issues. By default there is no logger enabled. Most commonly you will want to set the global logger to pipe to Android's Logcat, which has a convenience function as follows. This could be done in your activity's `onCreate` method or in your `Application` subclass, for instance, before any Rive functionality is used.
 
 ```kotlin
 RiveLog.logger = RiveLog.LogcatLogger()
 ```
 
-## Adding Rive to Your Composition
+### Adding Rive to your composition
 <Steps>
   <Step title="Creating a Worker">
     The Compose API uses an explicit Rive worker which owns a thread for Rive operations, including file and asset decoding, advancing, and drawing. Before you can use any of the API surface, you must create a worker to host these operations. Be aware that the worker must live for the duration of all Rive resources made from it.
@@ -176,7 +174,7 @@ RiveLog.logger = RiveLog.LogcatLogger()
   </Step>
 </Steps>
 
-# Resources
+## Resources
 
 [GitHub](https://github.com/rive-app/rive-android)
 

--- a/runtimes/android/animation-playback.mdx
+++ b/runtimes/android/animation-playback.mdx
@@ -35,7 +35,7 @@ animationView.setRiveResource(
 
 <ControllingPlayback />
 
-#### Invoking Playback Controls
+#### Invoking playback controls
 
 After setting the Rive Resource with your animation view, you can invoke animation playback control methods.
 
@@ -55,7 +55,7 @@ animationView.stop()
 animationView.stop("bouncing")
 ```
 
-#### Animation Event Listeners
+#### Animation event listeners
 
 The Rive Android runtime also allows listener registration. Check out the events section in the
 [rive player](https://github.com/rive-app/rive-android/blob/master/app/src/main/java/app/rive/runtime/example/AndroidPlayerActivity.kt) for an example of how this works.

--- a/runtimes/android/caching-a-rive-file.mdx
+++ b/runtimes/android/caching-a-rive-file.mdx
@@ -7,7 +7,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
 
-## Example Usage
+## Example usage
 
 To cache a rive file in Android, you can use the Rive `File` class to load and cache the file. That `RiveFile` can then be reused across multiple `RiveAnimationView` instances. Here's a basic example:
 

--- a/runtimes/android/data-binding.mdx
+++ b/runtimes/android/data-binding.mdx
@@ -524,9 +524,9 @@ import { Demos } from "/snippets/demos.jsx";
 
     // Set the bound artboard on the main artboard.
     artboardProperty.set(bindableArtboard)
-    
+
     // Release the reference we hold from creation.
-    bindableArtboard.release() 
+    bindableArtboard.release()
     ```
     </Tab>
 </Tabs>
@@ -552,7 +552,7 @@ import { Demos } from "/snippets/demos.jsx";
     </Tab>
 </Tabs>
 
-# Examples
+## Examples
 
 <Tabs>
     <Tab title="Compose">

--- a/runtimes/android/fonts.mdx
+++ b/runtimes/android/fonts.mdx
@@ -23,7 +23,7 @@ As of v9.12.0, various options for fallback fonts can be used on Android.
 </Note>
 The `Fonts` class provides ways to handle and customize fonts, including retrieving system fonts, defining font options, and finding fallback fonts based on specific characteristics.
 
-### 1. Setting a Fallback Font
+### 1. Setting a fallback font
 
 With v9.12.0, the runtime provides a new API to match missing fonts against a specific weight by extending the `FontFallbackStrategy` interface.
 
@@ -68,7 +68,7 @@ The method returns a list of `FontBytes` (\`ByteArray\`). The runtime attempts t
 
 Fallback fonts can also be set using `Rive.setFallbackFont()`, with optional font preferences defined in `Fonts.FontOpts`. These fonts are tried only after attempting the ones returned by `FontFallbackStrategy.getFont()`.
 
-### 2. Font.FontOpts - Font Options
+### 2. Font.FontOpts - font options
 
 Defines the font characteristics when selecting a fallback font.
 
@@ -83,7 +83,7 @@ Defines the font characteristics when selecting a fallback font.
 val defaultFontOpts = Fonts.FontOpts.DEFAULT
 ```
 
-### 3. Retrieving a Fallback Font
+### 3. Retrieving a fallback font
 
 Use `FontHelper.getFallbackFont()` to find a suitable fallback font based on specified options. Returns a `Fonts.Font` object or `null` if no match is found.
 
@@ -94,7 +94,7 @@ val fontOpts = Fonts.FontOpts(familyName = "Roboto", weight = Fonts.Weight.BOLD)
 val fallbackFont = FontHelper.getFallbackFont(fontOpts)
 ```
 
-### 4. Getting Font File and Bytes
+### 4. Getting font file and bytes
 
 - `FontHelper.getFontFile(font: Fonts.Font)`: Retrieves the file for the specified font.
 - `FontHelper.getFontBytes(font: Fonts.Font)`: Reads the font file and returns its bytes.
@@ -106,7 +106,7 @@ val fontFile = FontHelper.getFontFile(fallbackFont)
 val fontBytes = FontHelper.getFontBytes(fallbackFont)
 ```
 
-### 5. Fonts.Weight - Font Weight
+### 5. Fonts.Weight - font weight
 
 Represents the font weight, allowing values from 0 to 1000.
 
@@ -121,7 +121,7 @@ val normalWeight = Fonts.Weight.NORMAL
 val customWeight = Fonts.Weight.fromInt(500)
 ```
 
-### 6. Fonts.Style - Font Style
+### 6. Fonts.Style - font style
 
 Represents the font style, allowing "normal" and "italic"
 
@@ -136,7 +136,7 @@ val normalStyle = Fonts.Font.STYLE_NORMAL
 val italicStyle = Fonts.Font.STYLE_ITALIC
 ```
 
-### 7. Getting System Fonts
+### 7. Getting system fonts
 
 - `FontHelper.getSystemFonts()`: Returns a map of all available system font families.
 

--- a/runtimes/android/legacy-getting-started.mdx
+++ b/runtimes/android/legacy-getting-started.mdx
@@ -2,7 +2,7 @@
 title: 'Getting Started (Legacy API)'
 description: 'Getting started instructions for the Rive Android Legacy API.'
 ---
-## Adding Rive to Your Project
+## Adding Rive to your project
 See the [Adding Rive to Your Project](/runtimes/android/android#adding-rive-to-your-project) section for instructions on adding Rive to your Android project. Once complete, resume here.
 
 ## Building a RiveAnimationView
@@ -44,7 +44,7 @@ val riveView = RiveAnimationView.Builder(this)
 setContentView(riveView)
 ```
 
-### Using a Rive File
+### Using a Rive file
 
 If you have already loaded a Rive `File` instance, you can use that to initialize the view as well. See [Caching a Rive File](/runtimes/caching-a-rive-file) for more details on how and why to load Rive files.
 
@@ -101,7 +101,7 @@ From your activity you can load it as usual:
 setContentView(R.layout.my_layout)
 ```
 
-## Internet Permissions
+## Internet permissions
 
 If you're retrieving Rive files over a network, your app will need permission to access the internet in `AndroidManifest.xml`:
 

--- a/runtimes/android/migrating-from-legacy.mdx
+++ b/runtimes/android/migrating-from-legacy.mdx
@@ -41,7 +41,7 @@ The new runtime makes use of the `AutoCloseable` interface to manage lifetimes e
 
 In Compose, lifecycles are tied to `remember` Composables and use `DisposableEffect` to create and dispose of objects as needed, simplifying memory management.
 
-## Shared Features
+## Shared features
 
 ### Shared APIs
 
@@ -61,7 +61,7 @@ The legacy Rive Android runtime is View based and provided the `RiveAnimationVie
 
 The new API is Compose based, with the intention to provide a View API in the future. The main Composable is simply called `Rive`, reflecting the broader feature set and use cases it supports.
 
-#### Setting a Local Raw Resource
+#### Setting a local raw resource
 
 <Info>
   The new API will use the I/O dispatcher by default to load Rive files asynchronously. This is different from the legacy runtime, which loaded files synchronously on the main thread. If you want to load files using a different threading model, load the resource using your preferred method and pass the bytes to a `RiveFileSource.Bytes` source.
@@ -102,7 +102,7 @@ when (riveFile) {
 }
 ```
 
-#### Setting a Rive File from Bytes
+#### Setting a Rive file from bytes
 
 **Legacy RiveAnimationView**
 
@@ -132,7 +132,7 @@ when (riveFile) {
 }
 ```
 
-#### Caching a Rive File
+#### Caching a Rive file
 
 <Card icon="eye" href="/runtimes/android/caching-a-rive-file" horizontal>
   See also Caching a Rive File for more details.
@@ -330,7 +330,7 @@ Rive(
 )
 ```
 
-#### Playing, Pausing, and State Machine Settling
+#### Playing, pausing, and State Machine settling
 
 **Legacy RiveAnimationView**
 
@@ -353,7 +353,7 @@ Rive(
 )
 ```
 
-#### Autoplay and Setting Initial Values
+#### Autoplay and setting initial values
 
 The legacy runtime includes an `autoplay` feature, defaulting to true, that automatically starts playing the given animation or state machine when the Rive file is loaded. This can be disabled to allow setting initial values before playback begins.
 
@@ -400,7 +400,7 @@ Rive(
 )
 ```
 
-#### Touch Pass-Through
+#### Touch pass-through
 
 **Legacy RiveAnimationView**
 
@@ -460,7 +460,7 @@ LaunchedEffect(riveFile) {
 }
 ```
 
-### View Model Instance Properties
+### View Model instance properties
 
 **Legacy**
 
@@ -520,7 +520,7 @@ val artboard = rememberArtboard(riveFile, "My Artboard")
 vmi.setArtboard("My Artboard Property", artboard)
 ```
 
-### Loading Referenced Assets
+### Loading referenced assets
 
 **Legacy**
 
@@ -596,7 +596,7 @@ Rive(
 )
 ```
 
-## New Exclusive Features
+## New exclusive features
 
 A growing number of features are only available in the new runtime. These features were added to address limitations in the legacy runtime or to provide new capabilities that were not previously possible. Below is a list of such features along with brief descriptions.
 
@@ -610,7 +610,7 @@ By comparison, the legacy runtime has limited logs.
   We may consider retrofitting more logging capabilities to the legacy runtime in the future, especially if doing so would illuminate a potential source for bugs.
 </Callout>
 
-### Tracking the Loading State of a Rive File
+### Tracking the loading state of a Rive file
 
 The new runtime provides a `Result` wrapper around Rive file loading operations, allowing you to track the state (loading, success, error) of a Rive file. This is useful for providing user feedback during loading or handling errors gracefully.
 
@@ -638,7 +638,7 @@ The legacy runtime's convenience methods, e.g. `setRiveResource()`, do not provi
   There are no plans to retrofit this feature into the legacy runtime.
 </Callout>
 
-### Rendering to a Bitmap
+### Rendering to a bitmap
 
 The new runtime provides built-in support for [rendering Rive to an Android `Bitmap`](/runtimes/advanced-topic/rendering-to-a-bitmap), which can be useful for scenarios such as snapshot testing or rendering video encoded from data-bound Rive files into image frames on the edge (i.e. the user's device). This is done using the `RenderBuffer` class or the `onBitmapAvailable` callback in the `Rive` Composable.
 
@@ -648,7 +648,7 @@ The new runtime provides built-in support for [rendering Rive to an Android `Bit
     There are no plans to retrofit this feature into the legacy runtime.
 </Callout>
 
-### Updating a Data Bind Unsettles the State Machine
+### Updating a Data Bind unsettles the State Machine
 
 In the new runtime, updating a data-bound property [automatically "unsettles" the state machine](/runtimes/android/android#adding-rive-to-your-composition), causing it to advance and draw based on the new data. By comparison, the legacy runtime required you to call `RiveAnimationView.play()` after updating data-bound properties on a settled state machine to achieve the same effect.
 
@@ -656,11 +656,11 @@ In the new runtime, updating a data-bound property [automatically "unsettles" th
   We may consider retrofitting this behavior into the legacy runtime in the future as it is a common source of confusion. However, doing so would be a breaking change, and it may not be worth the disruption for existing users.
 </Callout>
 
-## Legacy Exclusive Features
+## Legacy exclusive features
 
 Some features are only available in the legacy runtime. This is usually because they were less commonly used, were complex in practice, or were difficult to maintain and support. Below is a list of such features along with guidance on how to handle their absence in the new runtime.
 
-### View-Based API
+### View-based API
 
 The legacy runtime is built around the `RiveAnimationView` class, which is a subclass of Android's `TextureView` (and subsequently `View`). This makes it easy to integrate into existing View-based Android applications. The new runtime is currently Compose-based and does not provide a View subclass. If you need to use Rive in a View-based application, you will need to set up a Compose environment within your View hierarchy using `ComposeView`.
 
@@ -668,7 +668,7 @@ The legacy runtime is built around the `RiveAnimationView` class, which is a sub
   There are plans to provide a View-based API in the future.
 </Callout>
 
-### Frame Metrics
+### Frame metrics
 
 The legacy runtime includes support for frame metrics, providing some rendering performance numbers and potentially helping to identify bottlenecks. This is done by enabling frame metrics collection on the `RiveAnimationView`.
 
@@ -682,7 +682,7 @@ The new runtime does not yet include any comparable feature. Instead, you can us
   We will be adding performance monitoring in the future. The specific form it takes is to be determined.
 </Callout>
 
-### CDN Assets
+### CDN assets
 
 **Legacy**
 
@@ -718,7 +718,7 @@ The new runtime does not include built-in support for loading CDN assets.
   We will be adding a new API in a future update to query the asset manifest for a file, which will include URLs for hosted assets. This will allow you to load them using standard networking libraries and supply them to the Rive worker using existing asset APIs.
 </Callout>
 
-### Setting a Rive File from Network
+### Setting a Rive file from network
 
 The legacy runtime provides built-in support for loading Rive files from network URLs using the now defunct Volley library. This includes methods such as:
 
@@ -740,7 +740,7 @@ RiveAnimationView.Builder(context)
   We are considering adding built-in network loading capabilities in future releases. If implemented, it would not use Volley, preferring a modern alternative. It would also likely be opt-in to avoid adding unnecessary dependencies for users who do not need network loading.
 </Callout>
 
-### Rendering to Canvas
+### Rendering to canvas
 
 <Card icon="eye" href="/runtimes/choose-a-renderer/overview#android" horizontal>
   See also Choose a Renderer for more details.
@@ -777,7 +777,7 @@ The new runtime does not include a Canvas renderer, focusing instead on the Rive
   There are no current plans to reintroduce Canvas rendering in the new runtime.
 </Callout>
 
-### Artboard Volume
+### Artboard volume
 
 The legacy runtime can set an artboard's audio volume through the `Artboard.volume` property or `RiveAnimationView.setVolume()`. This feature is not present in the new runtime.
 
@@ -858,7 +858,7 @@ vmi.setString("My Text Property", "Hello, World!")
   There are no current plans to reintroduce text run support in the new runtime.
 </Callout>
 
-### Linear Animations
+### Linear animations
 
 <Card icon="eye" href="/runtimes/android/animation-playback" horizontal>
   See also the Linear Animation documentation for more details.
@@ -901,7 +901,7 @@ In practice, working with linear animations is more granular and brittle compare
   There are no current plans to reintroduce direct linear animation playback in the new runtime.
 </Callout>
 
-### Multiple State Machines Per View
+### Multiple State Machines per view
 
 The legacy runtime allows multiple state machines to be associated with a single `RiveAnimationView` instance. At the core runtime level there is no technical limitation, and each state machine is processed in sequence. In practice this leads to complexity and difficulty reasoning about state, especially when data binding is involved. Only the Android legacy runtime supported this capability among the various Rive runtimes.
 
@@ -911,7 +911,7 @@ The new runtime enforces a one-to-one relationship between Rive instances and st
   There are no current plans to reintroduce multiple state machines per Rive instance in the new runtime.
 </Callout>
 
-### Observing State Machine State
+### Observing State Machine state
 
 The legacy runtime provides methods to observe which state is currently active in a state machine. This can be useful for triggering actions in your application based on the current state of the animation.
 
@@ -929,7 +929,7 @@ The new runtime does not include this feature. The original feature was added be
   There are no current plans to reintroduce state observation in the new runtime.
 </Callout>
 
-### Single Touch Support
+### Single touch support
 
 The legacy runtime supports single touch input, allowing only one touch interaction at a time. This is to maintain backwards compatibility with existing Rive files that were designed with single touch in mind. As such it is also the default behavior.
 
@@ -959,7 +959,7 @@ The new runtime supports only multitouch input. In practice, Rive files should r
   There are no current plans to reintroduce single touch support in the new runtime.
 </Callout>
 
-### Getting by Index
+### Getting by index
 
 The legacy runtime provides methods to get artboards, animations state machines, view models, and view model instances by their index in addition to their name. This is rarely useful in scenarios where you want to iterate over all elements.
 
@@ -988,7 +988,7 @@ LaunchedEffect(riveFile) {
   There are no current plans to reintroduce getting by index in the new runtime.
 </Callout>
 
-### Renderer Class
+### Renderer class
 
 The legacy runtime includes the `Renderer` and `RiveArtboardRenderer` classes that allow you to override rendering behavior for Rive. It is difficult to use correctly, ensure proper life cycles, and maintain compatibility with the Rive Renderer as it evolves.
 
@@ -998,7 +998,7 @@ The new runtime does not include a `Renderer` class, focusing instead on the mos
   There are no current plans to reintroduce a Renderer class in the new runtime.
 </Callout>
 
-### Controller Class
+### Controller class
 
 The legacy runtime includes a `RiveFileController` class that provides methods to control playback, manage state machines, and observe state changes. It is tightly coupled to the `RiveAnimationView`.
 

--- a/runtimes/android/rive-events.mdx
+++ b/runtimes/android/rive-events.mdx
@@ -11,7 +11,7 @@ import AdditionalResources from "/snippets/runtimes/events/additional-resources.
 
 <Overview />
 
-### Adding an Event Listener
+### Adding an event listener
 
 Use the `addEventListener` and `removeEventListener` on `RiveAnimationView` to subscribe/unsubscribe a`RiveFileController.RiveEventListener`.
 

--- a/runtimes/android/text.mdx
+++ b/runtimes/android/text.mdx
@@ -11,7 +11,7 @@ import Resources from "/snippets/runtimes/text/resources.mdx"
 
 <Overview />
 
-#### Reading Text via RiveAnimationView
+#### Reading text via RiveAnimationView
 
 To read a given text run text value at any given time, reference the `.getTextRunValue()` API on the `RiveAnimationView`:
 
@@ -21,7 +21,7 @@ fun getTextRunValue(textRunName: String): String? = try
 
 Supply the text run name and you'll have the Rive text run value returned, or `null` if the text run could not be queried.
 
-#### Setting Text via RiveAnimationView
+#### Setting text via RiveAnimationView
 
 To set a given text run value at any given time, reference the `.setTextRunValue()` API on the `RiveAnimationView`:
 
@@ -81,7 +81,7 @@ class DynamicTextActivity : AppCompatActivity(), TextWatcher {
 
 <NestedArtboard />
 
-#### Reading Text via RiveAnimationView
+#### Reading text via RiveAnimationView
 
 To read a given text run text value at any given time, reference the `.getTextRunValue()` API on the `RiveAnimationView`:
 
@@ -91,7 +91,7 @@ fun getTextRunValue(textRunName: String, path: String): String? = try
 
 Supply the text run name and the path to where it exists and you'll have the Rive text run value returned, or `null` if the text run could not be queried.
 
-#### Setting Text via RiveAnimationView
+#### Setting text via RiveAnimationView
 
 To set a given text run value at any given time, reference the `.setTextRunValue()` API on the `RiveAnimationView`:
 

--- a/runtimes/apple/animation-playback.mdx
+++ b/runtimes/apple/animation-playback.mdx
@@ -50,7 +50,7 @@ class AnimationViewController: UIViewController {
 
 <ControllingPlayback />
 
-#### Invoking Playback Controls
+#### Invoking playback controls
 
 After creating a `RiveViewModel`, you can invoke animation playback control methods on a reference to this view model.
 
@@ -89,7 +89,7 @@ If there are multiple animations on the active artboard you can play a specific 
 simpleVM.play(animationName: "Fancy Animation")
 ```
 
-### Pause/Stop/Reset
+### Pause/stop/reset
 
 Based on certain events in your app you may want to adjust the playback further.
 
@@ -99,7 +99,7 @@ simpleVM.stop()
 simpleVM.reset()
 ```
 
-#### Player Delegates
+#### Player delegates
 
 This runtime allows for delegates that can be set on the `RiveViewModel`. You can use delegates to define functions that hook into when certain playback events are invoked. See the below class for how you can hook into the following playback events:
   - played

--- a/runtimes/apple/apple.mdx
+++ b/runtimes/apple/apple.mdx
@@ -29,7 +29,7 @@ It is important to note that while multi-threading is supported, the calls from 
 
 Most APIs are marked as `throws`, with `Error` types available for the different Rive primitives.
 
-## Getting Started
+## Getting started
 
 Follow the steps below for a quick start on integrating Rive into your Apple app.
 
@@ -319,7 +319,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
     </Tab>
 </Tabs>
 
-## Playing / Pausing
+## Playing / pausing
 
 <Tabs>
     <Tab title={"{{runtimeCurrentNameApple}}"}>
@@ -360,7 +360,7 @@ Follow the steps below for a quick start on integrating Rive into your Apple app
     </Tab>
 </Tabs>
 
-## Frame Rate
+## Frame rate
 
 <Tabs>
     <Tab title={"{{runtimeCurrentNameApple}}"}>
@@ -480,7 +480,7 @@ See [Semantics](/runtimes/apple/semantics) for the available modes and more deta
     </Tab>
 </Tabs>
 
-## Example App
+## Example app
 
 You can run our Apple example app from the Rive GitHub repository.
 

--- a/runtimes/apple/caching-a-rive-file.mdx
+++ b/runtimes/apple/caching-a-rive-file.mdx
@@ -7,7 +7,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
 
-## Example Usage
+## Example usage
 
 <Tabs>
     <Tab title={"{{runtimeCurrentNameApple}}"}>

--- a/runtimes/apple/data-binding.mdx
+++ b/runtimes/apple/data-binding.mdx
@@ -610,6 +610,6 @@ import { Demos } from "/snippets/demos.jsx";
 
 <Enums />
 
-# Examples
+## Examples
 
 See the [Data Binding view](https://github.com/rive-app/rive-ios/blob/main/Example-iOS/Source/Examples/SwiftUI/DataBindingView.swift) in the Example app for a demo.

--- a/runtimes/apple/faq.mdx
+++ b/runtimes/apple/faq.mdx
@@ -4,14 +4,14 @@ description: ''
 ---
 
 
-# How do I enable support for ProMotion displays?
+## How do I enable support for ProMotion displays?
 
 Support for ProMotion on iOS requires two things:
 
 1. Using an API in the Apple runtime to set the desired FPS (range)
 2. Adding an additional entry into your app's`Info.plist` file
 
-## Example Usage
+### Example usage
 
 ```swift
 let preferredFPS = UIScreen.main.maximumFramesPerSecond
@@ -32,6 +32,6 @@ Additionally, add the following to your app's `Info.plist` file:
 
 You can view more information about preferred FPS [here](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1648421-preferredframespersecond), and about preferred FPS range [here](https://developer.apple.com/documentation/quartzcore/cadisplaylink/3875343-preferredframeraterange).
 
-# Why is resource usage different compared to other libraries?
+### Why is resource usage different compared to other libraries?
 
 See our [Resource Usage](/runtimes/apple/resource-usage) documentation for more details.

--- a/runtimes/apple/gpu-canvas.mdx
+++ b/runtimes/apple/gpu-canvas.mdx
@@ -38,7 +38,7 @@ let rive = try await Rive(file: file)
 
 No additional configuration is required when creating a `RiveUIView`, `RiveUIViewRepresentable`, or `AsyncRiveUIViewRepresentable`. Each view inherits the GPU Canvas setting from the worker associated with its `Rive` object.
 
-## Default Behavior
+## Default behavior
 
 GPU Canvas is disabled by default. Continue to create a worker without a configuration when your content does not require it:
 
@@ -46,7 +46,7 @@ GPU Canvas is disabled by default. Continue to create a worker without a configu
 let worker = try await Worker()
 ```
 
-## Sharing a GPU Canvas Worker
+## Sharing a GPU Canvas worker
 
 Share a GPU Canvas worker when multiple files or views can use the same worker. An example implementation is shown below.
 

--- a/runtimes/apple/migrating-from-legacy.mdx
+++ b/runtimes/apple/migrating-from-legacy.mdx
@@ -19,7 +19,7 @@ This guide covers:
     This guide is not meant to be exhaustive as it would be redundant with existing general documentation. Please refer to the relevant sections of the documentation for more details on specific topics.
 </Note>
 
-## Package and Import
+## Package and import
 
 The new Apple runtime is available in the same Swift package and CocoaPods pod as the legacy runtime. Both runtime APIs are available in the same package, so you can import the runtime using the same import statement.
 
@@ -47,7 +47,7 @@ let file = try await File(source: .local("my_file", Bundle.main), worker: worker
 let rive = try await Rive(file: file)
 ```
 
-## Lifecycles and Threading
+## Lifecycles and threading
 
 The legacy runtime is effectively main-thread driven through `RiveViewModel` and `RiveView`.
 
@@ -71,7 +71,7 @@ let file = try await File(source: ..., worker: worker)
 let rive = try await Rive(file: file)
 ```
 
-## Shared Features
+## Shared features
 
 ### Shared APIs
 
@@ -82,7 +82,7 @@ For fallback font types and behavior, see [Fallback Fonts](/runtimes/fonts#fallb
 
 Use the sections below as a migration map: [Loading a File from Disk](#loading-a-file-from-disk), [Creating a Rive View](#creating-a-rive-view), and [Data Binding](#data-binding). Legacy `RiveViewModel` flows in these areas become explicit `File` + `Rive` setup, then `RiveUIView`/SwiftUI representables in the new runtime.
 
-### Loading a File from Disk
+### Loading a file from disk
 
 #### {{runtimeLegacyNameApple}}
 
@@ -101,7 +101,7 @@ let file = try await File(source: .local("my_rive_file", Bundle.main), worker: w
 let rive = try await Rive(file: file)
 ```
 
-### Loading a File from URL
+### Loading a file from URL
 
 #### {{runtimeLegacyNameApple}}
 
@@ -124,7 +124,7 @@ let file = try await File(
 let rive = try await Rive(file: file)
 ```
 
-### Loading a File from Data (Bytes)
+### Loading a file from data (bytes)
 
 #### {{runtimeLegacyNameApple}}
 
@@ -146,7 +146,7 @@ let file = try await File(source: .data(data), worker: worker)
 let rive = try await Rive(file: file)
 ```
 
-### Tracking Loading and Error State
+### Tracking loading and error state
 
 For common setup operations (loading files, creating artboards, creating state machines), the migration pattern is:
 
@@ -218,7 +218,7 @@ let stateMachine = try await artboard.createStateMachine("My State Machine")
 let rive = try await Rive(file: file, artboard: artboard, stateMachine: stateMachine)
 ```
 
-### Creating a Rive View
+### Creating a Rive view
 
 #### {{runtimeLegacyNameApple}}
 
@@ -383,7 +383,7 @@ let defaultFromArtboard = try await file.createViewModelInstance(
 )
 ```
 
-### View Model Instance Properties
+### View Model instance properties
 
 #### {{runtimeLegacyNameApple}}
 
@@ -515,7 +515,7 @@ let instanceBoundRive = try await Rive(file: file, dataBind: .instance(viewModel
 let noBindingRive = try await Rive(file: file, dataBind: .none)
 ```
 
-### Updating a Data Bind Unsettles the State Machine
+### Updating a Data Bind unsettles the State Machine
 
 Legacy and new runtime behavior differ here:
 
@@ -560,7 +560,7 @@ let riveView = RiveUIView(rive: rive)
 instance.setValue(of: property, to: "Updated Value") // Applies without play()
 ```
 
-### Playing and Pausing
+### Playing and pausing
 
 <Card icon="eye" href="/runtimes/apple/apple#playing--pausing" horizontal>
   For more information, see playback controls in the Apple runtime guide.
@@ -585,7 +585,7 @@ RiveUIViewRepresentable(rive)
     .paused(true)
 ```
 
-### Frame Rate
+### Frame rate
 
 <Card icon="eye" href="/runtimes/apple/apple#frame-rate" horizontal>
   For more information, see frame rate controls and ProMotion notes.
@@ -610,7 +610,7 @@ riveView.frameRate = .range(minimum: 30, maximum: 60)
 riveView.frameRate = .default
 ```
 
-### Loading Referenced Assets
+### Loading referenced assets
 
 #### {{runtimeLegacyNameApple}}
 
@@ -699,7 +699,7 @@ RiveLog.logger = MyLogger()
 RiveLog.logger = RiveLog.none
 ```
 
-### Fallback Fonts
+### Fallback fonts
 
 Both runtimes support fallback fonts.
 
@@ -719,9 +719,9 @@ RiveFont.fallbackFontsCallback = { style in
 }
 ```
 
-## New Exclusive Features
+## New exclusive features
 
-### Worker-Based Concurrency
+### Worker-based concurrency
 
 The new runtime introduces `Worker` as an explicit concurrency primitive. This is a substantial change from the legacy runtime, which did not expose an equivalent concept.
 
@@ -735,7 +735,7 @@ Benefits include:
   A shared worker is usually the best default. Use multiple workers only when you need additional parallel processing, such as when rendering multiple heavyweight graphics.
 </Callout>
 
-### Async Initialization APIs
+### Async initialization APIs
 
 The new runtime supports async constructors and async view wrappers (`RiveUIView` with async closure and `AsyncRiveUIViewRepresentable`) to better model real-world loading flows.
 
@@ -743,11 +743,11 @@ The new runtime supports async constructors and async view wrappers (`RiveUIView
   The async wrappers are useful when a view must own its own loading lifecycle. If you need reuse and caching across screens, prefer creating and storing `File`/`Rive` objects at a higher level.
 </Callout>
 
-## Legacy Exclusive Features
+## Legacy exclusive features
 
 Some features in the legacy runtime are intentionally not present in the new runtime.
 
-### Automatic CDN Asset Loading
+### Automatic CDN asset loading
 
 The legacy runtime can fetch hosted assets automatically through `loadCdn`. In the new runtime, query `File.getAssets()` and use each asset's optional `cdn` metadata to fetch its bytes yourself, then decode and register it with the worker using `asset.uniqueName`. See [Loading Hosted Assets](/runtimes/apple/loading-assets#loading-hosted-assets).
 
@@ -771,13 +771,13 @@ Simple event-like behavior can often be modeled with trigger-oriented view model
   There are no current plans to reintroduce legacy-style event listener APIs in the new runtime.
 </Callout>
 
-### Linear Animations
+### Linear animations
 
 Legacy integrations can directly target linear animations. In migration, graphics are required to contain a state machine.
 
 For existing files that rely on linear animations, create a state machine in the Editor with a single state that plays the desired animation.
 
-### Observing State Machine State
+### Observing State Machine state
 
 Legacy integrations often used state-change delegate callbacks (for example, `RiveStateDelegate.stateChange(...)`) to react to animation state.
 
@@ -791,6 +791,6 @@ for try await value in stream {
 }
 ```
 
-### Getting by Index
+### Getting by index
 
 Where possible, prefer named queries and explicit sources (for example, `ViewModelSource` and named artboard/state machine queries) over index-based coupling.

--- a/runtimes/apple/playing-audio.mdx
+++ b/runtimes/apple/playing-audio.mdx
@@ -16,7 +16,7 @@ import ReferencedAssets from "/snippets/runtimes/playing-audio/referenced-assets
 
 For more information, see [Loading Assets](/runtimes/apple/loading-assets).
 
-## Audio Settings
+## Audio settings
 
 On iOS, playing audio will respect your `AVAudioSession` shared instance settings. For more information, see [Apple's documentation](https://developer.apple.com/documentation/avfaudio/avaudiosession) on `AVAudioSession`. Using this, you can choose to mix audio, duck audio, and more. You can update your shared instance early in your app lifecycle if you would like to ensure all Rive audio plays  with the correct settings.
 
@@ -27,7 +27,7 @@ let options: AVAudioSession.CategoryOptions = [.mixWithOthers]
 AVAudioSession.sharedInstance().setCategory(category, options: options)
 ```
 
-## Setting Volume
+## Setting volume
 
 An artboard is capable of setting its volume. A parent artboard will set the volume of all component instances; however, setting a component's volume will **not** update the parent's volume.
 

--- a/runtimes/apple/rive-events.mdx
+++ b/runtimes/apple/rive-events.mdx
@@ -15,7 +15,7 @@ import AdditionalResources from "/snippets/runtimes/events/additional-resources.
 
 <Overview />
 
-### Subscribing to Events via State Machine Delegate
+### Subscribing to events via State Machine delegate
 
 To subscribe to Rive events, implement the `onRiveEventReceived` protocol from `StateMachineDelegate`.
 

--- a/runtimes/apple/text.mdx
+++ b/runtimes/apple/text.mdx
@@ -15,7 +15,7 @@ import Resources from "/snippets/runtimes/text/resources.mdx"
 
 <Overview />
 
-#### Reading Text
+#### Reading text
 
 To read a given text run text value at any given time, reference the `.getTextRunValue()` API on the `RiveViewModel`:
 
@@ -25,7 +25,7 @@ open func getTextRunValue(_ textRunName: String) -> String?
 
 Supply the text run name and you'll have the Rive text run value returned, or `nil` if the text run could not be queried.
 
-#### Setting Text
+#### Setting text
 
 To set a given text run value at any given time, reference the `.setTextRunValue()` API on the `RiveViewModel`:
 
@@ -38,7 +38,7 @@ Supply the text run name and a second parameter, `textValue`, with a String valu
 <Note>
 If the supplied `textRunName` Rive text run cannot be queried on the active artboard, Rive will throw a `RiveError.textValueRunError` that you may need to catch and handle gracefully in your application.
 </Note>
-#### Example Usage
+#### Example usage
 
 ```swift
 @State private var userInput: String = ""
@@ -63,7 +63,7 @@ var body: some View {
 
 <NestedArtboard />
 
-### Reading Text
+### Reading text
 
 Similar to [reading text from a text run within a parent artboard](#reading-text), you can set the value of a text run within a component instance using the following API:
 
@@ -71,7 +71,7 @@ Similar to [reading text from a text run within a parent artboard](#reading-text
 open func getTextRunValue(_ textRunName: String, path: String) -> String?
 ```
 
-### Setting Text
+### Setting text
 
 Additionally, similar to [setting text within a parent artboard](#setting-text), you can read the value of a text run within a component instance using the following API:
 

--- a/runtimes/choose-a-renderer/overview.mdx
+++ b/runtimes/choose-a-renderer/overview.mdx
@@ -14,7 +14,7 @@ The Rive Renderer is designed to provide better performance and visual fidelity 
   Support](/feature-support) for more information.
 </Note>
 
-## Renderer Defaults
+## Renderer defaults
 
 | Runtime      | Default Renderer | Options                                      |
 | ------------ | ---------------- | -------------------------------------------- |
@@ -27,7 +27,7 @@ The Rive Renderer is designed to provide better performance and visual fidelity 
 | [Flutter](#flutter)      | No default       | Rive / Flutter Skia / Flutter Impeller       |
 
 
-## Runtime Setup
+## Runtime setup
 
 Only some runtimes require you to choose or configure a renderer. The sections below cover runtimes that expose renderer setup through packages, initialization options, or factory settings.
 

--- a/runtimes/cpp/asset-loading.mdx
+++ b/runtimes/cpp/asset-loading.mdx
@@ -8,7 +8,7 @@ or reference them by CDN UUID and let the runtime fetch them. Implement
 `FileAssetLoader` to control the second path — resolving from disk, the
 network, or your own asset pipeline.
 
-## The `FileAssetLoader` Interface
+## The `FileAssetLoader` interface
 
 ```cpp
 #include "rive/file_asset_loader.hpp"
@@ -36,7 +36,7 @@ public:
 | Font       | `FontAsset`     | `asset.font(factory->decodeFont(bytes))` |
 | Audio      | `AudioAsset`    | `asset.audioSource(factory->decodeAudio(bytes))` |
 
-## Sync Example: Load by File Name
+## Sync example: load by file name
 
 ```cpp
 #include "rive/file_asset_loader.hpp"
@@ -90,7 +90,7 @@ private:
 `asset.uniqueFilename()` is the editor-assigned name with extension; use
 `asset.cdnUuidStr()` if you index by CDN UUID instead.
 
-## Wiring It Up
+## Wiring it up
 
 ```cpp
 rcp<FileAssetLoader> loader = make_rcp<DiskAssetLoader>("assets/");
@@ -102,7 +102,7 @@ rcp<File> file = File::import(bytes, factory, &result, loader);
 The loader is reference-counted — `File` keeps it alive for the file's
 lifetime so async loads can complete after `import` returns.
 
-## Async Loading
+## Async loading
 
 For async (HTTP, decoder thread, etc), return `true` from `loadContents`
 **without** calling `renderImage` / `font` / `audioSource`, then populate the
@@ -135,7 +135,7 @@ bool loadContents(FileAsset& asset, Span<const uint8_t>, Factory* factory) overr
   thread-safe `Factory` if your backend supports it.
 </Warning>
 
-## Built-In Loaders
+## Built-in loaders
 
 For simple cases the runtime ships a relative-path loader you can extend:
 
@@ -149,7 +149,7 @@ rcp<FileAssetLoader> loader =
 It loads files by `uniqueFilename()` from a directory on disk — handy for
 samples and tooling.
 
-## When In-Band Bytes Already Cover Everything
+## When in-band bytes already cover everything
 
 If your `.riv` file embeds all of its assets, you can skip the loader
 entirely. `inBandBytes` will be non-empty for those assets and the runtime

--- a/runtimes/cpp/command-queue.mdx
+++ b/runtimes/cpp/command-queue.mdx
@@ -37,7 +37,7 @@ plumbing you don't need.
 - Async results (file loaded, state machine settled, image decoded) come
   back via **listener callbacks** registered against handles.
 
-## Setting Up the Queue and Server
+## Setting up the queue and server
 
 ```cpp
 #include "rive/command_queue.hpp"
@@ -65,7 +65,7 @@ server.processCommands();
 blocks waiting for commands, and returns when the app thread calls
 `queue->disconnect()`.
 
-## Loading a File and Creating a State Machine
+## Loading a file and creating a State Machine
 
 All these calls happen on the app thread. They enqueue commands and
 return handles **immediately** — the actual work happens on the server
@@ -83,7 +83,7 @@ The handles are valid to use immediately even though the load hasn't
 happened yet — subsequent commands queued against them will execute in
 order on the server.
 
-## Advancing and Drawing
+## Advancing and drawing
 
 ```cpp
 // App thread:
@@ -100,7 +100,7 @@ for the full draw-callback API; the canonical example is the
 command-queue D3D11 sample in the rive monorepo
 (`packages/sample_win32_d3d11_cq/`).
 
-## Async Results: Listeners
+## Async results: listeners
 
 Because commands run asynchronously, results come back via listener
 callbacks. Each handle type has a matching listener with `on…` methods:
@@ -136,7 +136,7 @@ Pass a non-zero `requestId` to the queue methods that accept one (e.g.
 `deleteFile(handle, requestId)`) and your listener will receive the same
 ID back.
 
-## Pointer Events
+## Pointer events
 
 Pointer events go through the queue too. `CommandQueue::PointerEvent`
 carries the screen-space position; the server converts it to artboard
@@ -170,7 +170,7 @@ queue->deleteArtboard(artboard);
 queue->deleteFile(file);
 ```
 
-## When to Use the Direct API Instead
+## When to use the Direct API instead
 
 The direct `File` / `Artboard` / `StateMachineInstance` API documented in
 the other pages on this site is simpler when:

--- a/runtimes/cpp/command-queue.mdx
+++ b/runtimes/cpp/command-queue.mdx
@@ -170,7 +170,7 @@ queue->deleteArtboard(artboard);
 queue->deleteFile(file);
 ```
 
-## When to use the Direct API instead
+## When to use the direct API instead
 
 The direct `File` / `Artboard` / `StateMachineInstance` API documented in
 the other pages on this site is simpler when:

--- a/runtimes/cpp/data-binding.mdx
+++ b/runtimes/cpp/data-binding.mdx
@@ -22,7 +22,7 @@ on the next `advanceAndApply`.
 - `ViewModelInstance*Runtime` — typed handles for individual properties
   (`…NumberRuntime`, `…StringRuntime`, etc).
 
-## Creating an Instance
+## Creating an instance
 
 The simplest path is to ask the file for the artboard's default view model,
 then create a default instance from it:
@@ -68,7 +68,7 @@ sm     ->bindViewModelInstance(instance->instance());
   drives state-machine transitions and listener conditions.
 </Note>
 
-## Reading & Writing Properties
+## Reading & writing properties
 
 All accessors are path-based — `/`-separated for nested view models.
 
@@ -144,7 +144,7 @@ rcp<ViewModelInstanceRuntime> row = items->instanceAt(0);
 List items are themselves `ViewModelInstanceRuntime`s — same property API as
 above.
 
-### Image & Artboard Properties
+### Image & Artboard properties
 
 ```cpp
 auto* image = card->propertyImage("avatar");
@@ -164,7 +164,7 @@ artboardRef->value(file->bindableArtboardNamed("Badge"));   // rcp<BindableArtbo
 - After mutating properties, the next `sm->advanceAndApply(dt)` propagates
   the changes through data binds and into rendering.
 
-## When Properties Don't Exist
+## When properties don't exist
 
 Every `propertyX(name)` getter returns `nullptr` if the name doesn't
 resolve, so you can probe an instance safely:

--- a/runtimes/cpp/external-renderer.mdx
+++ b/runtimes/cpp/external-renderer.mdx
@@ -14,7 +14,7 @@ core runtime is renderer-agnostic — anything you pass to
 
 Implement both and Rive will route everything through them.
 
-## Use Cases
+## Use cases
 
 - You already have a 2D vector engine (Skia, Direct2D, custom) and want
   Rive to render through it.
@@ -26,7 +26,7 @@ If you only need Rive on Windows / macOS / iOS / Linux / Web / Android,
 prefer the [built-in renderers](/runtimes/cpp/renderers) — they're
 faster and feature-complete.
 
-## The `Renderer` Interface
+## The `Renderer` interface
 
 ```cpp
 class Renderer {
@@ -63,7 +63,7 @@ A few constraints worth knowing up front:
 - `drawImageMesh` indices are 16-bit; vertex / UV buffers are
   tightly-packed `float` pairs.
 
-## The `Factory` Interface
+## The `Factory` interface
 
 ```cpp
 class Factory {
@@ -102,7 +102,7 @@ Things to keep in mind:
   override points; use the actual virtual `Factory` extension points for
   custom font shaping or audio integration.
 
-## RenderPath / RenderPaint Subclasses
+## RenderPath / RenderPaint subclasses
 
 Each holds the state your backend reads during drawing:
 
@@ -137,7 +137,7 @@ public:
 `rive/renderer.hpp` (for `RenderPath` and `RenderPaint`) — read those for
 the full set.)
 
-## Wiring It Up
+## Wiring it up
 
 ```cpp
 class MyFactory : public rive::Factory { /* ... */ };
@@ -157,7 +157,7 @@ There's no `RenderContext` in this path — your `Renderer` is responsible
 for making the GPU calls (or buffering them, or counting them, or whatever
 you want).
 
-## Reference Implementations
+## Reference implementations
 
 All paths below are in the [rive-runtime](https://github.com/rive-app/rive-runtime) repo.
 

--- a/runtimes/cpp/file-and-artboard.mdx
+++ b/runtimes/cpp/file-and-artboard.mdx
@@ -8,7 +8,7 @@ A Rive `.riv` file is a binary container of **artboards**, **animations**,
 read-only access to that container (`File`, `Artboard`) and mutable instances
 you can advance and draw (`ArtboardInstance`, `StateMachineInstance`).
 
-## Importing a File
+## Importing a file
 
 ```cpp
 #include "rive/file.hpp"
@@ -125,7 +125,7 @@ sm->advanceAndApply(0.f);
 `Artboard::bounds()` returns the current 'rect' — feed it to `computeAlignment`
 to map artboard-space into your viewport.
 
-## File Lifetime
+## File lifetime
 
 Reference-counted ownership keeps lifetimes simple:
 

--- a/runtimes/cpp/getting-started.mdx
+++ b/runtimes/cpp/getting-started.mdx
@@ -19,7 +19,7 @@ This guide walks you through cloning the runtime, compiling it, and getting a
   latest version available — older toolchains may fail to compile the renderer.
 </Note>
 
-## 1. Clone and Build the Runtime
+## 1. Clone and build the runtime
 
 ```bash
 git clone https://github.com/rive-app/rive-runtime.git
@@ -52,7 +52,7 @@ Build artifacts land in `out/release/` (or `out/debug/`). You'll link
 against `librive.a` (or `rive.lib` on Windows), plus the per-backend
 renderer libraries like `librive_pls_renderer.a`.
 
-## 2. Add Headers to Your Project
+## 2. Add headers to your project
 
 The public include roots are:
 
@@ -76,7 +76,7 @@ target_link_libraries(my_app PRIVATE
 )
 ```
 
-## 3. Load a `.riv` File
+## 3. Load a `.riv` file
 
 ```cpp
 #include "rive/file.hpp"
@@ -116,7 +116,7 @@ if (!sm && artboard->stateMachineCount() > 0) {
 }
 ```
 
-## 5. Advance and Draw
+## 5. Advance and draw
 
 A render loop has three phases each frame: **advance**, **draw**, **flush**.
 
@@ -155,7 +155,7 @@ void renderFrame(float dt) {
   [Rendering Loop](/runtimes/cpp/rendering-loop).
 </Tip>
 
-## 6. Forward Input
+## 6. Forward input
 
 Route pointer events back through the state machine so
 listeners and hit-testing work:
@@ -177,7 +177,7 @@ sm->pointerDown(toArtboard(mouseX, mouseY));
 sm->pointerUp(toArtboard(mouseX, mouseY));
 ```
 
-## What's Next
+## What's next
 
 <CardGroup cols={2}>
   <Card title="Renderers" icon="microchip" href="/runtimes/cpp/renderers">

--- a/runtimes/cpp/overview.mdx
+++ b/runtimes/cpp/overview.mdx
@@ -46,7 +46,7 @@ Use the C++ runtime when you are:
   </Card>
 </CardGroup>
 
-## Architecture at a Glance
+## Architecture at a glance
 
 ![Rive runtime rendering pipeline: your application owns a File (.riv data) and a RenderContext (D3D/Metal/Vulkan/...); File produces an ArtboardInstance, which produces a StateMachineInstance, which feeds the RiveRenderer along with the RenderContext to produce pixels.](/images/runtimes/cpp/rive_pipeline.png)
 
@@ -55,7 +55,7 @@ and `Renderer` / `RenderContext` know nothing about Rive content. Either
 half works on its own — render Rive content through your own `Renderer`
 implementation, or drive `RiveRenderer` with non-Rive draw commands.
 
-## Supported Platforms & APIs
+## Supported platforms & APIs
 
 | Backend | Headers                                            | Class                  |
 | ------- | -------------------------------------------------- | ---------------------- |
@@ -71,7 +71,7 @@ implementation, or drive `RiveRenderer` with non-Rive draw commands.
   platforms ship a thin wrapper, not a separate engine.
 </Note>
 
-## Source & License
+## Source & license
 
 - GitHub: [rive-app/rive-runtime](https://github.com/rive-app/rive-runtime)
 - License: MIT

--- a/runtimes/cpp/renderers.mdx
+++ b/runtimes/cpp/renderers.mdx
@@ -183,7 +183,7 @@ hand it to your render loop, and the rest of the C++ API stays identical.
   </Tab>
 </Tabs>
 
-## Picking Modes per Frame
+## Picking modes per frame
 
 `RenderContext::FrameDescriptor` carries flags that change the rendering
 algorithm:
@@ -199,7 +199,7 @@ algorithm:
 Most apps leave these at defaults. Override only when you see a specific issue
 on a specific GPU.
 
-## Choosing a Backend
+## Choosing a backend
 
 | Platform | Recommendation |
 | -------- | -------------- |

--- a/runtimes/cpp/rendering-loop.mdx
+++ b/runtimes/cpp/rendering-loop.mdx
@@ -64,7 +64,7 @@ On D3D12, Vulkan, and Metal you must update `currentFrameNumber` and
 renderer can't safely recycle staging buffers and you'll either see
 overwrites mid-flight or unbounded memory growth.
 
-## Fixed-Timestep Accumulator
+## Fixed-timestep accumulator
 
 State machines and animations are deterministic at fixed `dt`s. Wrap your
 real-elapsed-time delta in an accumulator so playback is reproducible across
@@ -88,7 +88,7 @@ void tick(float realDt) {
 The cap (`kMaxFrameDt`) prevents catch-up storms after the app gets paused
 in a debugger or backgrounded by the OS.
 
-## Resize Handling
+## Resize handling
 
 Three things have to happen on a resize:
 
@@ -139,7 +139,7 @@ Vec2D pt = align.invertOrIdentity() * Vec2D{(float)mx, (float)my};
 sm->pointerMove(pt);
 ```
 
-## When to Skip a Frame
+## When to skip a frame
 
 `advanceAndApply` returns `true` if the state machine has more work; `false` if
 everything has settled. For animations that have looped to rest, you can
@@ -149,7 +149,7 @@ zero between user inputs.
 Pointer events and external view-model writes can wake the state machine back up —
 re-draw at least once after each.
 
-## Tear-Down
+## Tear-down
 
 ```cpp
 sm.reset();

--- a/runtimes/cpp/state-machines.mdx
+++ b/runtimes/cpp/state-machines.mdx
@@ -41,7 +41,7 @@ frame should re-draw. `false` means everything has settled.
   across frame rates. See [Rendering Loop](/runtimes/cpp/rendering-loop).
 </Tip>
 
-### Forcing a Layout Pass
+### Forcing a Layout pass
 
 Pass `dt = 0` to re-solve layout without advancing time. Useful right after
 resizing the window or changing the artboard's `width()` / `height()`:
@@ -52,7 +52,7 @@ artboard->height(newHeight);
 sm->advanceAndApply(0.f);
 ```
 
-## Pointer Events
+## Pointer events
 
 A state machine listens for pointer events on `Listener` components placed
 in the editor. Map your window-space coordinates into **artboard-local**
@@ -87,7 +87,7 @@ same event to other UI behind Rive:
 - `hitOpaque` — a listener fired and the shape is opaque. Rive consumed
   the event; don't forward.
 
-## Reading State Changes
+## Reading state changes
 
 After each `advanceAndApply` you can introspect what happened on a
 `StateMachineInstance`. Call directly on your `StateMachineInstance`:

--- a/runtimes/flutter/alternative-widget-setup.mdx
+++ b/runtimes/flutter/alternative-widget-setup.mdx
@@ -6,7 +6,7 @@ description: 'Techniques and considerations to cache a Rive File in Flutter.'
 
 The easiest way to integrate Rive animations and state machines into your application is via the `RiveAnimation` widget mentioned throughout the runtime help docs. However, there are cases where you may want to set up animation or state machine controllers associated with the Rive widget before the Artboard is rendered. Check out below for other ways to integrate Rive into your Flutter applications:
 
-## Alternative Methods
+## Alternative methods
 
 ### File loading
 
@@ -89,7 +89,7 @@ If you want to load in the `.riv` file from the `rootBundle`, you'll need to imp
   </Step>
 </Steps>
 
-### Complete Example
+### Complete example
 
 Altogether, this pattern might look like the following snippet below:
 

--- a/runtimes/flutter/caching-a-rive-file.mdx
+++ b/runtimes/flutter/caching-a-rive-file.mdx
@@ -7,7 +7,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
 
-## Example Usage
+## Example usage
 
 In Flutter, you are responsible for managing the lifecycle of a Rive file. You can create a `File` object directly, or use the `FileLoader` convenience class with `RiveWidgetBuilder`. In both cases, you must call `dispose()` on the object when it's no longer needed to free up memory.
 
@@ -84,7 +84,7 @@ To optimize memory usage, reuse the same `File` object across multiple `RiveWidg
 After a `File` is disposed, it cannot be used again. To use the same `.riv` file, create a new `File` object.
 </Warning>
 
-#### Managing State
+#### Managing state
 
 How you keep the Rive `File` alive and share it with widgets depends on your state management approach. For global access, load the file in `main` or during app startup, and expose it using a package like [Provider](https://pub.dev/packages/provider). If the file is only needed in a specific part of your app, consider loading the file only when required.
 
@@ -92,6 +92,6 @@ How you keep the Rive `File` alive and share it with widgets depends on your sta
 
 Managing the file yourself gives you fine-grained control over memory usage, especially when the same Rive file is used in multiple places or simultaneously in several widgets. Use [Flutter DevTools memory tooling](https://docs.flutter.dev/tools/devtools/memory#memory-view-guide) to monitor and optimize memory if needed.
 
-#### Network Assets
+#### Network assets
 
 To load a Rive file from the Internet, use `File.url('YOUR:URL')`. For network assets, cache the file in memory to avoid repeated downloads and unnecessary decoding of the file.

--- a/runtimes/flutter/custom-painter.mdx
+++ b/runtimes/flutter/custom-painter.mdx
@@ -16,7 +16,7 @@ The [Flame game engine](https://docs.flame-engine.org/latest/) makes use of the 
  **Note that this is a low-level API, and under most circumstances, it is preferable to make use of the**`RiveAnimation` **or** `Rive` **widgets instead.**
 </Note>
 
-### Example Code 
+### Example code
 
 The following is a complete example demonstrating how to manually advance a single artboard and draw it multiple times in a grid to the same Flutter canvas.
 
@@ -304,7 +304,7 @@ The important steps are:
 
 The rest of the code is responsible for layout and sizing.
 
-### Other Examples
+### Other examples
 
 In this example a single artboard is used, however, it's possible to draw multiple artboard instances (from the same or different Rive file) to the same canvas.
 

--- a/runtimes/flutter/custom-rive-renderobject.mdx
+++ b/runtimes/flutter/custom-rive-renderobject.mdx
@@ -9,7 +9,7 @@ It is possible to have finer control over your Rive animation at runtime by exte
  Note that this is a low-level API, and under most circumstances, it is preferable to make use of `RiveAnimation` or `Rive` widgets instead.
 </Note>
 
-### Example Code
+### Example code
 
 The following is a basic example that demonstrates how to paint a Rive animation and advance a state machine using a custom [RenderObject](https://api.flutter.dev/flutter/rendering/RenderObject-class.html).
 
@@ -145,12 +145,12 @@ class CustomRiveRenderObject extends RiveRenderObject {
 
 The artboard can be controlled and configured as it normally would, through a `StateMachineController` (or any other animation controller).
 
-### Example Usage 
+### Example usage
 
 - [Dynamically update component colors at runtime](https://github.com/HayesGordon/rive_flutter_runtime_color_change_example) - Make use of a custom Rive render object to change a shape's fill color, accessing it by name. This is helpful for when a color's opacity is animating, but the color needs to be changed at runtime.
 - [Track a Rive component in Flutter](https://github.com/luigi-rosso/rive_flutter_painting_context/) - Track a Rive component’s position at runtime and overlay a Flutter widget or perform additional painting operations.
 
-### Additional Documentation 
+### Additional documentation
 
 For additional information on RenderObjects, see the official Flutter examples:
 

--- a/runtimes/flutter/data-binding.mdx
+++ b/runtimes/flutter/data-binding.mdx
@@ -374,7 +374,7 @@ Artboard properties work with the `BindableArtboard` class, which is different f
 print("Data enums: ${file.enums}");
 ```
 
-# Examples
+## Examples
 
     - [Data binding overview](https://github.com/rive-app/rive-flutter/blob/master/example/lib/examples/databinding.dart)
     - [Data binding images](https://github.com/rive-app/rive-flutter/blob/master/example/lib/examples/databinding_images.dart)

--- a/runtimes/flutter/flutter.mdx
+++ b/runtimes/flutter/flutter.mdx
@@ -483,7 +483,7 @@ When multiple `RiveWidget`s draw to the same shared texture - through a [RivePan
 `drawOrder` only applies when drawing to a shared texture with `Factory.rive`. When a widget owns its own texture, Flutter's normal paint order applies.
 </Note>
 
-### Render Resolution
+### Render resolution
 
 `Factory.rive` draws content into a backing texture. `RiveWidget.renderResolution` (default: `RenderResolution.display()`) controls how that texture is sized - the same way on every platform, including web. It changes backing resolution only; layout, fit, alignment, and hit testing are unaffected.
 
@@ -647,7 +647,7 @@ Some considerations when choosing a renderer:
 
 For more information see [Choosing a Renderer](/runtimes/choose-a-renderer/).
 
-### Note on Flutter Rendering
+### Note on Flutter rendering
 
 [Impeller](https://docs.flutter.dev/perf/impeller) is replacing [Skia](https://skia.org/) to become the default renderer for all platforms. As such, there is a possibility of rendering and [performance](https://github.com/flutter/flutter/issues/134432) discrepancies when using the Rive Flutter runtime with platforms that use the Impeller renderer that may not have surfaced before. If you encounter any visual or performance errors at runtime compared to expected behavior in the Rive editor, we recommend trying the following steps to triage:
 
@@ -679,7 +679,7 @@ If you encounter build errors related to Rive, ensure that:
 
 If you're still having issues, please see the [Troubleshooting section](/runtimes/flutter/rive-native#troubleshooting) in the Rive Native documentation.
 
-## Manually building Rive native libraries
+## Manually building Rive Native libraries
 
 Rive automatically downloads the native libraries for you as part of the `rive_native` plugin.
 

--- a/runtimes/flutter/fonts.mdx
+++ b/runtimes/flutter/fonts.mdx
@@ -10,7 +10,7 @@ import fallbackFontsUnsupported from "/snippets/runtimes/fonts/fallback-fonts-un
 
 For more information, see [Loading Assets](/runtimes/flutter/loading-assets).
 
-## Fallback Fonts
+## Fallback fonts
 
 Fallback fonts are **not yet supported in Flutter**.
 

--- a/runtimes/flutter/migration-guide.mdx
+++ b/runtimes/flutter/migration-guide.mdx
@@ -9,7 +9,7 @@ This is a significant update for Rive Flutter. We've completely removed all of t
 
 This has resulted in a number of changes to the underlying API, and a large portion of the code base that was previously accessible through Dart is now implemented in C++ through FFI.
 
-### What's New in 0.14.0
+### What's new in 0.14.0
 
 This release of Rive Flutter adds support for:
 
@@ -33,7 +33,7 @@ Now that Rive Flutter makes use of the core Rive C++ runtime, you can expect new
 
 ### Requirements
 
-#### Dart and Flutter Versions
+#### Dart and Flutter versions
 
 This release bumps to these versions:
 
@@ -42,7 +42,7 @@ sdk: ">=3.5.0 <4.0.0"
 flutter: ">=3.3.0"
 ```
 
-#### Required Setup
+#### Required setup
 
 **Important:** You must call `RiveNative.init` at the start of your app, or before you use Rive. For example, in `main.dart`:
 
@@ -56,9 +56,9 @@ Future<void> main() async {
 }
 ```
 
-### Migration Guide
+### Migration guide
 
-#### Quick Migration Checklist
+#### Quick migration checklist
 
 1. ✅ Update your `pubspec.yaml` dependencies to use version `0.14.0` or later
    ```yaml
@@ -71,7 +71,7 @@ Future<void> main() async {
 5. ✅ Review and update any custom asset loading code
 6. ✅ Test your graphics and interactions
 
-#### Removed Classes
+#### Removed classes
 
 The following classes have been completely removed:
 
@@ -85,7 +85,7 @@ The following classes have been completely removed:
 - `SMINumber` → Replaced with `NumberInput`
 - `FileAssetLoader` → Replaced with optional callback when creating a `File`
 
-#### Loading Rive Files
+#### Loading Rive files
 
 `RiveFile` has been removed and replaced with `File`. Important changes:
 
@@ -119,7 +119,7 @@ The provided `Factory` determines the renderer that will be used. Use `Factory.r
 - Replace `RiveFile.network` with `File.url`
 - Replace `RiveFile.file` with `File.path`
 
-#### Widget Migration
+#### Widget migration
 
 See the updated example app for a complete migration guide, including how to use the new `RiveWidget` and `RiveWidgetBuilder` APIs.
 
@@ -250,7 +250,7 @@ See the updated example app for a complete migration guide, including how to use
 
 </Tabs>
 
-#### Controller Migration
+#### Controller migration
 
 | Old Controller                           | New Controller           | Notes                       |
 | ---------------------------------------- | ------------------------ | --------------------------- |
@@ -278,7 +278,7 @@ final controller = RiveWidgetController(
 );
 ```
 
-#### Playing Animations
+#### Playing animations
 
 <Warning>
   This functionality is deprecated. We strongly encourage playing and blending
@@ -357,7 +357,7 @@ class _ExampleSingleAnimationPainterState
   advance multiple animations.
 </Note>
 
-#### Handling State Machine Inputs
+#### Handling State Machine inputs
 
 <Tip>
   Consider using [Data Binding](/editor/data-binding/overview) for more advanced
@@ -462,7 +462,7 @@ event.booleanProperty(name);    // Returns a CustomBooleanProperty
 event.stringProperty(name);     // Returns a CustomStringProperty
 ```
 
-#### Layout Changes
+#### Layout changes
 
 ##### BoxFit → Fit
 
@@ -477,7 +477,7 @@ Fit.contain
 Fit.layout  // New option for layout-based fitting
 ```
 
-#### Asset Loading Changes
+#### Asset loading changes
 
 The `FileAssetLoader` class and all its subclasses have been removed:
 
@@ -486,7 +486,7 @@ The `FileAssetLoader` class and all its subclasses have been removed:
 - `CallbackAssetLoader`
 - `FallbackAssetLoader`
 
-##### Out-of-band Asset Loading
+##### Out-of-band asset loading
 
 <Tabs>
   <Tab title="New API">
@@ -576,7 +576,7 @@ The `FileAssetLoader` class and all its subclasses have been removed:
 - `FontAsset.font = value` → `FontAsset.font(value)` (returns boolean)
 - `AudioAsset.audio = value` → `AudioAsset.audio(value)` (returns boolean)
 
-#### Text Run Updates
+#### Text Run updates
 
 <Tip>
   We recommend using [Data Binding](/editor/data-binding/overview) instead to
@@ -598,7 +598,7 @@ artboard.setText('textRunName', 'new value')
 artboard.setText('textRunName', 'new value', path: 'nested/path')
 ```
 
-### Known Missing Features
+### Known missing features
 
 These features are not available in `v0.14.0` but may be added in future releases:
 
@@ -609,7 +609,7 @@ These features are not available in `v0.14.0` but may be added in future release
 - `isTouchScrollEnabled`
 - `dynamicLibraryHelper`
 
-### Removed Code Paths
+### Removed code paths
 
 All of the "runtime" Dart code has been removed from these paths:
 
@@ -619,7 +619,7 @@ All of the "runtime" Dart code has been removed from these paths:
 - `rive_core`
 - `utilities`
 
-### Getting Help
+### Getting help
 
 If you encounter issues during migration:
 

--- a/runtimes/flutter/rive-native.mdx
+++ b/runtimes/flutter/rive-native.mdx
@@ -37,7 +37,7 @@ Rive Native acts as the bridge between Flutter and the Rive C++ runtime, allowin
 
 ---
 
-## Getting Started
+## Getting started
 
 `rive_native` is not yet publicly available on GitHub but will be soon. For now, you can pull the source code and example by running:
 
@@ -53,7 +53,7 @@ For an example implementation, see the `rive_player.dart` file in `rive_native/e
 
 ---
 
-## Platform Support
+## Platform support
 
 | Platform | Flutter Renderer | Rive Renderer |
 | -------- | ---------------- | ------------- |
@@ -71,7 +71,7 @@ For an example implementation, see the `rive_player.dart` file in `rive_native/e
 
 ---
 
-## Feature Support
+## Feature support
 
 See the [Feature Support page](/feature-support) for details.
 
@@ -118,7 +118,7 @@ dart run rive_native:setup --verbose --clean --build --platform macos
 
 A successful build leaves a `rive_marker_<platform>_development` file in the package, so subsequent `flutter run` and `flutter build` calls use your locally built libraries instead of downloading prebuilts. Without `--clean`, setup does nothing once this marker exists.
 
-### Build Requirements
+### Build requirements
 
 All platforms:
 
@@ -132,7 +132,7 @@ Per platform:
 - **Windows**: Visual Studio 2022 (**Desktop development with C++** workload) with `msbuild.exe` on `PATH` (for example, run from a Visual Studio developer prompt), Git Bash, and `make` (`choco install make`).
 - **Linux**: `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `uuid-dev`, `libstdc++-12-dev`, and `libvulkan-dev` (apt package names).
 
-### Returning to Prebuilt Libraries
+### Returning to prebuilt libraries
 
 Run the setup script without `--build` - `--clean` removes the built libraries and marker files, and prebuilts are downloaded again:
 

--- a/runtimes/flutter/state-machines.mdx
+++ b/runtimes/flutter/state-machines.mdx
@@ -15,7 +15,7 @@ import PlayingStateMachines from "/snippets/runtimes/state-machines/playing-stat
 
 There are a number of ways to play/select a state machine in Flutter.
 
-#### When Using `RiveWidgetController` (Recommended)
+#### When using `RiveWidgetController` (recommended)
 
 When you create a `RiveWidgetController` it will use the default state machine, or you can specify a state machine by name or index.
 
@@ -62,7 +62,7 @@ return RiveWidgetBuilder(
 );
 ```
 
-#### When Using `StateMachinePainter`
+#### When using `StateMachinePainter`
 
 When using `StateMachinePainter`, you can specify the state machine to use by passing an optional name.
 ```dart
@@ -75,7 +75,7 @@ painter = rive.StateMachinePainter(
 );
 ```
 
-#### Creating a State Machine Directly
+#### Creating a State Machine directly
 
 Create the state machine directly from an `Artboard`:
 

--- a/runtimes/react-native/adding-rive-to-expo.mdx
+++ b/runtimes/react-native/adding-rive-to-expo.mdx
@@ -14,7 +14,7 @@ Because this package contains custom native code, it's not compatible with Expo 
 
 This guide will walk you through integrating Rive into your Expo project, including installing dependencies, configuring your build, and testing your graphics.
 
-## Initial Setup
+## Initial setup
 
 If you don’t already have a project, create a new Expo app:
 
@@ -81,7 +81,7 @@ npx expo install rive-react-native
   After updating, run `npx expo prebuild --clean` and rebuild your app.
 </Accordion>
 
-## iOS Minimum Version
+## iOS minimum version
 
 <Tabs>
   <Tab title="New Runtime (Recommended)">
@@ -91,7 +91,7 @@ If you’re using Expo SDK 52 or later, it already requires `15.1` or later.
 
 If you're using an older SDK, you’ll need to update your iOS deployment target manually or via configuration.
 
-### Option 1: Using `expo-build-properties` (Recommended)
+### Option 1: using `expo-build-properties` (recommended)
 
     [Continuous Native Generation (CNG)](https://docs.expo.dev/workflow/continuous-native-generation/) simplifies app maintenance and configuration by automatically generating your iOS and Android native projects using [Prebuild](https://docs.expo.dev/workflow/continuous-native-generation/#usage).
 
@@ -114,7 +114,7 @@ If you're using an older SDK, you’ll need to update your iOS deployment target
 }
 ```
 
-### Option 2: Manual Configuration
+### Option 2: manual configuration
 
 If you’re not using Prebuild, update the target directly in your `ios/Podfile`:
 
@@ -164,13 +164,13 @@ platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
   </Tab>
 </Tabs>
 
-## Creating a Development Build
+## Creating a development build
 
 To run your app with the Rive runtime, you’ll need to create a development build.
 
 Since there are several ways to do this, refer to the [Expo development builds guide](https://docs.expo.dev/develop/development-builds/create-a-build/) to choose the method that best suits your needs.
 
-## Running Your App
+## Running your app
 
 Once you've created a development build and installed it on your device or simulator, start your app with:
 
@@ -256,7 +256,7 @@ You can use the following component to test Rive:
   </Tab>
 </Tabs>
 
-## Adding Local Assets
+## Adding local assets
 
 The example above loads a `.riv` file from a remote URL.
 To use local `.riv` files, they must be bundled into your native build.

--- a/runtimes/react-native/caching-a-rive-file.mdx
+++ b/runtimes/react-native/caching-a-rive-file.mdx
@@ -7,7 +7,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
 
-## Example Usage
+## Example usage
 
 <Tabs>
     <Tab title="New Runtime (Recommended)">

--- a/runtimes/react-native/data-binding.mdx
+++ b/runtimes/react-native/data-binding.mdx
@@ -830,7 +830,7 @@ import { Demos } from "/snippets/demos.jsx";
     </Tab>
 </Tabs>
 
-# Examples
+## Examples
 
 <Tabs>
     <Tab title="New Runtime (Recommended)">

--- a/runtimes/react-native/error-handling.mdx
+++ b/runtimes/react-native/error-handling.mdx
@@ -3,7 +3,7 @@ title: "Error Handling"
 description: "Handling errors in Rive React Native"
 ---
 
-## Error Handling
+## Error handling
 
 <Note>
   This page only applies to the [new
@@ -25,7 +25,7 @@ try {
 }
 ```
 
-### View-Based Errors
+### View-based errors
 
 Use the `onError` callback prop to handle errors during view configuration or runtime operations:
 
@@ -40,7 +40,7 @@ Use the `onError` callback prop to handle errors during view configuration or ru
 />
 ```
 
-#### Error Types
+#### Error types
 
 The following error types may occur during view operations:
 
@@ -89,7 +89,7 @@ import { RiveView, RiveErrorType } from "@rive-app/react-native";
   default.
 </Note>
 
-### Android Runtime Initialization
+### Android runtime initialization
 
 On Android, the Rive native library is automatically initialized at app startup. In rare cases (ABI mismatch, missing native libraries, etc.), this initialization can fail. Use `RiveRuntime.getStatus()` to check whether initialization succeeded:
 

--- a/runtimes/react-native/loading-rive-files.mdx
+++ b/runtimes/react-native/loading-rive-files.mdx
@@ -14,7 +14,7 @@ description: "How to use Rive files with the Rive React Native runtime. "
 
     All loading methods use the `useRiveFile` hook, which returns a `RiveFile` object that you pass to the `RiveView` component via the `file` prop.
 
-### Option 1: Using `require()` (Recommended)
+### Option 1: using `require()` (recommended)
 
     <Note>
       Loading Rive files using `require()` is recommended because it doesn't require a native rebuild when you update the Rive file. During development, files loaded with `require()` are served by the Metro development server. When you build your app, the file is automatically bundled into the app's assets. With Expo, this also enables Over The Air (OTA) updates.

--- a/runtimes/react-native/migration-guide.mdx
+++ b/runtimes/react-native/migration-guide.mdx
@@ -61,7 +61,7 @@ The deprecated synchronous APIs (and the state machine input, text run, and even
 
 This release introduces async view model instance creation and deprecates the synchronous creation path.
 
-### `useViewModelInstance` Gains `async: true` and `isLoading`
+### `useViewModelInstance` gains `async: true` and `isLoading`
 
 Pass `async: true` to opt in to asynchronous instance creation. The flag signals that your component handles the loading state: the result now includes `isLoading`, and the instance is not available on the first render — gate rendering on it. This prepares your code for the new runtime implementation, where creating an instance is an asynchronous operation.
 
@@ -99,16 +99,16 @@ Pass `async: true` to opt in to asynchronous instance creation. The flag signals
 
 `async` must stay constant for the lifetime of the component — remount (e.g. change `key`) to switch modes.
 
-### `useRive` Ref Starts `undefined`
+### `useRive` ref starts `undefined`
 
 `useRive().riveViewRef` starts as `undefined` (view pending) instead of `null` (failed/detached), mirroring the `useRiveFile` convention. Code using `riveViewRef === null` as a "not ready yet" check should use `riveViewRef == null` or optional chaining instead.
 
-### Other Changes
+### Other changes
 
 - On the synchronous (deprecated) path, a `null` source now settles to a terminal `{ instance: null, isLoading: false }` instead of reporting a loading state indefinitely.
 - On Android, reading the auto-bound instance from a view ref right after mount can briefly resolve `null` while binding completes. The `async: true` path waits for the instance; one-shot reads via the deprecated sync path should be avoided.
 
-### Quick Reference
+### Quick reference
 
 | Previous | Replacement |
 |---|---|
@@ -121,7 +121,7 @@ Pass `async: true` to opt in to asynchronous instance creation. The flag signals
 
 This release improves error transparency and loading semantics for hooks, preparing for the async experimental runtime.
 
-### `useViewModelInstance` Returns `{ instance, error }`
+### `useViewModelInstance` returns `{ instance, error }`
 
 The hook now returns a discriminated union instead of `ViewModelInstance | null`:
 
@@ -154,7 +154,7 @@ The hook now returns a discriminated union instead of `ViewModelInstance | null`
   </Tab>
 </Tabs>
 
-### `useRiveFile` Error Is Now `Error`
+### `useRiveFile` error is now `Error`
 
 The `error` field is now an `Error` object instead of a `string`, and `riveFile` is `undefined` while loading (was `null`). `isLoading` is kept for convenience.
 
@@ -177,7 +177,7 @@ The `error` field is now an `Error` object instead of a `string`, and `riveFile`
   </Tab>
 </Tabs>
 
-### Property Hooks Start `undefined`
+### Property hooks start `undefined`
 
 `useRiveNumber`, `useRiveString`, `useRiveBoolean`, `useRiveColor`, and `useRiveEnum` no longer read `property.value` synchronously on mount. The value starts as `undefined` and arrives via the property listener.
 
@@ -191,7 +191,7 @@ const { value: health } = useRiveNumber('health', instance);
 setHealth((prev) => (prev ?? 0) + 1);
 ```
 
-### Quick Reference
+### Quick reference
 
 | Previous | Replacement |
 |---|---|
@@ -206,16 +206,16 @@ setHealth((prev) => (prev ?? 0) + 1);
 
 This release introduces an **async-first API** to prepare for the new experimental Rive runtime. Synchronous methods that block the JS thread are deprecated and replaced with async equivalents. State machine input and text run methods are deprecated in favor of [data binding](/runtimes/data-binding) and will be removed entirely in the experimental runtime (and therefore in upcoming `@rive-app/react-native` versions).
 
-### What's Changed
+### What's changed
 
 - **Async methods** replace all synchronous ViewModel and property accessors
 - **Name-based access** replaces count/index-based ViewModel and artboard lookups
 - **`getValueAsync()` / `set()`** replace `property.value` for reading and writing properties
 - **State machine inputs, text runs, and events** are deprecated and will be removed in the experimental runtime — use [data binding](/runtimes/data-binding) instead
 
-### Migration Steps
+### Migration steps
 
-#### 1. ViewModel Access
+#### 1. ViewModel access
 
 <Tabs>
   <Tab title="New API">
@@ -236,7 +236,7 @@ This release introduces an **async-first API** to prepare for the new experiment
   </Tab>
 </Tabs>
 
-#### 2. Instance Creation
+#### 2. Instance creation
 
 <Tabs>
   <Tab title="New API">
@@ -263,7 +263,7 @@ This release introduces an **async-first API** to prepare for the new experiment
   directly.
 </Tip>
 
-#### 3. Property Value Access
+#### 3. Property value access
 
 <Tabs>
   <Tab title="New API">
@@ -282,7 +282,7 @@ This release introduces an **async-first API** to prepare for the new experiment
   </Tab>
 </Tabs>
 
-#### 4. Nested ViewModelInstance Access
+#### 4. Nested ViewModelInstance access
 
 <Tabs>
   <Tab title="New API">
@@ -299,7 +299,7 @@ This release introduces an **async-first API** to prepare for the new experiment
   </Tab>
 </Tabs>
 
-#### 5. List Property Access
+#### 5. List property access
 
 <Tabs>
   <Tab title="New API">
@@ -318,7 +318,7 @@ This release introduces an **async-first API** to prepare for the new experiment
   </Tab>
 </Tabs>
 
-#### 6. Artboard Access
+#### 6. Artboard access
 
 <Tabs>
   <Tab title="New API">
@@ -337,7 +337,7 @@ This release introduces an **async-first API** to prepare for the new experiment
   </Tab>
 </Tabs>
 
-#### 7. Async Setup Pattern
+#### 7. Async setup pattern
 
 Synchronous `useMemo` chains for ViewModel setup should be replaced with `useState` + `useEffect`, or simplified with the `useViewModelInstance` hook.
 
@@ -391,7 +391,7 @@ Synchronous `useMemo` chains for ViewModel setup should be replaced with `useSta
   </Tab>
 </Tabs>
 
-### Quick Reference
+### Quick reference
 
 | Deprecated | Replacement |
 |---|---|
@@ -414,7 +414,7 @@ Synchronous `useMemo` chains for ViewModel setup should be replaced with `useSta
 | `prop.value` (read) | `await prop.getValueAsync()` |
 | `prop.value = x` (write) | `prop.set(x)` |
 
-### Platform Caveats
+### Platform caveats
 
 | Limitation | Details |
 |---|---|
@@ -439,7 +439,7 @@ The new Rive React Native runtime (`@rive-app/react-native`) is a complete rewri
   before.
 </Note>
 
-### What's New
+### What's new
 
 **RiveFile Ownership:** You now own the `RiveFile` object via the `useRiveFile` hook, enabling file caching, multiple instances from one file, and better resource management.
 
@@ -481,7 +481,7 @@ Error handling is improved. See the [error handling](/runtimes/react-native/erro
 - **JDK**: 17+
 - **Nitro Modules**: 0.25.2+
 
-### Migration Steps
+### Migration steps
 
 #### 1. Installation
 
@@ -495,7 +495,7 @@ npm install @rive-app/react-native react-native-nitro-modules
   Modules](https://nitro.margelo.com/).
 </Note>
 
-#### 2. Update Imports
+#### 2. Update imports
 
 ```tsx
 // Old
@@ -505,7 +505,7 @@ import Rive from "rive-react-native";
 import { RiveView } from "@rive-app/react-native";
 ```
 
-#### 3. Loading Rive Files
+#### 3. Loading Rive files
 
 <Tabs>
   <Tab title="New Runtime">
@@ -528,7 +528,7 @@ import { RiveView } from "@rive-app/react-native";
 
 See [loading Rive files](/runtimes/react-native/loading-rive-files) for more information.
 
-#### 4. Component Migration
+#### 4. Component migration
 
 <Tabs>
   <Tab title="New Runtime">
@@ -561,7 +561,7 @@ See [loading Rive files](/runtimes/react-native/loading-rive-files) for more inf
 
 See [React Native runtime](/runtimes/react-native) and [props](/runtimes/react-native/props) documentation for more information.
 
-#### 5. View Reference Migration
+#### 5. View reference migration
 
 <Tabs>
   <Tab title="New Runtime">
@@ -590,7 +590,7 @@ See [React Native runtime](/runtimes/react-native) and [props](/runtimes/react-n
 
 See [Rive ref methods](/runtimes/react-native/rive-ref-methods) for more information.
 
-#### 6. State Machine Inputs (Deprecated)
+#### 6. State Machine inputs (deprecated)
 
 <Warning>
   These methods are deprecated. Migrate to [data binding](#8-data-binding)
@@ -618,7 +618,7 @@ See [Rive ref methods](/runtimes/react-native/rive-ref-methods) for more informa
 
 See [state machine inputs](/runtimes/react-native/inputs) for more information.
 
-#### 7. Rive Events (Deprecated)
+#### 7. Rive Events (deprecated)
 
 <Warning>
   These methods are deprecated. Use [data binding triggers](#8-data-binding)
@@ -696,7 +696,7 @@ Main API changes:
 
 See [react-native/data binding](/runtimes/react-native/data-binding) for more information.
 
-#### 9. Out of Band Assets
+#### 9. Out of band assets
 
 <Tabs>
   <Tab title="New Runtime">
@@ -734,7 +734,7 @@ See [react-native/data binding](/runtimes/react-native/data-binding) for more in
 
 See [loading assets](/runtimes/react-native/loading-assets) for more information.
 
-#### 10. Text Run Updates (Deprecated)
+#### 10. Text Run updates (deprecated)
 
 <Warning>
   Direct text run methods (`.setTextRunValue()`, `.getTextRunValue()`) are
@@ -799,7 +799,7 @@ See [text runs](/runtimes/react-native/text) for more information.
 
 See [data binding](/runtimes/react-native/data-binding) for more information.
 
-### Getting Help
+### Getting help
 
 If you encounter issues:
 

--- a/runtimes/react-native/native-version-customization.mdx
+++ b/runtimes/react-native/native-version-customization.mdx
@@ -12,7 +12,7 @@ This section is for advanced users who need to use specific versions of the Rive
 
 </Warning>
 
-### Default Behavior
+### Default behavior
 
 By default, Rive React Native uses the native SDK versions specified in `package.json`:
 
@@ -25,13 +25,13 @@ By default, Rive React Native uses the native SDK versions specified in `package
 
 These versions are tested and known to work well with this version of Rive React Native.
 
-### Customizing Versions
+### Customizing versions
 
 You can override these default versions using platform-specific configuration files.
 
 See the available native Rive [Android](https://github.com/rive-app/rive-android/releases) and [iOS](https://github.com/rive-app/rive-ios/releases) versions.
 
-#### iOS (Vanilla React Native)
+#### iOS (vanilla React Native)
 
 Create or edit `ios/Podfile.properties.json`:
 
@@ -47,7 +47,7 @@ Then run:
 cd ios && pod install
 ```
 
-#### Android (Vanilla React Native)
+#### Android (vanilla React Native)
 
 Add to `android/gradle.properties`:
 
@@ -55,7 +55,7 @@ Add to `android/gradle.properties`:
 Rive_RiveRuntimeAndroidVersion={{versionAndroid}}
 ```
 
-#### Expo Projects
+#### Expo projects
 
 For Expo projects, use config plugins in your `app.config.ts`:
 
@@ -83,7 +83,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 });
 ```
 
-### Version Resolution Priority
+### Version resolution priority
 
 The library resolves versions in the following order:
 

--- a/runtimes/react/animation-playback.mdx
+++ b/runtimes/react/animation-playback.mdx
@@ -32,7 +32,7 @@ export default function Simple() {
 
 <ControllingPlayback />
 
-#### Invoking Playback Controls
+#### Invoking playback controls
 
 Very similarly to Web, you can pass in Rive params and callbacks for certain animation events. See the Web tab for some examples of callbacks you can set. Additionally, you can use the `rive` object returned from the `useRive` hook to invoke playback controls.
 

--- a/runtimes/react/best-practices.mdx
+++ b/runtimes/react/best-practices.mdx
@@ -11,7 +11,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
   </Card>
 </CardGroup>
 
-## Avoiding Unnecessary Rerenders
+## Avoiding unnecessary rerenders
 
 When using useRive, keep the hook and its returned `<RiveComponent />` together in a dedicated wrapper component.
 

--- a/runtimes/react/caching-a-rive-file.mdx
+++ b/runtimes/react/caching-a-rive-file.mdx
@@ -8,7 +8,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
 
-## Example Usage
+## Example usage
 
 <Demos examples={["cachingARiveFile"]} runtime="react"/>
 

--- a/runtimes/react/data-binding.mdx
+++ b/runtimes/react/data-binding.mdx
@@ -597,6 +597,6 @@ const enums = rive?.enums();
 console.log(enums);
 ```
 
-# Examples
+## Examples
 
 See the `DataBinding` story in the [Rive React repo](https://github.com/rive-app/rive-react) for a demo.

--- a/runtimes/react/gpu-canvas.mdx
+++ b/runtimes/react/gpu-canvas.mdx
@@ -49,7 +49,7 @@ import Rive from '@rive-app/react-webgl2';
 
 GPU Canvas is disabled by default, but that may change in a future major version.
 
-## Enabling GPU Canvas on a Cached File
+## Enabling GPU Canvas on a cached file
 
 `useRiveFile` takes the same flag. A `RiveFile`'s rendering mode is fixed at creation, so changing `enableGPUCanvas` re-constructs the file:
 

--- a/runtimes/react/parameters-and-return-values.mdx
+++ b/runtimes/react/parameters-and-return-values.mdx
@@ -41,7 +41,7 @@ The following parameters are specific to `useRive`, or behave differently in Rea
 - `fitCanvasToArtboardHeight` - *(optional)* If `true`, then the canvas will resize based on the height of the artboard. Defaults to `false`
 - `useOffscreenRenderer` - *(optional)* If `true`, the Rive instance will share (or create if one does not exist) an offscreen `WebGL` context. This allows you to display multiple Rive animations on one screen to work around some browser limitations regarding multiple concurrent WebGL contexts. If `false`, each Rive instance will have its own dedicated `WebGL` context and you may need to be cautious of the browser limitations just mentioned. We recommend **not** changing this default prop, so you don't have to manage WebGL contexts. Destroying a React component does not guarantee the browser cleans up the WebGL context that was created when the canvas was mounted. Only relevant when using `@rive-app/react-webgl2`. Defaults to `true`, unless [GPU Canvas](/runtimes/react/gpu-canvas) is on, which flips the default to `false`. An explicit value always wins — setting `true` alongside `enableGPUCanvas` means GPU Canvas content will not draw
 
-#### Return Values
+#### Return values
 
 **RiveState**
 
@@ -77,7 +77,7 @@ The `useStateMachineInput` hook can be used to grab references to Rive State Mac
 - `inputName?` - *(optional)* Name of a single state machine input to grab a reference to
 - `initialValue?` - *(optional)* Initial value to set on the input
 
-#### Return Values
+#### Return values
 
 This hook returns a default instance of a `StateMachineInput`.
 

--- a/runtimes/react/react.mdx
+++ b/runtimes/react/react.mdx
@@ -17,7 +17,7 @@ There are three main ways to use Rive in a React app:
 
 <Demos examples={['reactHome']} />
 
-## Quick Start
+## Quick start
 
 <Steps>
   <Step title="Install the dependency">

--- a/runtimes/react/rive-events.mdx
+++ b/runtimes/react/rive-events.mdx
@@ -15,14 +15,14 @@ import AdditionalResources from "/snippets/runtimes/events/additional-resources.
 
 - [Star rating example](https://codesandbox.io/p/sandbox/rive-events-react-forked-ct9k2z?file=%2Fsrc%2FApp.js%3A6%2C44)
 
-### Adding an Event Listener
+### Adding an event listener
 
 Similar to the `addEventListener()` / `removeEventListener()` API for DOM elements, you'll use the Rive instance's `on()` / `off()` API to subscribe to Rive events from the `rive` object returned from the `useRive` hook. Simply supply the RiveEvent enum and a callback for the runtime to call at the appropriate moment any Rive event gets detected.
 
 <Note>
     **Note:** You must use the `useRive()` hook to subscribe to Rive events
 </Note>
-#### Example Usage
+#### Example usage
 
 ```javascript
 import { useRive, EventType, RiveEventType } from '@rive-app/canvas';

--- a/runtimes/react/semantics.mdx
+++ b/runtimes/react/semantics.mdx
@@ -37,7 +37,7 @@ export default function Login() {
 }
 ```
 
-### Labeling the Graphic
+### Labeling the graphic
 
 Use `semanticsOptions.riveCanvasLabel` to set an `aria-label` on the semantic overlay container describing what the graphic is, so screen reader users know what they are entering.
 
@@ -58,7 +58,7 @@ export default function Login() {
 }
 ```
 
-### Enabling Semantics After Load
+### Enabling semantics after load
 
 To control when semantics turn on, omit `semanticsMode` and call `enableSemantics()` on the `rive` instance returned by `useRive`.
 
@@ -84,7 +84,7 @@ export default function Login({ accessibilityEnabled }) {
 }
 ```
 
-## Overlay Positioning
+## Overlay positioning
 
 `RiveComponent` renders the `<canvas>` inside a container `<div>`. As described in [overlay positioning](/runtimes/web/semantics#semantic-overlay-positioning), the overlay aligns best when the canvas has a positioned ancestor. That `<div>` container is not positioned by default.
 

--- a/runtimes/react/state-machines.mdx
+++ b/runtimes/react/state-machines.mdx
@@ -30,7 +30,7 @@ export default function Simple() {
 }
 ```
 
-#### Controlling State Machine Playback
+#### Controlling State Machine playback
 
 You can manually play and pause the state machine using the `play`, `pause`, and `stop` methods.
 

--- a/runtimes/react/text.mdx
+++ b/runtimes/react/text.mdx
@@ -15,7 +15,7 @@ import Resources from "/snippets/runtimes/text/resources.mdx"
 
 - [Updating Text at Runtime - Localization example](https://codesandbox.io/p/sandbox/rive-text-react-38lt4k)
 
-#### Reading Text
+#### Reading text
 
 To read a given text run text value at any given time, reference the `.getTextRunValue()` API on the `rive` instance returned from `useRive`:
 
@@ -25,7 +25,7 @@ public getTextRunValue(textRunName: string): string | undefined
 
 Supply the text run name, and you'll have the Rive text run value returned, or `undefined` if the text run could not be queried.
 
-#### Setting Text
+#### Setting text
 
 To set a given text run value at any given time, reference the `.setTextRunValue()` API on the `rive` instance returned from `useRive`:
 
@@ -35,7 +35,7 @@ public setTextRunValue(textRunName: string, textRunValue: string): void
 
 Supply the text run name and a second parameter, `textValue`, with a String value that you want to set the new text value for if the text run can be successfully queried on the active artboard.
 
-#### Example Usage
+#### Example usage
 
 ```javascript
 import { useRive } from '@rive-app/canvas';
@@ -70,7 +70,7 @@ return (
 
 - [Updating Text at Runtime - Localization example](https://codesandbox.io/p/sandbox/rive-text-react-38lt4k)
 
-#### Reading Text
+#### Reading text
 
 To read a given text run text value at any given time, reference the `.getTextRunValue()` API on the `rive` instance returned from `useRive`:
 
@@ -80,7 +80,7 @@ public getTextRunValue(textRunName: string): string | undefined
 
 Supply the text run name, and you'll have the Rive text run value returned, or `undefined` if the text run could not be queried.
 
-#### Setting Text
+#### Setting text
 
 To set a given text run value at any given time, reference the `.setTextRunValue()` API on the `rive` instance returned from `useRive`:
 
@@ -90,7 +90,7 @@ public setTextRunValue(textRunName: string, textRunValue: string): void
 
 Supply the text run name and a second parameter, `textValue`, with a String value that you want to set the new text value for if the text run can be successfully queried on the active artboard.
 
-#### Example Usage
+#### Example usage
 
 ```javascript
 import { useRive } from '@rive-app/canvas';

--- a/runtimes/runtime-sizes.mdx
+++ b/runtimes/runtime-sizes.mdx
@@ -70,7 +70,7 @@ description: "Last updated: January 2026"
   </Tab>
 </Tabs>
 
-# Third Party Dependencies
+## Third Party Dependencies
 
 The common Rive C++ runtime includes a number of open source third party dependencies which contribute to its binary weight. These are:
 

--- a/runtimes/runtime-sizes.mdx
+++ b/runtimes/runtime-sizes.mdx
@@ -70,7 +70,7 @@ description: "Last updated: January 2026"
   </Tab>
 </Tabs>
 
-## Third Party Dependencies
+## Third-party dependencies
 
 The common Rive C++ runtime includes a number of open source third party dependencies which contribute to its binary weight. These are:
 

--- a/runtimes/web/animation-playback.mdx
+++ b/runtimes/web/animation-playback.mdx
@@ -24,7 +24,7 @@ new rive.Rive({
 
 <ControllingPlayback />
 
-#### Invoking Playback Controls
+#### Invoking playback controls
 
 With the web runtime, you can provide callback functions to receive notification when certain animation events have occurred:
 

--- a/runtimes/web/caching-a-rive-file.mdx
+++ b/runtimes/web/caching-a-rive-file.mdx
@@ -8,7 +8,7 @@ import Overview from "/snippets/runtimes/caching/overview.mdx"
 
 <Overview />
 
-## Example Usage
+## Example usage
 
 <Demos examples={["cachingARiveFile"]} runtime="web" />
 

--- a/runtimes/web/canvas-vs-webgl.mdx
+++ b/runtimes/web/canvas-vs-webgl.mdx
@@ -21,7 +21,7 @@ Switching is a one-line import change, so you can try both and measure against y
 
 ## Other notable tradeoffs
 
-### WebGL Context Limits
+### WebGL context limits
 
 Note that if you're using `@rive-app/webgl2`, browsers cap how many WebGL contexts a page can hold at once. The exact number varies by browser and device, and the oldest context is typically dropped once the cap is reached — which limits how many `new Rive({...})` instances you can run. See [WebGL Context Limits](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_context_limits) for more details.
 
@@ -40,7 +40,7 @@ const r = new rive.Rive({
 This limit does not apply to `@rive-app/canvas`.
 
 
-### Fill Rules
+### Fill rules
 
 `@rive-app/canvas` uses the Canvas2D renderer, which offers the non-zero and even-odd [fill rules](/editor/fundamentals/fill-and-stroke#fill-rule), so Rive's clockwise fill rule draws as non-zero. The result is identical unless a path has self-intersecting, reversed, or overlapping contours. This applies to both fills and clipping paths.
 
@@ -57,7 +57,7 @@ In practice:
 - Blend modes on mobile are the case where `@rive-app/canvas` can be meaningfully faster. If your file leans on them and does not use Vector Feathering, it is worth comparing the two.
 - Measure on real devices. Swapping packages is a one-line change, so testing both is cheap.
 
-## Canvas Package Variants
+## Canvas package variants
 
 Two variants of the canvas package are available if you have specific bundling needs.
 
@@ -73,6 +73,6 @@ Use it when your files do not rely on those features. If a file does use them, t
 
 Use it when you want to avoid a separate WASM request. The tradeoff is a larger JavaScript bundle.
 
-## Deprecated Package
+## Deprecated package
 
 `@rive-app/webgl` is deprecated and receives no updates after `v2.37.0`. Move to `@rive-app/webgl2`, or to `@rive-app/canvas` if your file does not need the Rive Renderer. Neither move requires API changes — see the [migration guide](/runtimes/web/migration-guides).

--- a/runtimes/web/data-binding.mdx
+++ b/runtimes/web/data-binding.mdx
@@ -178,7 +178,7 @@ Global instances are never created implicitly by the getter. `globalViewModelIns
   With `autoBind: true`, Rive creates a default instance for every global view model in the file alongside the artboard's default instance, so `globalViewModelInstance(name)` is populated by the time `onLoad` fires.
 </Note>
 
-### Get View Model from Instance
+### Get View Model from instance
 
 When working with view model instances, you may want to get a reference to the view model the instance came from so you can dynamically create more instances of the same type (i.e. creating instances from lists).
 To do so, first grab the name of the view model the instance came from via the `.viewModelName` property:
@@ -473,7 +473,7 @@ const r = new rive.Rive({
 });
 ```
 
-# Examples
+## Examples
 
 <YouTube id="y7glxOIFEjg" />
 <YouTube id="1WFtGX2coXM" />

--- a/runtimes/web/faq.mdx
+++ b/runtimes/web/faq.mdx
@@ -79,7 +79,7 @@ Then there are the width/height attributes on a `<canvas>` element that determin
 
 Ideally, you want to ensure that the width/height attributes on the canvas are at least the size of or greater than the width/height CSS properties on the canvas, otherwise, you may have blurry output (see above for how to address blurry animations).
 
-### How come my state machine isn't playing?
+### How come my State Machine isn't playing?
 
 Make sure you've specified the `stateMachine` property when instantiating Rive with the name of your state machine. To autoplay the state machine, don't forget to set `autoplay: true` when instantiating the Rive object.
 

--- a/runtimes/web/gpu-canvas.mdx
+++ b/runtimes/web/gpu-canvas.mdx
@@ -33,7 +33,7 @@ const rive = new Rive({
 
 GPU Canvas is disabled by default, but that may change in a future major version.
 
-## Enabling GPU Canvas on a Cached File
+## Enabling GPU Canvas on a cached file
 
 A `RiveFile` takes the same `enableGPUCanvas` flag and cannot be changed once the `RiveFile` is constructed:
 

--- a/runtimes/web/low-level-api-usage.mdx
+++ b/runtimes/web/low-level-api-usage.mdx
@@ -33,7 +33,7 @@ Here's the basic render workflow using the low-level API to render Rives:
   <Step title="Clean-up created instances when finished" />
 </Steps>
 
-## Getting Started
+## Getting started
 
 If you’ve decided that the low-level JS APIs are what you need for your app, read below for a guide on how to set everything up, or you can skip to the end to see some examples in action.
 
@@ -64,7 +64,7 @@ async function main() {
 main();
 ```
 
-### Creating the Renderer
+### Creating the renderer
 
 Once the WASM is loaded in, the next step is to create the renderer with the `makeRenderer()` API and pass in the canvas element on which Rive should render. The renderer draws Rive onto the `<canvas>` element with a rendering context. If you're using `@rive-app/canvas-advanced`, it will create a Canvas2D rendering context. If you're using `@rive-app/webgl2-advanced`, it will create a WebGL rendering context.
 
@@ -73,7 +73,7 @@ const canvas = document.getElementById('your-canvas-element');
 const renderer = rive.makeRenderer(canvas);
 ```
 
-### Loading in Rive Files
+### Loading in Rive files
 
 After the renderer is created, you can also start to load in the Rive file(s) as an ArrayBuffer, which you'll feed into the runtime's `load()` API. You can fetch this at a URL or from somewhere within your project.
 
@@ -89,7 +89,7 @@ const file = (await rive.load(new Uint8Array(bytes))) as File;
 <Note>
  Make sure to await the `.load()` call, as it synchronously tries to load assets from the `File`. Additionally, pass in the `ArrayBuffer` to a `Uint8Array` view before sending it as a param to `.load()`
 </Note>
-### Setting up the Instances
+### Setting up the instances
 
 Once you have a reference to the loaded `File` object, you can begin instancing all the artboards, state machines, and linear animations from the Rive file. Instancing creates an underlying CPP reference and allows you to control how each entity advances over time. More on that further down this guide.
 
@@ -117,7 +117,7 @@ The great thing here is if you want to display multiple artboards or even copies
 
 Beyond instancing the relevant pieces for the render loop, you can also extract references to nodes, targets, and bones within the drawing hierarchy. This is useful if you need to track any transform property values on a given node for any calculations or even to get world-space or parent transforms (i.e., tracking the x, y-coordinate, or rotation value of a node over the lifetime of an animation). See some of the examples at the bottom of the guide to see this in action.
 
-### Constructing the Render Loop
+### Constructing the render loop
 
 You may be familiar with constructing a render loop using `requestAnimationFrame` (rAF) to build animations frame-by-frame in between the browser's repaint cycle. If not, check out [this guide](https://developer.mozilla.org/en-US/docs/Games/Anatomy#building_a_main_loop_in_javascript) as a starting point for building a render loop.
 
@@ -144,7 +144,7 @@ function renderLoop(time) {
 rive.requestAnimationFrame(renderLoop);
 ```
 
-#### Advancing Animations
+#### Advancing animations
 
 A `LinearAnimationInstance` has a set of keyframes to apply to objects in an artboard. In the render loop, you'll want to call `.advance()` on the created animation instances to get those keyframes and, like the API is named, advance the animation by a certain amount of time (in seconds).
 
@@ -209,7 +209,7 @@ function renderLoop(time) {
 
 As you've seen above, advancing the artboard will do the work of updating the relevant objects in the hierarchy after the values have been applied through animations and/or state machines. If you're controlling multiple animations at once, you only need to advance the artboard once in the render loop. If you're controlling multiple artboards for your scene in the canvas, advance each artboard as needed in the render loop.
 
-#### Align and Render
+#### Align and render
 
 The last bit to consider in the render loop is to set the alignment of the artboard(s), set the bounds for the drawing area and artboard, and then finally pass the rendering context to the artboard so that the artboard gets drawn in the canvas.
 
@@ -267,7 +267,7 @@ rive.requestAnimationFrame(renderLoop);
 
 At this point, you should be able to render Rive on the canvas!
 
-### Cleaning Up Instances
+### Cleaning up instances
 
 For each of the created CPP instances, you’ll want to delete them when you are finished so that you don’t have any memory leaks in your application. Unfortunately, this is a manual operation as we cannot yet rely on the new finalizer API in browsers to be called for garbage collection. Call the `.delete()` API on any instances created from the Rive runtime when they are no longer needed. An example is shown below:
 
@@ -305,7 +305,7 @@ See below for links to examples demonstrating the use of low-level JS APIs:
 - [Simple use of @rive-app/webgl2-advanced](https://codesandbox.io/p/sandbox/rive-webgl-advanced-57lczl?file=%2Fsrc%2Findex.ts)
 - [Out of band assets (fonts) @rive-app/canvas-advanced](https://codesandbox.io/p/sandbox/rive-canvas-advanced-out-of-band-assets-fonts-3q4zzy?file=%2Fsrc%2Findex.ts)
 
-## API References
+## API references
 
 See our [types file](https://github.com/rive-app/rive-wasm/blob/master/js/src/rive_advanced.mjs.d.ts) for the advanced API to understand the API signatures and return types.
 
@@ -319,6 +319,6 @@ The high-level JS runtime APIs are built with the low-level APIs specified above
 
 When using Rive’s advanced JS APIs to customize how you use Rive, you will have to set up some of these affordances yourself. Take a look at how the [high-level Rive API is built here](https://github.com/rive-app/rive-wasm/blob/master/js/src/rive.ts) to get a sense of how to replicate some of these high-level affordances should you need these.
 
-## Integrating Rive into Existing rAF Loop
+## Integrating Rive into existing rAF loop
 
 If you're looking to add Rive to your existing render loop (the JS API `requestAniationFrame()`) and do not want to use the Rive-wrapped `requestAnimationFrame()` API, you can do so with an extra API call at the end of your render loop. Call the `rive.resolveAnimationFrame()` API at the end of the render loop before calling `requestAnimationFrame()` again.

--- a/runtimes/web/rive-events.mdx
+++ b/runtimes/web/rive-events.mdx
@@ -18,11 +18,11 @@ import AdditionalResources from "/snippets/runtimes/events/additional-resources.
 
 ### High-level API usage
 
-#### Adding an Event Listener
+#### Adding an event listener
 
 Similar to the `addEventListener()` / `removeEventListener()` API for DOM elements, you'll use the Rive instance's `on()` / `off()` API to subscribe to Rive events. Simply supply the RiveEvent enum and a callback for the runtime to call at the appropriate moment any Rive event gets detected.
 
-#### Example Usage
+#### Example usage
 
 ```javascript
 import { Rive, EventType, RiveEventType } from '@rive-app/canvas'

--- a/runtimes/web/rive-parameters.mdx
+++ b/runtimes/web/rive-parameters.mdx
@@ -127,7 +127,7 @@ The following APIs are available on a `Rive` instance after construction.
 
 ---
 
-### Data binding (View Models)
+### Data Binding (View Models)
 
 View model APIs on `Rive` are documented in depth on the [data binding](/runtimes/web/data-binding) guide. For a quick reference on available APIs on the `Rive` instance, see below:
 
@@ -450,7 +450,7 @@ class StateMachineInput {
 
 ---
 
-#### Nested artboard paths
+#### Nested Artboard paths
 
 For inputs and text runs on **nested artboards**, use a path string (for example `"parentArtboard"` or `"group/nested"`) to set input and text run values.
 

--- a/runtimes/web/semantics.mdx
+++ b/runtimes/web/semantics.mdx
@@ -25,7 +25,7 @@ Because a `<canvas>` is opaque to assistive technologies (AT), this DOM overlay 
 
 <DefinedInEditor />
 
-## Semantics Modes
+## Semantics modes
 
 Semantics are controlled by the `SemanticMode` enum, which you import from your Rive package and pass as a parameter when you instantiate Rive:
 
@@ -51,7 +51,7 @@ const rive = new Rive({
 });
 ```
 
-### Enabling Semantics After Load
+### Enabling semantics after load
 
 If you want to programmatically control when semantics are enabled, construct `Rive` with the default `SemanticMode.Disabled` and call the `enableSemantics()` method when the user opts in.
 
@@ -72,7 +72,7 @@ accessibilityToggle.addEventListener("change", (event) => {
 });
 ```
 
-### Labeling the Graphic
+### Labeling the graphic
 
 The semantic overlay's container element is a `role="region"` landmark. Use the `semanticsOptions.riveCanvasLabel` parameter when instantiating Rive to give it an `aria-label` that describes what the graphic is, so screen reader users know what they are entering.
 
@@ -94,7 +94,7 @@ const rive = new Rive({
 | --- | --- | --- |
 | `riveCanvasLabel` | `string` | `aria-label` applied to the overlay container. Defaults to `"Rive animation"`. |
 
-## How Semantics Map to the DOM
+## How semantics map to the DOM
 
 The runtime translates each editor semantic role into an ARIA role, and each state and trait into the matching ARIA attribute. In most cases, these are attached to `<div>` elements to standardize
 on common style/layout patterns across browsers. Text content is wrapped in an inner `<span>` to assist with AT's browsing text.
@@ -129,19 +129,19 @@ States and traits map to ARIA attributes such as `aria-expanded`, `aria-selected
   An image with no label is treated as decorative and hidden from assistive technologies, since a `role="img"` element without an accessible name is a WCAG failure. Add a label in the editor to any image that carries meaning.
 </Note>
 
-## Other Considerations
+## Other considerations
 
-### Tab Index
+### Tab index
 
 Interactive, focusable, and list item overlay elements are given `tabindex="-1"`, which keeps them out of the browser's sequential Tab order; the rest carry no tabindex at all. These elements remain reachable by a screen reader's cursor, but a sighted keyboard-only user cannot Tab into individual elements inside the graphic.
 
-### Semantic Overlay Positioning
+### Semantic overlay positioning
 
 Rive keeps the overlay matched to the canvas as it resizes or moves. The runtime watches the canvas, its parent, and the window for changes and re-syncs the overlay, so the common cases need no extra work.
 
 The overlay container is inserted as a sibling of the `<canvas>` and positioned using the canvas's layout offsets. When possible, give the canvas's container `position: relative` so the overlay and the canvas resolve their positions against the same ancestor. If no ancestor of the canvas is positioned, the overlay resolves against the document instead, and the `<body>` margin offsets it from the canvas.
 
-## Testing Semantics
+## Testing semantics
 
 Turn on a screen reader and navigate through your graphic after enabling semantics at runtime:
 

--- a/runtimes/web/state-machines.mdx
+++ b/runtimes/web/state-machines.mdx
@@ -38,7 +38,7 @@ const r = new rive.Rive({
 });
 ```
 
-### Controlling State Machine Playback
+### Controlling State Machine playback
 
 You can manually play and pause the State Machine using the `play`, `pause`, and `stop` methods.
 

--- a/runtimes/web/text.mdx
+++ b/runtimes/web/text.mdx
@@ -37,7 +37,7 @@ public setTextRunValue(textRunName: string, textRunValue: string): void
 
 Supply the text run name and a second parameter, `textValue`, with a String value that you want to set the new text value for if the text run can be successfully queried on the active artboard.
 
-### Example Usage
+### Example usage
 
 ```javascript
 import {Rive} from '@rive-app/canvas'
@@ -103,7 +103,7 @@ public setTextRunValueAtPath(textRunName: string, textRunValue: string, path: st
 
 Supply the `textRunName`, the new `textValue`, and the `path` where the run is located at a component instance level.
 
-### Example Usage
+### Example usage
 
 ```javascript
 import {Rive} from '@rive-app/canvas'
@@ -124,7 +124,7 @@ onLoad: () => {
 
 The following code snippets provide guidance on how to add semantic labels to your Rive animations.
 
-#### Adding ARIA Label
+#### Adding ARIA label
 
 At a minimum - if it is important to convey the text value displayed in the Rive animation to all users, add an `aria-label` to the `<canvas>` element with the text value from the animation. Screen readers may read this label out immediately as it parses out the DOM contents. You'll also want to add `role="img"` to the `<canvas>` element as well.
 
@@ -146,7 +146,7 @@ Live regions are useful in cases where the text content in your Rive graphic bec
 
 Read more on ARIA live regions [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 
-#### Example: Rating Graphic
+#### Example: rating graphic
 
 <Note>
     To try this example out, visit this [CodeSandbox link](https://codesandbox.io/p/sandbox/rive-rating-ally-example-ptydr8)

--- a/runtimes/web/web-js.mdx
+++ b/runtimes/web/web-js.mdx
@@ -200,7 +200,7 @@ const riveInstance = new Rive({...});
 riveInstance.cleanup();
 ```
 
-# Additional Rive web resources
+## Additional Rive web resources
 
 More in-depth Rive web documentation and advanced use cases.
 
@@ -222,7 +222,7 @@ More in-depth Rive web documentation and advanced use cases.
   </Card>
 </CardGroup>
 
-# Examples
+## Examples
 
 - [Basic gallery app](https://github.com/rive-app/rive-wasm/tree/master/js/examples/_frameworks/parcel_example_canvas)
 - [Tracking mouse cursor](https://codesandbox.io/p/sandbox/tracking-mouse-cursor-n38gdd?file=%2Fsrc%2Findex.ts)

--- a/scripting/configuration.mdx
+++ b/scripting/configuration.mdx
@@ -5,15 +5,15 @@ description: "Customize the Rive code editor with themes, typography, and execut
 
 You can customize the appearance and behavior of the Rive code editor by editing its configuration file. Your settings will be reflected in all code editor views for your user account. 
 
-## Opening the Configuration
+## Opening the configuration
 
 Press **⌘ + ,** on macOS or **Ctrl + ,** on Windows to open the editor configuration.
 
-## Editing the Config
+## Editing the config
 
 The configuration file returns a Lua table. Start with the default configuration and override any settings you want to change.
 
-### Example Configuration
+### Example configuration
 
 ```lua
 -- Import the default configuration
@@ -28,7 +28,7 @@ config.code.executionTimeoutMs = 2000
 return config
 ```
 
-## Available Options
+## Available options
 
 | Option | Description |
 |-------|-------------|

--- a/scripting/creating-scripts.mdx
+++ b/scripting/creating-scripts.mdx
@@ -27,7 +27,7 @@ Use **PascalCase** for script names and update the script’s type name accordin
 Example: If the script is named `MyConverter`, the main type should also be named `MyConverter`.
 </Tip>
 
-## Adding Scripts to Your Scene
+## Adding Scripts to your scene
 
 To run [Node](/scripting/protocols/node-scripts) and [Layout](/scripting/protocols/layout-scripts) scripts, they need to be added to the scene.
 

--- a/scripting/data-binding.mdx
+++ b/scripting/data-binding.mdx
@@ -65,7 +65,7 @@ return function(): Node<GetContexts>
 end
 ```
 
-### View Models as Inputs
+### View Models as inputs
 
 You can create an [Input](/scripting/script-inputs) that accepts a view model instance, which gives the script access to its properties.
 
@@ -112,7 +112,7 @@ You can create an [Input](/scripting/script-inputs) that accepts a view model in
   </Step>
 </Steps>
 
-## Reading and Setting Properties
+## Reading and setting properties
 
 The following methods allow you to reference view model properties:
 
@@ -152,9 +152,9 @@ if vmi then
 end
 ```
 
-## Listening for Property Changes
+## Listening for property changes
 
-### Add a Listener
+### Add a listener
 
 Use `addListener` to listen for triggers or changes to view model properties.
 
@@ -197,7 +197,7 @@ end
 
 ```
 
-### Remove a Listener
+### Remove a listener
 
 Always remove listeners when they are no longer needed to avoid memory leaks.
 
@@ -237,7 +237,7 @@ return function(): Node<ScriptInputs>
 end
 ```
 
-## Creating a View Model Instance
+## Creating a View Model instance
 
 
 ```lua highlight={10}

--- a/scripting/debugging/unit-testing.mdx
+++ b/scripting/debugging/unit-testing.mdx
@@ -102,7 +102,7 @@ case('never examples', function(expect)
 end)
 ```
 
-## Running Tests
+## Running tests
 
 1. In the Assets panel, right-click your Test script.
 2. Select Run Tests.

--- a/scripting/getting-started.mdx
+++ b/scripting/getting-started.mdx
@@ -8,7 +8,7 @@ import { YouTube } from '/snippets/youtube.mdx'
 
 Scripting lets you iterate on code, design, and animation in one collaborative editor.
 
-## Quick Start
+## Quick start
 
 This video introduces the basics of writing and using scripts in Rive. You’ll learn how to create different types of scripts and how they connect to data bindings and artboards, and how you can create scripts with the [AI Agent](/editor/ai-agent).
 

--- a/scripting/keyboard-shortcuts.mdx
+++ b/scripting/keyboard-shortcuts.mdx
@@ -3,7 +3,7 @@ title: "Keyboard Shortcuts"
 description: "A comprehensive reference for all keyboard shortcuts in the Rive script editor."
 ---
 
-## Basic Editing
+## Basic editing
 
 | Command                 | macOS                                           | Windows/Linux                        |
 | ----------------------- | ----------------------------------------------- | ------------------------------------ |
@@ -24,7 +24,7 @@ description: "A comprehensive reference for all keyboard shortcuts in the Rive s
 | --- | --- | ---
 | Open Settings / Configuration | `⌘` + `,` | `Ctrl` + `,`
 
-## Cursor Movement
+## Cursor movement
 
 | Command                     | macOS                                              | Windows/Linux                              |
 | --------------------------- | -------------------------------------------------- | ------------------------------------------ |
@@ -47,7 +47,7 @@ All cursor movement commands can be combined with <kbd>⇧</kbd> (Shift) to exte
 | **Select to Line Start/End**     | <kbd>⇧</kbd> + <kbd>⌘</kbd> + <kbd>←</kbd>/<kbd>→</kbd> | <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>←</kbd>/<kbd>→</kbd> |
 | **Select to Document Start/End** | <kbd>⇧</kbd> + <kbd>⌘</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> | <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> |
 
-## Line Operations
+## Line operations
 
 | Command                 | macOS                                           | Windows/Linux                                    |
 | ----------------------- | ----------------------------------------------- | ------------------------------------------------ |
@@ -59,7 +59,7 @@ All cursor movement commands can be combined with <kbd>⇧</kbd> (Shift) to exte
 | **Duplicate Line Up**   | <kbd>⇧</kbd> + <kbd>⌥</kbd> + <kbd>↑</kbd>      | <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>↑</kbd> |
 | **Duplicate Line Down** | <kbd>⇧</kbd> + <kbd>⌥</kbd> + <kbd>↓</kbd>      | <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>↓</kbd> |
 
-## Multi-Cursor Editing
+## Multi-cursor editing
 
 | Command                      | macOS                                    | Windows/Linux                         |
 | ---------------------------- | ---------------------------------------- | ------------------------------------- |
@@ -67,7 +67,7 @@ All cursor movement commands can be combined with <kbd>⇧</kbd> (Shift) to exte
 | **Select Next Occurrence**   | <kbd>⌘</kbd> + <kbd>D</kbd>              | <kbd>Ctrl</kbd> + <kbd>D</kbd>        |
 | **Collapse to Single Cursor**| <kbd>Esc</kbd>                           | <kbd>Esc</kbd>                        |
 
-## Search and Replace
+## Search and replace
 
 | Command                 | macOS                                           | Windows/Linux                                    |
 | ----------------------- | ----------------------------------------------- | ------------------------------------------------ |
@@ -82,7 +82,7 @@ The search panel includes toggle buttons for:
 - **Whole Word**: Toggle whole word matching
 - **Regex**: Toggle regular expression mode
 
-## Code Navigation
+## Code navigation
 
 | Command                 | macOS                                           | Windows/Linux                        |
 | ----------------------- | ----------------------------------------------- | ------------------------------------ |
@@ -91,7 +91,7 @@ The search panel includes toggle buttons for:
 | **Command Palette**     | <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd>      | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> |
 | **Global Search**       | <kbd>⌘</kbd> + <kbd>K</kbd>                     | <kbd>Ctrl</kbd> + <kbd>K</kbd>       |
 
-## File and Tab Management
+## File and tab management
 
 | Command                     | macOS                                           | Windows/Linux                                    |
 | --------------------------- | ----------------------------------------------- | ------------------------------------------------ |
@@ -110,7 +110,7 @@ The search panel includes toggle buttons for:
 | **Accept Suggestion**   | <kbd>↩</kbd> or <kbd>Tab</kbd>                  | <kbd>Enter</kbd> or <kbd>Tab</kbd>   |
 | **Dismiss**             | <kbd>Esc</kbd>                                  | <kbd>Esc</kbd>                       |
 
-## Mouse Actions
+## Mouse actions
 
 | Action                      | Description                                          |
 | --------------------------- | ---------------------------------------------------- |
@@ -124,7 +124,7 @@ The search panel includes toggle buttons for:
 | Click and drag              | Select text by dragging                              |
 | Click and drag in gutter    | Select multiple lines                                |
 
-## Auto-Closing Pairs
+## Auto-closing pairs
 
 The editor automatically inserts closing characters for:
 
@@ -137,7 +137,7 @@ The editor automatically inserts closing characters for:
 | `'`     | `'`     | Single quotes (not inside strings)   |
 | `` ` `` | `` ` `` | Backticks (not inside strings)       |
 
-## Surrounding Selection
+## Surrounding selection
 
 When text is selected, typing an opening character wraps the selection:
 
@@ -151,7 +151,7 @@ When text is selected, typing an opening character wraps the selection:
 | `` ` `` | `` `selection` ``  |
 | `<`     | `<selection>`      |
 
-## Auto-Completion for Luau Blocks
+## Auto-completion for Luau blocks
 
 When pressing <kbd>↩</kbd> (Enter) after certain keywords, the editor auto-completes the block structure:
 
@@ -163,7 +163,7 @@ When pressing <kbd>↩</kbd> (Enter) after certain keywords, the editor auto-com
 | `else`          | `end` on new line     |
 | `repeat`        | `until false` on new line |
 
-## Smart Indentation
+## Smart indentation
 
 - Pressing <kbd>↩</kbd> (Enter) automatically maintains the current indentation level
 - After opening keywords (`function`, `do`, `then`, `else`, `repeat`, `{`), the next line is indented
@@ -172,7 +172,7 @@ When pressing <kbd>↩</kbd> (Enter) after certain keywords, the editor auto-com
 - Indentation uses 2 spaces (soft tabs)
 - Line comments use `--` (Luau style)
 
-## Diff Mode
+## Diff mode
 
 When viewing AI-generated changes:
 

--- a/scripting/pointer-events.mdx
+++ b/scripting/pointer-events.mdx
@@ -105,7 +105,7 @@ end
 
 ```
 
-## Nested Pointer Events
+## Nested pointer events
 
 Rive only listens for Pointer Events on the main artboard.
 If you need to listen for Pointer Events in your [instantiated artboards](/scripting/protocols/node-scripts#instanting-components),

--- a/scripting/protocols/converter-scripts.mdx
+++ b/scripting/protocols/converter-scripts.mdx
@@ -86,6 +86,6 @@ Create a new converter using your new converter script:
 ![Create converter with a script](/images/scripting/create-converter-with-script.png)
 
 
-## Adding Inputs
+## Adding inputs
 
 See [Script Inputs](/scripting/script-inputs).

--- a/scripting/protocols/listener-action-scripts.mdx
+++ b/scripting/protocols/listener-action-scripts.mdx
@@ -53,7 +53,7 @@ end
 
 ![Add a custom listener action](/images/scripting/add-listener-action.gif)
 
-## Script Inputs
+## Script inputs
 
 Inputs let you add parameters to a listener action without changing script logic—making the same script reusable across different listeners. For more information on adding inputs to your scripts, see [Script Inputs](/scripting/script-inputs).
 
@@ -63,13 +63,13 @@ Inputs let you add parameters to a listener action without changing script logic
   If you need to control a view model property from your script, access the [Main View model through context](/scripting/data-binding#accessing-the-main-view-model) or [View Model Inputs](/scripting/script-inputs#view-model-inputs).
 </Note>
 
-### Setting an Input
+### Setting an input
 
 To set the value of an input, select the Properties icon next to the listener script.
 
 ![listener action script inputs](/images/scripting/listener-action-script-input.png)
 
-### Data Binding an Input
+### Data Binding an input
 
 Right-click your property and select Data Bind to bind your input to a view model property.
 

--- a/scripting/protocols/node-scripts.mdx
+++ b/scripting/protocols/node-scripts.mdx
@@ -84,9 +84,9 @@ end
 
 See the [API Reference](/scripting/api-reference/path) for a complete list of drawing utilities.
 
-## Common Patterns
+## Common patterns
 
-### Instantiating Components
+### Instantiating components
 
 To be able to instantiate components at runtime, you will need to have a basic understanding of
 [Data Binding](/editor/data-binding/overview), [Components](/editor/fundamentals/components), and [Script Inputs](/scripting/script-inputs).
@@ -160,7 +160,7 @@ return function(): Node<MyGame>
 end
 ```
 
-### Fixed-Step Advance
+### Fixed-step advance
 
 Frame rates can vary between devices and scenes. If your script moves or animates objects based directly on the frame time, faster devices will move them farther each second, while slower ones will appear to lag behind.
 

--- a/scripting/protocols/path-effect-scripts.mdx
+++ b/scripting/protocols/path-effect-scripts.mdx
@@ -95,7 +95,7 @@ end
 </Note>
 
 
-## Add the Scripted Path Effect to a Stroke
+## Add the scripted Path Effect to a Stroke
 
 Select or add a stroke to a shape:
 
@@ -106,6 +106,6 @@ Select or add a stroke to a shape:
 
 ![Add Path Effect to a Stroke](/images/scripting/add-path-effect-to-stroke.png)
 
-## Adding Inputs
+## Adding inputs
 
 See [Script Inputs](/scripting/script-inputs).

--- a/scripting/protocols/path-effect-scripts.mdx
+++ b/scripting/protocols/path-effect-scripts.mdx
@@ -95,7 +95,7 @@ end
 </Note>
 
 
-## Add the scripted Path Effect to a Stroke
+## Adding the scripted Path Effect to a Stroke
 
 Select or add a stroke to a shape:
 

--- a/scripting/protocols/transition-condition-scripts.mdx
+++ b/scripting/protocols/transition-condition-scripts.mdx
@@ -57,7 +57,7 @@ end
 
 ![Add a custom transition](/images/scripting/add-transition-condition.gif)
 
-## Script Inputs
+## Script inputs
 
 Inputs let you add parameters a transition without changing script logic—making the same condition reusable across different transitions or states. For more information on adding inputs to your scripts, see [Script Inputs](/scripting/script-inputs).
 
@@ -67,13 +67,13 @@ Inputs let you add parameters a transition without changing script logic—makin
   If you need to control a view model property from your script, access the [Main View model through context](/scripting/data-binding#accessing-the-main-view-model) or [View Model Inputs](/scripting/script-inputs#view-model-inputs).
 </Note>
 
-### Setting an Input
+### Setting an input
 
 To set the value of an input, select the Properties icon next to the transition.
 
 ![transition script inputs](/images/scripting/transition-condition-input.png)
 
-### Data Binding an Input
+### Data Binding an input
 
 Right-click your property and select Data Bind to bind your input to a view model property.
 

--- a/scripting/protocols/util-scripts.mdx
+++ b/scripting/protocols/util-scripts.mdx
@@ -6,7 +6,7 @@ description: "Create helper modules to organize shared logic across your scripts
 Blank scripts let you organize your code into small, focused modules that can be reused across multiple scripts.
 They’re ideal for math helpers, geometry utilities, color functions, or any logic that should be broken out into its own script.
 
-## Creating a Blank Script
+## Creating a blank Script
 
 [Create a new script](/scripting/creating-scripts) and select **Blank** as the type.
 
@@ -33,7 +33,7 @@ print(result) -- 5
 
 ```
 
-## Blank Scripts with Custom Types
+## Blank Scripts with custom types
 
 Custom types defined in your Blank scripts will automatically be accessible
 in the parent script.

--- a/scripting/script-inputs.mdx
+++ b/scripting/script-inputs.mdx
@@ -16,7 +16,7 @@ Inputs transform static scripts into flexible, designer-friendly tools that enab
 
 <YouTube id="sO-v2eoNC2Y" />
 
-## Defining Inputs
+## Defining inputs
 
 To make new script inputs, add them to the type and set the defaults in the script's return function.
 
@@ -42,14 +42,14 @@ end
   href="https://rive.app/community/files/28395-53679-script-inputs"
 />
 
-## Setting Input Values
+## Setting input values
 
 To access the input properties in the right sidebar of the editor, select your [Node](/scripting/protocols/node-scripts) or [Layout script](/scripting/protocols/layout-scripts) in the Hierarchy Panel or the [Converter](/scripting/protocols/converter-scripts) in the Data Panel.
 
 ![Node script input](/images/scripting/script-input.png)
 
 
-## Data Binding Inputs
+## Data Binding inputs
 
 You can use [Data Binding](/editor/data-binding/overview) to control input values at runtime.
 
@@ -59,7 +59,7 @@ property.
 ![Data bind a converter input](/images/scripting/converter-script-input-data-binding.png)
 
 
-## Listening for Changes to Inputs
+## Listening for changes to inputs
 
 The `update` function fires every time any input changes.
 

--- a/scripting/wgsl-shaders.mdx
+++ b/scripting/wgsl-shaders.mdx
@@ -23,7 +23,7 @@ Rive shaders use standard WGSL, with some restrictions for compatibility across 
   - **Fragment shader** - decides the color of each pixel covered by those vertices.
 </Info>
 
-## Creating a Shader
+## Creating a shader
 
 [Create a new script](/scripting/creating-scripts), select **WGSL Shader** as the type, and name it `BasicShader`.
 
@@ -31,7 +31,7 @@ Rive shaders use standard WGSL, with some restrictions for compatibility across 
   The [AI Agent](/editor/ai-agent/ai-agent) can be a helpful way to create or iterate on shader code. Describe the effect you want, then review and test the generated WGSL in your file.
 </Note>
 
-### Basic WGSL Shader
+### Basic WGSL shader
 
 This shader draws a single large triangle that covers the render target. The parts of the triangle outside the render target are clipped, leaving the entire target covered. This is a common technique called a fullscreen triangle.
 
@@ -79,7 +79,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 }
 ```
 
-### Rendering a Shader with a Script
+### Rendering a shader with a Script
 
 ```lua
 type ShaderDemo = {
@@ -209,7 +209,7 @@ UV coordinates identify a position within the texture, typically from `0` to `1`
 
 On the script side, add a `GPUTextureView` and `GPUSampler` to a `GPUBindGroup`. Their slots must match the `@binding` values declared in the shader.
 
-### Using an Artboard as a Texture
+### Using an Artboard as a texture
 
 Shaders sample textures, not Rive artboards directly. To apply a shader to an artboard, first render the artboard to an offscreen canvas:
 
@@ -227,7 +227,7 @@ Call `srcCanvas.image:view()` to obtain a `GPUTextureView`, then add that view t
 The linked Marketplace example uses this technique to render an artboard through a shader that distorts its texture coordinates with animated noise.
 
 
-## Shader Targets
+## Shader targets
 
 Rive shaders are authored in WGSL. When you export your file, Rive compiles each shader for the selected targets and includes those variants in the `.riv` file. The original WGSL source isn't included.
 
@@ -245,6 +245,6 @@ If a target is not selected, the shader isn't included for that backend and won'
 
 ![Shader Targets options in the Inspector](/images/scripting/shaders/shader-targets.png)
 
-## WGSL Support
+## WGSL support
 
 Rive uses standard WGSL with some restrictions to ensure shaders work across supported rendering backends. Rive supports vertex and fragment shaders, with up to four bind groups. Compute shaders and override declarations aren't supported. Some WGSL features are also unavailable, including 64-bit float and integer types, push constants, subgroup operations, and non-uniform resource indexing.

--- a/snippets/runtimes/data-binding/listing-properties.mdx
+++ b/snippets/runtimes/data-binding/listing-properties.mdx
@@ -1,3 +1,3 @@
-### Listing Properties
+### Listing properties
 
 Property descriptors can be inspected on a view model to discover at runtime which are available. These are not the mutable properties themselves though - once again those are on instances. These descriptors have a type and name.

--- a/snippets/runtimes/data-binding/nested-property-paths.mdx
+++ b/snippets/runtimes/data-binding/nested-property-paths.mdx
@@ -1,3 +1,3 @@
-### Nested Property Paths
+### Nested property paths
 
 View models can have properties of type view model, allowing for arbitrary nesting. You can chain property calls on each instance starting from the root until you get to the property of interest. Alternatively, you can do this through a path parameter, which is similar to a URI in that it is a forward slash delimited list of property names ending in the name of the property of interest.

--- a/snippets/runtimes/data-binding/reading-and-writing-properties.mdx
+++ b/snippets/runtimes/data-binding/reading-and-writing-properties.mdx
@@ -1,4 +1,4 @@
-### Reading and Writing Properties
+### Reading and writing properties
 
 References to these properties can be retrieved by name or path.
 

--- a/snippets/runtimes/events/additional-resources.mdx
+++ b/snippets/runtimes/events/additional-resources.mdx
@@ -1,3 +1,3 @@
-## Additional Resources
+## Additional resources
 
 <YouTube id="e2bshfKuu8U" />

--- a/snippets/runtimes/events/overview.mdx
+++ b/snippets/runtimes/events/overview.mdx
@@ -22,7 +22,7 @@ Other practical use cases for events:
 - Send semantic information
 - Communicate any information your runtime needs at the right moment
 
-## Subscribing to Events
+## Subscribing to events
 
 When you subscribe to Rive events at runtime, you subscribe to **all** Rive events that may be emitted from a state machine, and you can parse through each event by name or type to execute conditional logic.
 

--- a/snippets/runtimes/fonts/data-binding-fonts.mdx
+++ b/snippets/runtimes/fonts/data-binding-fonts.mdx
@@ -1,4 +1,4 @@
-## Swapping Data Bound Fonts at Runtime
+## Swapping Data Bound fonts at runtime
 
 Data bound fonts can be loaded dynamically at runtime. Unlike swapping a font asset, this only changes text bound to that font property, allowing different parts of your Rive file to use different fonts independently.
 

--- a/snippets/runtimes/fonts/data-binding-fonts.mdx
+++ b/snippets/runtimes/fonts/data-binding-fonts.mdx
@@ -1,4 +1,4 @@
-## Swapping Data Bound fonts at runtime
+## Swapping data-bound fonts at runtime
 
 Data bound fonts can be loaded dynamically at runtime. Unlike swapping a font asset, this only changes text bound to that font property, allowing different parts of your Rive file to use different fonts independently.
 

--- a/snippets/runtimes/fonts/fallback-fonts-unsupported.mdx
+++ b/snippets/runtimes/fonts/fallback-fonts-unsupported.mdx
@@ -1,4 +1,4 @@
-## Fallback Fonts
+## Fallback fonts
 
 Fallback fonts are **not supported on the web**.
 

--- a/snippets/runtimes/fonts/fallback-fonts.mdx
+++ b/snippets/runtimes/fonts/fallback-fonts.mdx
@@ -1,4 +1,4 @@
-## Fallback Fonts
+## Fallback fonts
 
 When rendering text, not all glyphs (characters) may be available in the active font. This commonly occurs when:
 

--- a/snippets/runtimes/fonts/swapping-fonts.mdx
+++ b/snippets/runtimes/fonts/swapping-fonts.mdx
@@ -1,4 +1,4 @@
-## Swapping Font Assets at Runtime
+## Swapping font assets at runtime
 
 Fonts can be loaded dynamically at runtime. This allows you to localize your Rive content without increasing the file size of the exported .riv file.
 

--- a/snippets/runtimes/inputs/controlling-inputs.mdx
+++ b/snippets/runtimes/inputs/controlling-inputs.mdx
@@ -1,4 +1,4 @@
-## Controlling state machine inputs
+## Controlling State Machine inputs
 
 Once the Rive file is loaded and instantiated, the state machine can be queried for inputs, and these input values can be set, and in the case of triggers, fired, all programmatically.
 

--- a/snippets/runtimes/loading-assets/embedded-assets.mdx
+++ b/snippets/runtimes/loading-assets/embedded-assets.mdx
@@ -1,4 +1,4 @@
-### Embedded Assets
+### Embedded assets
 
 In the Rive editor, static assets can be included in the `.riv` file, by choosing the _"Embedded"_ export type. As stated in the beginning of this page, when the Rive file gets loaded, the runtime will implicitly attempt to load in the assets embedded in the `.riv` as well, and you don't need to concern yourself with loading any assets manually.
 

--- a/snippets/runtimes/loading-assets/handling-assets.mdx
+++ b/snippets/runtimes/loading-assets/handling-assets.mdx
@@ -1,1 +1,1 @@
-## Handling Assets
+## Handling assets

--- a/snippets/runtimes/loading-assets/methods-for-loading.mdx
+++ b/snippets/runtimes/loading-assets/methods-for-loading.mdx
@@ -1,4 +1,4 @@
-## Methods for Loading Assets
+## Methods for loading assets
 
 There are currently three different ways to load assets for your Rive files.
 

--- a/snippets/runtimes/loading-assets/referenced-assets.mdx
+++ b/snippets/runtimes/loading-assets/referenced-assets.mdx
@@ -1,4 +1,4 @@
-### Referenced Assets
+### Referenced assets
 
 In the Rive editor, you can mark an imported asset as a _"Referenced"_ export type, which means that when you export the `.riv` file, the asset will not be embedded in the file binary, and the responsibility of loading the asset will be handled by your application at runtime.
 

--- a/snippets/runtimes/loading-assets/resources.mdx
+++ b/snippets/runtimes/loading-assets/resources.mdx
@@ -1,3 +1,3 @@
-## Additional Resources
+## Additional resources
 
 <YouTube id="BrWBmZwouQQ" />

--- a/snippets/runtimes/playing-audio/embedded-assets.mdx
+++ b/snippets/runtimes/playing-audio/embedded-assets.mdx
@@ -1,3 +1,3 @@
-## Embedded Assets
+## Embedded assets
 
 Embedded assets require no additional work to play audio.

--- a/snippets/runtimes/playing-audio/referenced-assets.mdx
+++ b/snippets/runtimes/playing-audio/referenced-assets.mdx
@@ -1,3 +1,3 @@
-## Referenced Assets
+## Referenced assets
 
 Referenced assets require a little bit more work to play audio. Audio will still automatically play, but the audio file(s) must be loaded when a Rive runtime attempts to play audio.

--- a/snippets/runtimes/preloading-wasm/thanks.mdx
+++ b/snippets/runtimes/preloading-wasm/thanks.mdx
@@ -1,4 +1,4 @@
-## Special Thanks
+## Special thanks
 
 Special thanks to Alex Barashkov for their [original blog post](https://dev.to/alex_barashkov/optimization-techniques-for-rive-animations-in-react-apps-1a8p) that inspired us to add this tip.
 

--- a/snippets/runtimes/state-machines/controlling-playback.mdx
+++ b/snippets/runtimes/state-machines/controlling-playback.mdx
@@ -3,7 +3,7 @@
   runtime supports stopping = true
 */}
 
-## Controlling Playback
+## Controlling playback
 
 State machines play by "advancing" over time. This is done once per frame by the amount of time between frames. For example, for a graphic running at 60 frames per second, the state machine would be advanced by approximately 16.67 milliseconds (1/60th of a second) each frame. This advancing evaluates keyframes, transitions, data bindings changes, and ultimately the visible artboard elements to create the illusion of motion over time.
 

--- a/snippets/runtimes/text/nested-artboard.mdx
+++ b/snippets/runtimes/text/nested-artboard.mdx
@@ -1,4 +1,4 @@
-## Read/Update Nested Text Runs at Runtime
+## Read/update nested Text Runs at runtime
 
 <Warning>
   **⚠️ DEPRECATED FEATURE:** Nested Text Runs are part of the legacy Text

--- a/snippets/runtimes/text/overview.mdx
+++ b/snippets/runtimes/text/overview.mdx
@@ -36,7 +36,7 @@ For more information on designing and animating Text, please refer to the editor
   </Card>
 </CardGroup>
 
-## Read/Update Text Runs at Runtime
+## Read/update Text Runs at runtime
 
 <Warning>
   **⚠️ LEGACY CONTENT WARNING:** The following sections document the deprecated

--- a/snippets/runtimes/text/resources.mdx
+++ b/snippets/runtimes/text/resources.mdx
@@ -1,3 +1,3 @@
-### Additional Resources:
+### Additional resources:
 
 - [Accessible web animations: ARIA live regions](https://rive.app/blog/accesible-web-animations-aria-live-regions?utm_source=docs&utm_medium=content)

--- a/snippets/runtimes/text/semantics-for-accessibility.mdx
+++ b/snippets/runtimes/text/semantics-for-accessibility.mdx
@@ -1,4 +1,4 @@
-### Semantics for Accessibility
+### Semantics for accessibility
 
 
 Rive now supports screen readers through semantics.

--- a/tutorials/learn-rive.mdx
+++ b/tutorials/learn-rive.mdx
@@ -24,7 +24,7 @@ mode: 'wide'
   </Card>
 </CardGroup>
 
-## Learn by Example
+## Learn by example
 
 Learn by opening Rive files and runtime demos.
 
@@ -52,7 +52,7 @@ Learn by opening Rive files and runtime demos.
   <Link href="https://www.youtube.com/@Rive_app">More Videos &gt;</Link>
 </div>
 
-## Case Studies
+## Case studies
 
 See how teams are using Rive in production.
 
@@ -66,7 +66,7 @@ See how teams are using Rive in production.
   <Link href="https://rive.app/blog/case-studies?utm_source=docs&utm_medium=content">More Case Studies &gt;</Link>
 </div>
 
-## Community Content
+## Community content
 
 Learn from the Rive community through tips, tutorials, and in-depth courses.
 


### PR DESCRIPTION
Also makes sure headings go in order. There were some that went from `#` to `###`. 

This was all done with Claude. Copilot had some additional suggestions. I quickly reviewed all changes to make sure AI didn't do anything too crazy. 